### PR TITLE
fixed currentViewController method

### DIFF
--- a/ADALiOS/ADALiOS/UIApplication+ADExtensions.m
+++ b/ADALiOS/ADALiOS/UIApplication+ADExtensions.m
@@ -22,9 +22,32 @@
 
 @implementation UIApplication ( internal )
 
-+ (UIViewController *) adCurrentViewController
++ (UIViewController *)adCurrentViewController
 {
-    return [[[UIApplication sharedApplication] keyWindow] rootViewController];
+    return [self adCurrentViewControllerWithRootViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
+}
+
++ (UIViewController*)adCurrentViewControllerWithRootViewController:(UIViewController*)rootViewController
+{
+    if ([rootViewController isKindOfClass:[UITabBarController class]])
+    {
+        UITabBarController* tabBarController = (UITabBarController*)rootViewController;
+        return [self adCurrentViewControllerWithRootViewController:tabBarController.selectedViewController];
+    }
+    else if ([rootViewController isKindOfClass:[UINavigationController class]])
+    {
+        UINavigationController* navigationController = (UINavigationController*)rootViewController;
+        return [self adCurrentViewControllerWithRootViewController:navigationController.visibleViewController];
+    }
+    else if (rootViewController.presentedViewController)
+    {
+        UIViewController* presentedViewController = rootViewController.presentedViewController;
+        return [self adCurrentViewControllerWithRootViewController:presentedViewController];
+    }
+    else
+    {
+        return rootViewController;
+    }
 }
 
 @end


### PR DESCRIPTION
rootViewController does not always return the current view controller.
If the root view controller is already presenting a modal view
controller its view is not even in the view hierarchy
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/256?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/256'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>