### PR TITLE
Pod framework support

### DIFF
--- a/ADALiOS.podspec
+++ b/ADALiOS.podspec
@@ -21,5 +21,7 @@ Pod::Spec.new do |s|
   s.source_files = "ADALiOS/ADALiOS/**/*.{h,m}"
   s.resources    = "ADALiOS/ADALiOS/*.storyboard"
   s.preserve_paths = "ADALiOS/ADALiOS/**/*.{h,m}"
+  s.public_header_files = "ADALiOS/ADALiOS/*.h"
+  s.private_header_files = "ADALiOS/ADALiOS/*+Internal.h"
   s.requires_arc = true
 end

--- a/ADALiOS.podspec
+++ b/ADALiOS.podspec
@@ -21,7 +21,6 @@ Pod::Spec.new do |s|
   s.source_files = "ADALiOS/ADALiOS/**/*.{h,m}"
   s.resources    = "ADALiOS/ADALiOS/*.storyboard"
   s.preserve_paths = "ADALiOS/ADALiOS/**/*.{h,m}"
-  s.public_header_files = "ADALiOS/ADALiOS/*.h"
-  s.private_header_files = "ADALiOS/ADALiOS/*+Internal.h"
+  s.public_header_files = "ADALiOS/ADALiOS/ADAL.h", "ADALiOS/ADALiOS/ADLogger.h", "ADALiOS/ADALiOS/ADAuthenticationContext.h", "ADALiOS/ADALiOS/ADTokenCacheStoring.h", "ADALiOS/ADALiOS/ADAuthenticationError.h", "ADALiOS/ADALiOS/ADAuthenticationResult.h", "ADALiOS/ADALiOS/ADTokenCacheStoreItem.h", "ADALiOS/ADALiOS/ADUserInformation.h", "ADALiOS/ADALiOS/ADTokenCacheStoreKey.h", "ADALiOS/ADALiOS/ADAuthenticationSettings.h", "ADALiOS/ADALiOS/ADAuthenticationBroker.h", "ADALiOS/ADALiOS/ADErrorCodes.h", "ADALiOS/ADALiOS/ADAuthenticationParameters.h"
   s.requires_arc = true
 end

--- a/ADALiOS/ADALiOS/ADAuthenticationParameters+Internal.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationParameters+Internal.h
@@ -16,6 +16,8 @@
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
 
+#import "ADAuthenticationParameters.h"
+
 //Protocol constants:
 extern NSString* const OAuth2_Bearer;
 extern NSString* const OAuth2_Authenticate_Header;


### PR DESCRIPTION
Investigating the upcoming support for CocoaPods framework support, the updated podspec properly scopes the headers for the use_frameworks setting.

Also with this scope a small error with the ADAuthenticationParameters class needing the original interface as it's project scoped.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270%23issuecomment-75105695%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270%23discussion_r25011346%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270%23issuecomment-75105695%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Not%20all%20.h%20%20files%20are%20scoped%20for%20public%20use.%20We%20have%20several%20internal%20classes%20that%20we%20do%20no%20intend%20to%20expose.%20This%20change%20will%20break%20that%20intention.%22%2C%20%22created_at%22%3A%20%222015-02-19T18%3A16%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%202ed9c2e10384d5cb3e4e9b856b07798460edbab3%20ADALiOS.podspec%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270%23discussion_r25011346%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22this%20needs%20to%20be%20a%20selective%20list.%22%2C%20%22created_at%22%3A%20%222015-02-19T18%3A26%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS.podspec%3AL21-28%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270#issuecomment-75105695'>General Comment</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> Not all .h  files are scoped for public use. We have several internal classes that we do no intend to expose. This change will break that intention.
- [ ] <a href='#crh-comment-Pull 2ed9c2e10384d5cb3e4e9b856b07798460edbab3 ADALiOS.podspec 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270#discussion_r25011346'>File: ADALiOS.podspec:L21-28</a></b>
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> this needs to be a selective list.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/270?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/270?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/270'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>