### PR TITLE
memory leak fixes

### DIFF
--- a/ADALiOS/ADALiOS/ADClientMetrics.m
+++ b/ADALiOS/ADALiOS/ADClientMetrics.m
@@ -121,7 +121,6 @@ const NSString* HeaderLastEndpoint = @"x-client-last-endpoint";
         SAFE_ARC_RETAIN(_endpoint);
         SAFE_ARC_RETAIN(_correlationId);
         SAFE_ARC_RETAIN(_errorToReport);
-        SAFE_ARC_RETAIN(_startTime);
     }
 }
 

--- a/ADALiOS/ADALiOS/ADLogger.m
+++ b/ADALiOS/ADALiOS/ADLogger.m
@@ -126,6 +126,8 @@ additionalInformation: (NSString*) additionalInformation
                 sLogCallback(logLevel, [NSString stringWithFormat:@"ADALiOS [%@ - %@] %@", [dateFormatter stringFromDate:[NSDate date]], [[ADLogger getCorrelationId] UUIDString], message], additionalInformation, errorCode);
             }
         }
+        SAFE_ARC_RELEASE(dateFormatter);
+        dateFormatter = nil;
     }
 }
 

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -68,12 +68,16 @@ NSString* const sLog = @"HTTP Protocol";
     _connection = [[NSURLConnection alloc] initWithRequest:mutableRequest
                                                   delegate:self
                                           startImmediately:YES];
+    SAFE_ARC_RELEASE(mutableRequest);
+    mutableRequest = nil;
 }
 
 - (void)stopLoading
 {
     AD_LOG_VERBOSE_F(sLog, @"Stop loading");
     [_connection cancel];
+    SAFE_ARC_RELEASE(_connection);
+    _connection = nil;
     [self.client URLProtocol:self didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil]];
 }
 
@@ -123,6 +127,8 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
         [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:response];
         
         [_connection cancel];
+        SAFE_ARC_RELEASE(_connection);
+        _connection = nil;
         [self.client URLProtocol:self didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil]];
         
         return mutableRequest;
@@ -146,6 +152,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
 {
 #pragma unused (connection)
     [self.client URLProtocolDidFinishLoading:self];
+    SAFE_ARC_RELEASE(_connection);
     _connection = nil;
 }
 

--- a/Samples/MyTestiOSApp/MyTestiOSApp/TestData.plist
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/TestData.plist
@@ -5,11 +5,11 @@
 	<key>AAD Instance</key>
 	<dict>
 		<key>Authority</key>
-		<string>https://login.windows-ppe.net/common</string>
+		<string>https://login.windows.net/common</string>
 		<key>ClientId</key>
 		<string>d3590ed6-52b3-4102-aeff-aad2292ab01c</string>
 		<key>Resource</key>
-		<string>https://msft.spoppe.com</string>
+		<string>https://graph.windows.net</string>
 		<key>RedirectUri</key>
 		<string>urn:ietf:wg:oauth:2.0:oob</string>
 		<key>UserId</key>


### PR DESCRIPTION
memory leak fixes
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RPangrle-MS%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23issuecomment-75162657%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-02-19T23%3A39%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20773194acaded2b854bc04e27f105f423a7a2236d%20ADALiOS/ADALiOS/ADLogger.m%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23discussion_r25037718%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Putting%20the%20%3D%20nil%20into%20the%20SAFE_ARC_RELEASE%20macro%20wouldn%27t%20be%20a%20bad%20idea.%22%2C%20%22created_at%22%3A%20%222015-02-19T23%3A39%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22will%20it%20be%20okay%20if%20I%20put%20nil%20after%20the%20release%20here%3F%20I%20think%20it%20will%20require%20a%20major%20sweep%20across%20the%20code%20else%20we%20can%20get%20double%20nil%20assignment%20errors.%22%2C%20%22created_at%22%3A%20%222015-02-19T23%3A40%3A35Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22Sure.%20I%20could%20see%20it%20causing%20compiler%20errors%20if%20the%20compiler%20is%20being%20overly%20aggressive.%20It%5Cu2019s%20not%20high%20pri%2C%20just%20an%20idea.%20%5Cu263a%5Cr%5Cn%5Cr%5CnFrom%3A%20Kanishk%20Panwar%20%5Bmailto%3Anotifications%40github.com%5D%5Cr%5CnSent%3A%20Thursday%2C%20February%2019%2C%202015%203%3A41%20PM%5Cr%5CnTo%3A%20AzureAD/azure-activedirectory-library-for-objc%5Cr%5CnCc%3A%20Ryan%20Pangrle%5Cr%5CnSubject%3A%20Re%3A%20%5Bazure-activedirectory-library-for-objc%5D%20memory%20leak%20fixes%20%28%23271%29%5Cr%5Cn%5Cr%5Cn%5Cr%5CnIn%20ADALiOS/ADALiOS/ADLogger.m%3Chttps%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23discussion_r25037814%3E%3A%5Cr%5Cn%5Cr%5Cn%3E%20%40%40%20-126%2C6%20%2B126%2C8%20%40%40%20%2B%28void%29%20log%3A%20%28ADAL_LOG_LEVEL%29logLevel%5Cr%5Cn%5Cr%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20%20sLogCallback%28logLevel%2C%20%5BNSString%20stringWithFormat%3A%40%5C%22ADALiOS%20%5B%25%40%20-%20%25%40%5D%20%25%40%5C%22%2C%20%5BdateFormatter%20stringFromDate%3A%5BNSDate%20date%5D%5D%2C%20%5B%5BADLogger%20getCorrelationId%5D%20UUIDString%5D%2C%20message%5D%2C%20additionalInformation%2C%20errorCode%29%3B%5Cr%5Cn%5Cr%5Cn%3E%20%20%20%20%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%5Cr%5Cn%3E%20%20%20%20%20%20%20%20%20%20%7D%5Cr%5Cn%5Cr%5Cn%3E%20%2B%20%20%20%20%20%20%20%20SAFE_ARC_RELEASE%28dateFormatter%29%3B%5Cr%5Cn%5Cr%5Cnwill%20it%20be%20okay%20if%20I%20put%20nil%20after%20the%20release%20here%3F%20I%20think%20it%20will%20require%20a%20major%20sweep%20across%20the%20code%20else%20we%20can%20get%20double%20nil%20assignment%20errors.%5Cr%5Cn%5Cr%5Cn%5Cu2014%5Cr%5CnReply%20to%20this%20email%20directly%20or%20view%20it%20on%20GitHub%3Chttps%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271/files%23r25037814%3E.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-02-20T00%3A00%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADLogger.m%3AL126-134%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23issuecomment-75162657%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23discussion_r25037718%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23discussion_r25037814%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271%23discussion_r25038985%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RPangrle-MS'><img src='https://avatars.githubusercontent.com/u/7004783?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 773194acaded2b854bc04e27f105f423a7a2236d ADALiOS/ADALiOS/ADLogger.m 4'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271#discussion_r25037718'>File: ADALiOS/ADALiOS/ADLogger.m:L126-134</a></b>
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Putting the = nil into the SAFE_ARC_RELEASE macro wouldn't be a bad idea.
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> will it be okay if I put nil after the release here? I think it will require a major sweep across the code else we can get double nil assignment errors.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Sure. I could see it causing compiler errors if the compiler is being overly aggressive. It’s not high pri, just an idea. ☺
From: Kanishk Panwar [mailto:notifications@github.com]
Sent: Thursday, February 19, 2015 3:41 PM
To: AzureAD/azure-activedirectory-library-for-objc
Cc: Ryan Pangrle
Subject: Re: [azure-activedirectory-library-for-objc] memory leak fixes (#271)
In ADALiOS/ADALiOS/ADLogger.m<https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271#discussion_r25037814>:
> @@ -126,6 +126,8 @@ +(void) log: (ADAL_LOG_LEVEL)logLevel
>                  sLogCallback(logLevel, [NSString stringWithFormat:@"ADALiOS [%@ - %@] %@", [dateFormatter stringFromDate:[NSDate date]], [[ADLogger getCorrelationId] UUIDString], message], additionalInformation, errorCode);
>              }
>          }
> +        SAFE_ARC_RELEASE(dateFormatter);
will it be okay if I put nil after the release here? I think it will require a major sweep across the code else we can get double nil assignment errors.
—
Reply to this email directly or view it on GitHub<https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271/files#r25037814>.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/271?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/271?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/271?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/271'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>