### PR TITLE
Fix bridging between non-ARC and ARC when calling SecCertificateBopySubj...

### DIFF
--- a/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
+++ b/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
@@ -133,19 +133,14 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
         if(certificate)
         {
             AD_LOG_VERBOSE(@"Found certificate in keychain", nil);
-            certificateSubject = (__bridge NSString *)(SecCertificateCopySubjectSummary(certificate));
-            certificateData = (__bridge NSData *)(SecCertificateCopyData(certificate));
+            certificateSubject = (NSString *)CFBridgingRelease(SecCertificateCopySubjectSummary(certificate));
+            certificateData = (NSData *)CFBridgingRelease(SecCertificateCopyData(certificate));
         }
         
         //Get the private key and data
         status = SecIdentityCopyPrivateKey(identity, &privateKey);
         if (status != errSecSuccess)
         {
-            if (certificateSubject)
-                CFRelease((__bridge CFTypeRef)(certificateSubject));
-            if (certificateData)
-                CFRelease((__bridge CFTypeRef)(certificateData));
-            
             return nil;
         }
         
@@ -166,12 +161,7 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     else
     {
         AD_LOG_VERBOSE_F(@"Unable to extract a workplace join identity for", @"%@ shared access keychain",
-                         sharedAccessGroup);
-        if (certificateSubject)
-            CFRelease((__bridge CFTypeRef)(certificateSubject));
-        if (certificateData)
-            CFRelease((__bridge CFTypeRef)(certificateData));
-        
+                         sharedAccessGroup);        
         return nil;
     }
 }


### PR DESCRIPTION
...ectSummary and SecCertificateCopyData.

This is a memory leak as the retain count will be off and never get decremented to zero.
