### PR TITLE
Fix regex for Oauth bearer challange

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationParameters+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationParameters+Internal.m
@@ -33,7 +33,7 @@ NSString* const InvalidResponse = @"Missing or invalid Url response.";
 NSString* const UnauthorizedHTTStatusExpected = @"Expected Unauthorized (401) HTTP status code. Actual status code %d";
 const unichar Quote = '\"';
 //The regular expression that matches the Bearer contents:
-NSString* const RegularExpression = @"^Bearer\\s*([^,\\s=\"]+?)=\"([^\"]*?)\"\\s*(?:,\\s*([^,\\s=\"]+?)=\"([^\"]*?)\"\\s*)*$";
+NSString* const RegularExpression = @"^Bearer\\s+([^,\\s=\"]+?)=\"([^\"]*?)\"\\s*(?:,\\s*([^,\\s=\"]+?)=\"([^\"]*?)\"\\s*)*$";
 NSString* const ExtractionExpression = @"\\s*([^,\\s=\"]+?)=\"([^\"]*?)\"";
 
 @implementation ADAuthenticationParameters (Internal)

--- a/ADALiOS/ADALiOSTests/ADAuthenticationParametersTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationParametersTests.m
@@ -311,7 +311,7 @@
     ADAuthenticationParameters* params = [ADAuthenticationParameters alloc];
     XCTAssertThrowsSpecificNamed([params initInternalWithParameters:0 error:nil],
                                  NSException, NSInvalidArgumentException, "Exception should be thrown in this case");
-    
+    [self validateExtractChallenge:@"Bearerauthorization_uri=\"abc\", resource_id=\"foo\"" authority:nil resource:nil line:__LINE__];
     [self validateExtractChallenge:@"Bearer foo" authority:nil resource:nil line:__LINE__];
     [self validateExtractChallenge:@"Bearer foo=bar" authority:nil resource:nil line:__LINE__];
     [self validateExtractChallenge:@"Bearer foo=\"bar\"" authority:nil resource:nil line:__LINE__];


### PR DESCRIPTION
Bearerauthorization_uri=\"abc\", resource_id=\"foo\" passes with current regex. It needs to require one or more space after "Bearer".
