### PR TITLE
Resolving bundle based on class location.

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -129,36 +129,7 @@ static NSString *_resourcePath = nil;
 // cannot be loaded.
 + (NSBundle *)frameworkBundle
 {
-    static NSBundle       *bundle     = nil;
-    static dispatch_once_t predicate;
-    
-    @synchronized(self)
-    {
-        dispatch_once( &predicate,
-                      ^{
-
-                          NSString* mainBundlePath      = [[NSBundle mainBundle] resourcePath];
-                          AD_LOG_VERBOSE_F(@"Resources Loading", @"Attempting to load resources from: %@", mainBundlePath);
-                          NSString* frameworkBundlePath = nil;
-                          
-                          if ( _resourcePath != nil )
-                          {
-                              frameworkBundlePath = [[mainBundlePath stringByAppendingPathComponent:_resourcePath] stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          else
-                          {
-                              frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          
-                          bundle = [NSBundle bundleWithPath:frameworkBundlePath];
-                          if (!bundle)
-                          {
-                              AD_LOG_INFO_F(@"Resource Loading", @"Failed to load framework bundle. Application main bundle will be attempted.");
-                          }
-                      });
-    }
-    
-    return bundle;
+	return [NSBundle bundleForClass:[self class]];
 }
 
 +(NSString*) getStoryboardName


### PR DESCRIPTION
Resolves #280 by following suggested way to resolve the appropriate bundle for resources when using dynamic frameworks
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RPangrle%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/304%23issuecomment-143013163%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-09-24T18%3A31%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/304%23issuecomment-143013163%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RPangrle'><img src='https://avatars.githubusercontent.com/u/7004783?v=3' width=34 height=34></a>

<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/304?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/304?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/304'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>