### PR TITLE
move broker changes to OSXUniversal

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -88,6 +88,8 @@
 		8BFEF07B182DB15E00122C0C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 8BFEF066182DA57800122C0C /* InfoPlist.strings */; };
 		8BFEF07C182DB15E00122C0C /* ADAL_iPhone_Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BFEF04B182D906700122C0C /* ADAL_iPhone_Storyboard.storyboard */; };
 		8BFEF07D182DB15E00122C0C /* ADAL_iPad_Storyboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8BFEF04C182D906700122C0C /* ADAL_iPad_Storyboard.storyboard */; };
+		971C56C31AF7CF370034820F /* ADBrokerKeyHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 971C56C01AF7CF370034820F /* ADBrokerKeyHelper.m */; };
+		971C56C41AF7CF370034820F /* ADBrokerNotificationManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 971C56C21AF7CF370034820F /* ADBrokerNotificationManager.m */; };
 		9722233819AB05D700092E85 /* ADPkeyAuthHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9722233719AB05D700092E85 /* ADPkeyAuthHelper.m */; };
 		9722234419AB060200092E85 /* RegistrationInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9722233D19AB060200092E85 /* RegistrationInformation.m */; };
 		9722234519AB060200092E85 /* WorkPlaceJoin.m in Sources */ = {isa = PBXBuildFile; fileRef = 9722233F19AB060200092E85 /* WorkPlaceJoin.m */; };
@@ -242,6 +244,10 @@
 		8BFEF065182DA57800122C0C /* ADALiOSBundle-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ADALiOSBundle-Info.plist"; sourceTree = "<group>"; };
 		8BFEF067182DA57800122C0C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8BFEF069182DA57800122C0C /* ADALiOSBundle-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALiOSBundle-Prefix.pch"; sourceTree = "<group>"; };
+		971C56BF1AF7CF370034820F /* ADBrokerKeyHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADBrokerKeyHelper.h; sourceTree = "<group>"; };
+		971C56C01AF7CF370034820F /* ADBrokerKeyHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADBrokerKeyHelper.m; sourceTree = "<group>"; };
+		971C56C11AF7CF370034820F /* ADBrokerNotificationManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADBrokerNotificationManager.h; sourceTree = "<group>"; };
+		971C56C21AF7CF370034820F /* ADBrokerNotificationManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADBrokerNotificationManager.m; sourceTree = "<group>"; };
 		9722233619AB05D700092E85 /* ADPkeyAuthHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADPkeyAuthHelper.h; sourceTree = "<group>"; };
 		9722233719AB05D700092E85 /* ADPkeyAuthHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADPkeyAuthHelper.m; sourceTree = "<group>"; };
 		9722233C19AB060200092E85 /* RegistrationInformation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegistrationInformation.h; sourceTree = "<group>"; };
@@ -333,6 +339,10 @@
 		8B0965AF17F25770002BDFB8 /* ADALiOS */ = {
 			isa = PBXGroup;
 			children = (
+				971C56BF1AF7CF370034820F /* ADBrokerKeyHelper.h */,
+				971C56C01AF7CF370034820F /* ADBrokerKeyHelper.m */,
+				971C56C11AF7CF370034820F /* ADBrokerNotificationManager.h */,
+				971C56C21AF7CF370034820F /* ADBrokerNotificationManager.m */,
 				9722233919AB05E500092E85 /* WorkPlaceJoin */,
 				9722233619AB05D700092E85 /* ADPkeyAuthHelper.h */,
 				9722233719AB05D700092E85 /* ADPkeyAuthHelper.m */,
@@ -672,6 +682,8 @@
 				8BBE6FB61964DD090039C23E /* ADKeyChainHelper.m in Sources */,
 				8BB8346218074CFA007F9F0D /* ADAuthenticationParameters.m in Sources */,
 				8B8FD79B188223770070B1BE /* ADKeychainTokenCacheStore.m in Sources */,
+				971C56C31AF7CF370034820F /* ADBrokerKeyHelper.m in Sources */,
+				971C56C41AF7CF370034820F /* ADBrokerNotificationManager.m in Sources */,
 				8B92DB70181B2335004AAB0E /* ADLogger.m in Sources */,
 				97EEE7C41A4FFD5600D003F8 /* ADNTLMHandler.m in Sources */,
 				8B5989551811B89800744AEE /* ADTokenCacheStoreKey.m in Sources */,

--- a/ADALiOS/ADALiOS/ADAL.h
+++ b/ADALiOS/ADALiOS/ADAL.h
@@ -31,8 +31,8 @@
 #import "ADAuthenticationParameters.h"
 
 #define ADAL_VER_HIGH   1
-#define ADAL_VER_LOW    2
-#define ADAL_VER_PATCH  2
+#define ADAL_VER_LOW    3
+#define ADAL_VER_PATCH  0
 
 #pragma mark - OSX Universal ARC compatibility macros
 

--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -181,8 +181,7 @@ correlationId:(NSUUID *)correlationId
     THROW_ON_NIL_ARGUMENT(startURL);
     THROW_ON_NIL_ARGUMENT(endURL);
     THROW_ON_NIL_ARGUMENT(correlationId);
-    THROW_ON_NIL_ARGUMENT(completionBlock)
-    AD_LOG_VERBOSE(@"Authorization", startURL.absoluteString);
+    THROW_ON_NIL_ARGUMENT(completionBlock);
     
     startURL = [self addToURL:startURL correlationId:correlationId];//Append the correlation id
     
@@ -192,6 +191,8 @@ correlationId:(NSUUID *)correlationId
     
     if (webView)
     {
+        AD_LOG_INFO(@"Authorization UI", @"Use the application provided WebView.");
+        
         // Use the application provided WebView
         _authenticationWebViewController = [[ADAuthenticationWebViewController alloc] initWithWebView:webView startAtURL:startURL endAtURL:endURL];
         
@@ -221,7 +222,7 @@ correlationId:(NSUUID *)correlationId
             _ntlmSession = [ADNTLMHandler startWebViewNTLMHandlerWithError:nil];
             if (_ntlmSession)
             {
-                AD_LOG_INFO(@"Authorization UI", @"The device is workplace joined. Client TLS Session started.");
+                AD_LOG_INFO(@"Authorization UI", @"NTLM support enabled");
             }
 
             parentController = parent;

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -116,6 +116,18 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
         tokenCacheStore: (id<ADTokenCacheStoring>)tokenCache
                   error: (ADAuthenticationError* __autoreleasing *) error;
 
+
+#if TARGET_OS_IPHONE
+/*!
+ */
++(BOOL) isResponseFromBroker:(NSString*) sourceApplication
+                    response:(NSURL*) response;
+
+/*!
+ */
++(void) handleBrokerResponse:(NSURL*) response;
+#endif
+
 /*! Creates the object, setting the authority, default cache and enables the authority validation. In case of an error
  the function will return nil and if the error parameter is supplied, it will be filled with error details.
  @param authority: The AAD or ADFS authority. Example: @"https://login.windows.net/contoso.com"
@@ -158,15 +170,6 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                                              validateAuthority: (BOOL) validate
                                                tokenCacheStore: (id<ADTokenCacheStoring>) tokenCache
                                                          error: (ADAuthenticationError* __autoreleasing *) error;
-
-/*!
- */
-+(BOOL) isResponseFromBroker:(NSString*) sourceApplication
-                    response:(NSURL*) response;
-
-/*!
- */
-+(void) handleBrokerResponse:(NSURL*) response;
 
 /*! Represents the authority used by the context. */
 @property (readonly) NSString* authority;
@@ -315,6 +318,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                        completionBlock: (ADAuthenticationCallback) completionBlock;
 
 #if !TARGET_OS_IPHONE
+
 /*! Follows the OAuth2 protocol (RFC 6749). Uses the refresh token to obtain an access token (and another refresh token). The method
  is superceded by acquireToken, which will implicitly use the refresh token if needed. Please use acquireTokenByRefreshToken
  only if you would like to store the access and refresh tokens, managing the expiration times in your application logic.

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -56,20 +56,27 @@ typedef enum
 
 typedef enum
 {
-    /*! Users will be prompted only if their attention is needed. Default option. */
+    /*! Default option. Users will be prompted only if their attention is needed. First the cache will
+     be checked for a suitable access token (non-expired). If none is found, the cache will be checked
+     for a suitable refresh token to be used for obtaining a new access token. If this attempt fails
+     too, it depends on the acquireToken method being called.
+     acquireTokenWithResource methods will prompt the user to re-authorize the resource usage by providing
+     credentials. If user login cookies are present from previous authorization, the webview will be
+     displayed and automatically dismiss itself without asking the user to re-enter credentials.
+     acquireTokenSilentWithResource methods will not show UI in this case, but fail with error code
+     AD_ERROR_USER_INPUT_NEEDED. */
     AD_PROMPT_AUTO,
-    
-    /*! Users will never be prompted. If their attention is needed, the corresponding calls will fail
-     with appropriate error code. This option is useful for background running tasks, while the user
-     attention is occupied by another activity. A subsequent call with AD_PROMPT_AUTO may be made in more
-     appropriate time.
-     */
-    AD_PROMPT_NEVER,
     
     /*! The user will be prompted explicitly for credentials, consent or any other prompts. This option
      is useful in multi-user scenarios. Example is authenticating for the same e-mail service with different
-     user */
+     user. */
     AD_PROMPT_ALWAYS,
+    
+    /*! Re-authorizes (through displaying webview) the resource usage, making sure that the resulting access
+     token contains updated claims. If user logon cookies are available, the user will not be asked for
+     credentials again and the logon dialog will dismiss automatically. This is equivalent to passing
+     prompt=refresh_session as an extra query parameter during the authorization. */
+    AD_PROMPT_REFRESH_SESSION,
 } ADPromptBehavior;
 
 @class ADAuthenticationResult;
@@ -152,6 +159,14 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                                                tokenCacheStore: (id<ADTokenCacheStoring>) tokenCache
                                                          error: (ADAuthenticationError* __autoreleasing *) error;
 
+/*!
+ */
++(BOOL) isResponseFromBroker:(NSString*) sourceApplication
+                    response:(NSURL*) response;
+
+/*!
+ */
++(void) handleBrokerResponse:(NSURL*) response;
 
 /*! Represents the authority used by the context. */
 @property (readonly) NSString* authority;
@@ -182,7 +197,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
 /*! Follows the OAuth2 protocol (RFC 6749). The function will first look at the cache and automatically check for token
  expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
  the function will use the refresh token automatically.
- @param samlAssertion: the SAML assertion to be used to authenticate the user.
+ @param samlAssertion: the SAML assertion to be used to authenticate the user. Required.
  @param assertionType: defines the assertion type.
  @param resource: the resource whose token is needed.
  @param clientId: the client identifier
@@ -194,6 +209,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                     assertionType: (ADAssertionType) assertionType
                          resource: (NSString*) resource
                          clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
                            userId: (NSString*) userId
                   completionBlock: (ADAuthenticationCallback) completionBlock;
 
@@ -267,6 +283,38 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
              extraQueryParameters: (NSString*) queryParams
                   completionBlock: (ADAuthenticationCallback) completionBlock;
 
+/*! Follows the OAuth2 protocol (RFC 6749). The function will first look at the cache and automatically check for token
+ expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
+ the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.
+ If reauthorization is needed, the method will return an error with code AD_ERROR_USER_INPUT_NEEDED.
+ @param resource: the resource whose token is needed.
+ @param clientId: the client identifier
+ @param redirectUri: The redirect URI according to OAuth2 protocol.
+ @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+-(void) acquireTokenSilentWithResource: (NSString*) resource
+                              clientId: (NSString*) clientId
+                           redirectUri: (NSURL*) redirectUri
+                       completionBlock: (ADAuthenticationCallback) completionBlock;
+
+/*! Follows the OAuth2 protocol (RFC 6749). The function will first look at the cache and automatically check for token
+ expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
+ the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.
+ If reauthorization is needed, the method will return an error with code AD_ERROR_USER_INPUT_NEEDED.
+ @param resource: the resource whose token is needed.
+ @param clientId: the client identifier
+ @param redirectUri: The redirect URI according to OAuth2 protocol
+ @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ it may not be used if it belongs to different token. This parameter can be nil.
+ @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+-(void) acquireTokenSilentWithResource: (NSString*) resource
+                              clientId: (NSString*) clientId
+                           redirectUri: (NSURL*) redirectUri
+                                userId: (NSString*) userId
+                       completionBlock: (ADAuthenticationCallback) completionBlock;
+
+#if !TARGET_OS_IPHONE
 /*! Follows the OAuth2 protocol (RFC 6749). Uses the refresh token to obtain an access token (and another refresh token). The method
  is superceded by acquireToken, which will implicitly use the refresh token if needed. Please use acquireTokenByRefreshToken
  only if you would like to store the access and refresh tokens, managing the expiration times in your application logic.
@@ -290,6 +338,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                           clientId: (NSString*) clientId
                           resource: (NSString*) resource
                    completionBlock: (ADAuthenticationCallback) completionBlock;
+#endif
 
 @end
 

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -32,8 +32,15 @@
 #import "ADTokenCacheStoreKey.h"
 #import "ADUserInformation.h"
 #import "ADClientMetrics.h"
+#import "ADKeyChainHelper.h"
+#import "ADBrokerKeyHelper.h"
+#import "NSString+ADHelperMethods.h"
+#import "ADHelpers.h"
+#import "ADOAuth2Constants.h"
 
 #ifdef TARGET_OS_IPHONE
+#import <objc/runtime.h>
+#import "ADBrokerNotificationManager.h"
 #import "WorkPlaceJoin.h"
 #import "ADPkeyAuthHelper.h"
 #import "WorkPlaceJoinConstants.h"
@@ -43,10 +50,31 @@ NSString* const unknownError = @"Uknown error.";
 NSString* const credentialsNeeded = @"The user credentials are need to obtain access token. Please call acquireToken with 'promptBehavior' not set to AD_PROMPT_NEVER";
 NSString* const serverError = @"The authentication server returned an error: %@.";
 
+NSString* const brokerAppIdentifier = @"com.microsoft.broker";
+NSString* const brokerURL = @"msauth://";
+
 //Used for the callback of obtaining the OAuth2 code:
 typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
 static volatile int sDialogInProgress = 0;
+
+typedef BOOL (*applicationOpenURLPtr)(id, SEL, UIApplication*, NSURL*, NSString*, id);
+IMP __original_ApplicationOpenURL = NULL;
+
+BOOL __swizzle_ApplicationOpenURL(id self, SEL _cmd, UIApplication* application, NSURL* url, NSString* sourceApplication, id annotation)
+{
+    if (![ADAuthenticationContext isResponseFromBroker:sourceApplication response:url])
+    {
+        if (__original_ApplicationOpenURL)
+            return ((applicationOpenURLPtr)__original_ApplicationOpenURL)(self, _cmd, application, url, sourceApplication, annotation);
+        else
+            return NO;
+    }
+    
+    [ADAuthenticationContext handleBrokerResponse:url];
+    return YES;
+}
+
 
 @implementation ADAuthenticationContext
 
@@ -57,6 +85,49 @@ static volatile int sDialogInProgress = 0;
 @synthesize validateAuthority = _validateAuthority;
 @synthesize webView           = _webView;
 @synthesize isCorrelationIdUserProvided = _isCorrelationIdUserProvided;
+
+
+
++ (void) load
+{
+    __block id observer = nil;
+    
+    observer = [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification
+                                                                 object:nil
+                                                                  queue:nil
+                                                             usingBlock:^(NSNotification* notification)
+                {
+                    // We don't want to swizzle multiple times so remove the observer
+                    [[NSNotificationCenter defaultCenter] removeObserver:observer name:UIApplicationDidFinishLaunchingNotification object:nil];
+                    
+                    SEL sel = @selector(application:openURL:sourceApplication:annotation:);
+                    
+                    // Dig out the app delegate (if there is one)
+                    __strong id appDelegate = [[UIApplication sharedApplication] delegate];
+                    if ([appDelegate respondsToSelector:sel])
+                    {
+                        Method m = class_getInstanceMethod([appDelegate class], sel);
+                        __original_ApplicationOpenURL = method_getImplementation(m);
+                        method_setImplementation(m, (IMP)__swizzle_ApplicationOpenURL);
+                    }
+                    else
+                    {
+                        NSString* typeEncoding = [NSString stringWithFormat:@"%s%s%s%s%s%s%s", @encode(BOOL), @encode(id), @encode(SEL), @encode(UIApplication*), @encode(NSURL*), @encode(NSString*), @encode(id)];
+                        if (!class_addMethod([appDelegate class], sel, (IMP)__swizzle_ApplicationOpenURL, [typeEncoding UTF8String]))
+                            NSLog(@"failed to add!");
+                        if (![appDelegate respondsToSelector:sel])
+                            NSLog(@"what the fucking fuck");
+                        
+                        // UIApplication caches whether or not the delegate responds to certain selectors. Clearing out the delegate and resetting it gaurantees that gets updated
+                        [[UIApplication sharedApplication] setDelegate:nil];
+                        // UIApplication employs dark magic to assume ownership of the app delegate when it gets the app delegate at launch, it won't do that for setDelegate calls so we
+                        // have to add a retain here to make sure it doesn't turn into a zombie
+                        [[UIApplication sharedApplication] setDelegate:(__bridge id)CFRetain((__bridge CFTypeRef)appDelegate)];
+                    }
+                    
+                }];
+    
+}
 
 -(id) init
 {
@@ -93,7 +164,7 @@ static volatile int sDialogInProgress = 0;
 
 //A wrapper around checkAndHandleBadArgument. Assumes that "completionMethod" is in scope:
 #define HANDLE_ARGUMENT(ARG) \
-if (![self checkAndHandleBadArgument:ARG \
+if (![ADAuthenticationContext checkAndHandleBadArgument:ARG \
 argumentName:TO_NSSTRING(#ARG) \
 completionBlock:completionBlock]) \
 { \
@@ -105,7 +176,7 @@ return; \
  Then the method calls the callback with the result.
  The method returns if the argument is valid. If the method returns false,
  the calling method should return. */
--(BOOL) checkAndHandleBadArgument: (NSObject*) argumentValue
++(BOOL) checkAndHandleBadArgument: (NSObject*) argumentValue
                      argumentName: (NSString*) argumentName
                   completionBlock: (ADAuthenticationCallback)completionBlock
 {
@@ -131,6 +202,26 @@ return; \
 {
     [ADLogger setCorrelationId: correlationId];
     _isCorrelationIdUserProvided = YES;
+}
+
+//Translates the ADPromptBehavior into prompt query parameter. May return nil, if such
+//parameter is not needed.
++(NSString*) getPromptParameter: (ADPromptBehavior) prompt
+{
+    switch (prompt) {
+        case AD_PROMPT_ALWAYS:
+            return @"login";
+        case AD_PROMPT_REFRESH_SESSION:
+            return @"refresh_session";
+        default:
+            return nil;
+    }
+}
+
++(BOOL) isForcedAuthorization: (ADPromptBehavior) prompt
+{
+    //If prompt parameter needs to be passed, re-authorization is needed.
+    return [self getPromptParameter:prompt] != nil;
 }
 
 -(id) initWithAuthority: (NSString*) authority
@@ -207,20 +298,119 @@ return; \
 }
 
 
++(BOOL) isResponseFromBroker:(NSString*) sourceApplication
+                    response:(NSURL*) response
+{
+    return sourceApplication && [NSString adSame:sourceApplication toString:brokerAppIdentifier];
+    response &&
+    [NSString adSame:[response path] toString:@"broker"];
+}
+
++(void) handleBrokerResponse:(NSURL*) response
+{
+    THROW_ON_NIL_ARGUMENT([ADBrokerNotificationManager sharedInstance].callbackForBroker);
+    ADAuthenticationCallback completionBlock = [ADBrokerNotificationManager sharedInstance].callbackForBroker;
+    
+    HANDLE_ARGUMENT(response);
+    
+    
+    NSString *qp = [response query];
+    //expect to either response or error and description, AND correlation_id AND hash.
+    NSDictionary* queryParamsMap = [NSDictionary adURLFormDecode:qp];
+    ADAuthenticationResult* result;
+    //response=encrypted_response&hash=hash_value
+    //code=some_code&error_details=message
+    if([queryParamsMap valueForKey:OAUTH2_ERROR_DESCRIPTION]){
+        result = [ADAuthenticationResult resultFromBrokerResponse:queryParamsMap];
+    }
+    else
+    {
+        HANDLE_ARGUMENT([queryParamsMap valueForKey:BROKER_HASH_KEY]);
+        
+        NSString* hash = [queryParamsMap valueForKey:BROKER_HASH_KEY];
+        NSString* encryptedBase64Response = [queryParamsMap valueForKey:BROKER_RESPONSE_KEY];
+        
+        //decrypt response first
+        ADBrokerKeyHelper* brokerHelper = [[ADBrokerKeyHelper alloc] initHelper];
+        ADAuthenticationError* error;
+        NSData *encryptedResponse = [NSString Base64DecodeData:encryptedBase64Response ];
+        NSData* decrypted = [brokerHelper decryptBrokerResponse:encryptedResponse error:&error];
+        NSString* decryptedString = nil;
+        
+        if(!error)
+        {
+            decryptedString =[[NSString alloc] initWithData:decrypted encoding:0];
+            //now compute the hash on the unencrypted data
+            if([NSString adSame:hash toString:[ADPkeyAuthHelper computeThumbprint:decrypted isSha2:YES]]){
+                //create response from the decrypted payload
+                queryParamsMap = [NSDictionary adURLFormDecode:decryptedString];
+                [ADHelpers removeNullStringFrom:queryParamsMap];
+                result = [ADAuthenticationResult resultFromBrokerResponse:queryParamsMap];
+                
+            }
+            else
+            {
+                result = [ADAuthenticationResult resultFromError:[ADAuthenticationError errorFromNSError:[NSError errorWithDomain:ADAuthenticationErrorDomain
+                                                                                                                             code:AD_ERROR_BROKER_RESPONSE_HASH_MISMATCH
+                                                                                                                         userInfo:nil]
+                                                                                            errorDetails:@"Decrypted response does not match the hash"]];
+            }
+        }
+        else
+        {
+            result = [ADAuthenticationResult resultFromError:error];
+        }
+    }
+    
+    if (AD_SUCCEEDED == result.status)
+    {
+        ADAuthenticationContext* ctx = [ADAuthenticationContext
+                                        authenticationContextWithAuthority:result.tokenCacheStoreItem.authority
+                                        error:nil];
+        
+        SEL selector = @selector(updateCacheToResult:cacheItem:withRefreshToken:);
+        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[ctx methodSignatureForSelector:selector]];
+        [inv setSelector:selector];
+        [inv setTarget:ctx];
+        [inv setArgument:&result atIndex:2];
+        [inv invoke];
+        
+        NSString* userId = [queryParamsMap valueForKey:@"user_id"];
+        selector = nil;
+        selector = @selector(updateResult:toUser:);
+        inv = nil;
+        inv = [NSInvocation invocationWithMethodSignature:[ctx methodSignatureForSelector:selector]];
+        [inv setSelector:selector];
+        [inv setTarget:ctx];
+        [inv setArgument:&result atIndex:2];
+        if(userId)
+        {
+            [inv setArgument:&userId atIndex:3];
+        }
+        
+        [inv invoke];
+    }
+    
+    completionBlock(result);
+    [ADBrokerNotificationManager sharedInstance].callbackForBroker = nil;
+    
+}
+
 -(void)  acquireTokenForAssertion: (NSString*) assertion
                     assertionType: (ADAssertionType) assertionType
                          resource: (NSString*) resource
                          clientId: (NSString*) clientId
+                      redirectUri: (NSString*)redirectUri
                            userId: (NSString*) userId
                   completionBlock: (ADAuthenticationCallback) completionBlock{
     API_ENTRY;
     return [self internalAcquireTokenForAssertion:assertion
                                          clientId:clientId
-                                         resource: resource
-                                    assertionType:  assertionType
+                                      redirectUri:redirectUri
+                                         resource:resource
+                                    assertionType:assertionType
                                            userId:userId
                                             scope:nil
-                                         tryCache:YES
                                 validateAuthority:self.validateAuthority
                                     correlationId:[self getCorrelationId]
                                   completionBlock:completionBlock];
@@ -238,10 +428,10 @@ return; \
                                          clientId:clientId
                                       redirectUri:redirectUri
                                    promptBehavior:AD_PROMPT_AUTO
+                                           silent:NO
                                            userId:nil
                                             scope:nil
                              extraQueryParameters:nil
-                                         tryCache:YES
                                 validateAuthority:self.validateAuthority
                                     correlationId:[self getCorrelationId]
                                   completionBlock:completionBlock];
@@ -258,10 +448,10 @@ return; \
                                   clientId:clientId
                                redirectUri:redirectUri
                             promptBehavior:AD_PROMPT_AUTO
+                                    silent:NO
                                     userId:userId
                                      scope:nil
                       extraQueryParameters:nil
-                                  tryCache:YES
                          validateAuthority:self.validateAuthority
                              correlationId:[self getCorrelationId]
                            completionBlock:completionBlock];
@@ -280,14 +470,54 @@ return; \
                                   clientId:clientId
                                redirectUri:redirectUri
                             promptBehavior:AD_PROMPT_AUTO
+                                    silent:NO
                                     userId:userId
                                      scope:nil
                       extraQueryParameters:queryParams
-                                  tryCache:YES
                          validateAuthority:self.validateAuthority
                              correlationId:[self getCorrelationId]
                            completionBlock:completionBlock];
 }
+
+-(void) acquireTokenSilentWithResource: (NSString*) resource
+                              clientId: (NSString*) clientId
+                           redirectUri: (NSURL*) redirectUri
+                       completionBlock: (ADAuthenticationCallback) completionBlock
+{
+    API_ENTRY;
+    return [self internalAcquireTokenWithResource:resource
+                                         clientId:clientId
+                                      redirectUri:redirectUri
+                                   promptBehavior:AD_PROMPT_AUTO
+                                           silent:YES
+                                           userId:nil
+                                            scope:nil
+                             extraQueryParameters:nil
+                                validateAuthority:self.validateAuthority
+                                    correlationId:[self getCorrelationId]
+                                  completionBlock:completionBlock];
+}
+
+-(void) acquireTokenSilentWithResource: (NSString*) resource
+                              clientId: (NSString*) clientId
+                           redirectUri: (NSURL*) redirectUri
+                                userId: (NSString*) userId
+                       completionBlock: (ADAuthenticationCallback) completionBlock
+{
+    API_ENTRY;
+    return [self internalAcquireTokenWithResource:resource
+                                         clientId:clientId
+                                      redirectUri:redirectUri
+                                   promptBehavior:AD_PROMPT_AUTO
+                                           silent:YES
+                                           userId:userId
+                                            scope:nil
+                             extraQueryParameters:nil
+                                validateAuthority:self.validateAuthority
+                                    correlationId:[self getCorrelationId]
+                                  completionBlock:completionBlock];
+}
+
 
 //Returns YES if we shouldn't attempt other means to get access token.
 //
@@ -306,6 +536,7 @@ return; \
                      clientId: (NSString*) clientId
                   redirectUri: (NSURL*) redirectUri
                promptBehavior: (ADPromptBehavior) promptBehavior
+                       silent: (BOOL) silent
                        userId: (NSString*) userId
          extraQueryParameters: (NSString*) queryParams
                 correlationId: (NSUUID*) correlationId
@@ -337,6 +568,7 @@ return; \
     //Now attempt to use the refresh token of the passed cache item:
     [self internalAcquireTokenByRefreshToken:item.refreshToken
                                     clientId:clientId
+                                 redirectUri:[redirectUri absoluteString]
                                     resource:resource
                                       userId:item.userInformation.userId
                                    cacheItem:item
@@ -383,6 +615,7 @@ return; \
                                         clientId:clientId
                                      redirectUri:redirectUri
                                   promptBehavior:promptBehavior
+                                          silent:silent
                                           userId:userId
                             extraQueryParameters:queryParams
                                    correlationId:correlationId
@@ -394,17 +627,16 @@ return; \
          
          //The refresh token attempt failed and no other suitable refresh token found
          //call acquireToken
-         [self internalAcquireTokenWithResource: resource
-                                       clientId: clientId
-                                    redirectUri: redirectUri
-                                 promptBehavior: promptBehavior
-                                         userId: userId
-                                          scope: nil
-                           extraQueryParameters: queryParams
-                                       tryCache: NO
-                              validateAuthority: NO
-                                  correlationId:correlationId
-                                completionBlock: completionBlock];
+         [self requestTokenWithResource: resource
+                               clientId: clientId
+                            redirectUri: redirectUri
+                         promptBehavior: promptBehavior
+                                 silent: silent
+                                 userId: userId
+                                  scope: nil
+                   extraQueryParameters: queryParams
+                          correlationId:correlationId
+                        completionBlock: completionBlock];
      }];//End of the refreshing token completion block, executed asynchronously.
 }
 
@@ -417,6 +649,7 @@ return; \
                 assertionType: (ADAssertionType) assertionType
                      resource: (NSString*) resource
                      clientId: (NSString*) clientId
+                  redirectUri: (NSString*) redirectUri
                        userId: (NSString*) userId
                 correlationId: (NSUUID*) correlationId
               completionBlock: (ADAuthenticationCallback)completionBlock
@@ -447,6 +680,7 @@ return; \
     //Now attempt to use the refresh token of the passed cache item:
     [self internalAcquireTokenByRefreshToken:item.refreshToken
                                     clientId:clientId
+                                 redirectUri:redirectUri
                                     resource:resource
                                       userId:item.userInformation.userId
                                    cacheItem:item
@@ -493,6 +727,7 @@ return; \
                                    assertionType:assertionType
                                         resource:resource
                                         clientId:clientId
+                                     redirectUri:redirectUri
                                           userId:userId
                                    correlationId:correlationId
                                  completionBlock:completionBlock];
@@ -503,16 +738,13 @@ return; \
          
          //The refresh token attempt failed and no other suitable refresh token found
          //call acquireToken
-         [self internalAcquireTokenForAssertion:samlAssertion
-                                       clientId:clientId
-                                       resource:resource
-                                  assertionType: assertionType
-                                         userId:userId
-                                          scope:nil
-                                       tryCache:NO
-                              validateAuthority:NO /* Already validated in this block. */
-                                  correlationId:correlationId
-                                completionBlock:completionBlock];
+         [self requestTokenByAssertion: samlAssertion
+                         assertionType: assertionType
+                              resource: resource
+                              clientId: clientId
+                                 scope: nil//For future use
+                         correlationId: correlationId
+                            completion: completionBlock];
      }];//End of the refreshing token completion block, executed asynchronously.
 }
 
@@ -530,10 +762,10 @@ return; \
                                   clientId:clientId
                                redirectUri:redirectUri
                             promptBehavior:promptBehavior
+                                    silent:NO
                                     userId:userId
                                      scope:nil
                       extraQueryParameters:queryParams
-                                  tryCache:YES
                          validateAuthority:self.validateAuthority
                              correlationId:[self getCorrelationId]
                            completionBlock:completionBlock];
@@ -654,11 +886,11 @@ return; \
 
 -(void) internalAcquireTokenForAssertion: (NSString*) samlAssertion
                                 clientId: (NSString*) clientId
+                             redirectUri: (NSString*) redirectUri
                                 resource: (NSString*) resource
                            assertionType: (ADAssertionType) assertionType
                                   userId: (NSString*) userId
                                    scope: (NSString*) scope
-                                tryCache:(BOOL) tryCache
                        validateAuthority: (BOOL) validateAuthority
                            correlationId: (NSUUID*) correlationId
                          completionBlock: (ADAuthenticationCallback)completionBlock
@@ -683,21 +915,43 @@ return; \
              }
              else
              {
-                 [self internalAcquireTokenForAssertion:samlAssertion
-                                               clientId:clientId
-                                               resource:resource
-                                          assertionType: assertionType
-                                                 userId:userId
-                                                  scope:scope
-                                               tryCache:tryCache
-                                      validateAuthority:NO /* Already validated in this block. */
-                                          correlationId:correlationId
-                                        completionBlock:localCompletionBlock];
+                 [self validatedAcquireTokenForAssertion:samlAssertion
+                                                clientId:clientId
+                                             redirectUri:redirectUri
+                                                resource:resource
+                                           assertionType: assertionType
+                                                  userId:userId
+                                                   scope:scope
+                                           correlationId:correlationId
+                                         completionBlock:localCompletionBlock];
              }
              SAFE_ARC_BLOCK_RELEASE( localCompletionBlock );
          }];
         return;//The asynchronous handler above will do the work.
     }
+    
+    [self validatedAcquireTokenForAssertion:samlAssertion
+                                   clientId:clientId
+                                redirectUri:redirectUri
+                                   resource:resource
+                              assertionType: assertionType
+                                     userId:userId
+                                      scope:scope
+                              correlationId:correlationId
+                            completionBlock:completionBlock];
+}
+
+- (void) validatedAcquireTokenForAssertion: (NSString*) samlAssertion
+                                  clientId: (NSString*) clientId
+                               redirectUri: (NSString*) redirectUri
+                                  resource: (NSString*) resource
+                             assertionType: (ADAssertionType) assertionType
+                                    userId: (NSString*) userId
+                                     scope: (NSString*) scope
+                             correlationId: (NSUUID*) correlationId
+                           completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    
     
     //Check the cache:
     ADAuthenticationError* error = nil;
@@ -712,7 +966,7 @@ return; \
         return;
     }
     
-    if (tryCache && self.tokenCacheStore)
+    if (self.tokenCacheStore)
     {
         //Cache should be used in this case:
         BOOL accessTokenUsable;
@@ -732,6 +986,7 @@ return; \
                           assertionType:assertionType
                                resource:resource
                                clientId:clientId
+                            redirectUri:redirectUri
                                  userId:userId
                           correlationId:correlationId
                         completionBlock:completionBlock];
@@ -739,28 +994,24 @@ return; \
         }
     }
     
-    dispatch_async([ADAuthenticationSettings sharedInstance].dispatchQueue, ^
-                   {
-                  [self requestTokenByAssertion: samlAssertion
-                   assertionType: assertionType
-                   resource: resource
-                   clientId: clientId
-                   scope: nil//For future use
-                   correlationId: correlationId
-                                     completion: completionBlock];
-                   });
+    [self requestTokenByAssertion: samlAssertion
+                    assertionType: assertionType
+                         resource: resource
+                         clientId: clientId
+                            scope: nil//For future use
+                    correlationId: correlationId
+                       completion: completionBlock];
 }
-
 
 
 -(void) internalAcquireTokenWithResource: (NSString*) resource
                                 clientId: (NSString*) clientId
                              redirectUri: (NSURL*) redirectUri
                           promptBehavior: (ADPromptBehavior) promptBehavior
+                                  silent: (BOOL) silent /* Do not show web UI for authorization. */
                                   userId: (NSString*) userId
                                    scope: (NSString*) scope
                     extraQueryParameters: (NSString*) queryParams
-                                tryCache: (BOOL) tryCache /* set internally to avoid infinite recursion */
                        validateAuthority: (BOOL) validateAuthority
                            correlationId: (NSUUID*) correlationId
                          completionBlock: (ADAuthenticationCallback)completionBlock
@@ -783,22 +1034,47 @@ return; \
              }
              else
              {
-                 [self internalAcquireTokenWithResource:resource
-                                               clientId:clientId
-                                            redirectUri:redirectUri
-                                         promptBehavior:promptBehavior
-                                                 userId:userId
-                                                  scope:scope
-                                   extraQueryParameters:queryParams
-                                               tryCache:tryCache
-                                      validateAuthority:NO /* Already validated in this block. */
-                                          correlationId:correlationId
-                                        completionBlock:localCompletionBlock];
+                 [self validatedAcquireTokenWithResource:resource
+                                                clientId:clientId
+                                             redirectUri:redirectUri
+                                          promptBehavior:promptBehavior
+                                                  silent:silent
+                                                  userId:userId
+                                                   scope:scope
+                                    extraQueryParameters:queryParams
+                                           correlationId:correlationId
+                                         completionBlock:completionBlock];
              }
              SAFE_ARC_BLOCK_RELEASE( localCompletionBlock );
          }];
         return;//The asynchronous handler above will do the work.
     }
+    
+    [self validatedAcquireTokenWithResource:resource
+                                   clientId:clientId
+                                redirectUri:redirectUri
+                             promptBehavior:promptBehavior
+                                     silent:silent
+                                     userId:userId
+                                      scope:scope
+                       extraQueryParameters:queryParams
+                              correlationId:correlationId
+                            completionBlock:completionBlock];
+    
+}
+
+- (void) validatedAcquireTokenWithResource: (NSString*) resource
+                                  clientId: (NSString*) clientId
+                               redirectUri: (NSURL*) redirectUri
+                            promptBehavior: (ADPromptBehavior) promptBehavior
+                                    silent: (BOOL) silent /* Do not show web UI for authorization. */
+                                    userId: (NSString*) userId
+                                     scope: (NSString*) scope
+                      extraQueryParameters: (NSString*) queryParams
+                             correlationId: (NSUUID*) correlationId
+                           completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    
     
     //Check the cache:
     ADAuthenticationError* error = nil;
@@ -813,7 +1089,7 @@ return; \
         return;
     }
     
-    if (tryCache && promptBehavior != AD_PROMPT_ALWAYS && self.tokenCacheStore)
+    if (![self.class isForcedAuthorization:promptBehavior] && self.tokenCacheStore)
     {
         //Cache should be used in this case:
         BOOL accessTokenUsable;
@@ -833,6 +1109,7 @@ return; \
                                clientId:clientId
                             redirectUri:redirectUri
                          promptBehavior:promptBehavior
+                                 silent:silent
                                  userId:userId
                    extraQueryParameters:queryParams
                           correlationId:correlationId
@@ -841,7 +1118,30 @@ return; \
         }
     }
     
-    if (promptBehavior == AD_PROMPT_NEVER)
+    [self requestTokenWithResource:resource
+                          clientId:clientId
+                       redirectUri:redirectUri
+                    promptBehavior:promptBehavior
+                            silent:silent
+                            userId:userId
+                             scope:scope
+              extraQueryParameters:queryParams
+                     correlationId:correlationId
+                   completionBlock:completionBlock];
+}
+
+- (void) requestTokenWithResource: (NSString*) resource
+                         clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
+                   promptBehavior: (ADPromptBehavior) promptBehavior
+                           silent: (BOOL) silent /* Do not show web UI for authorization. */
+                           userId: (NSString*) userId
+                            scope: (NSString*) scope
+             extraQueryParameters: (NSString*) queryParams
+                    correlationId: (NSUUID*) correlationId
+                  completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    if (silent)
     {
         //The cache lookup and refresh token attempt have been unsuccessful,
         //so credentials are needed to get an access token:
@@ -854,54 +1154,134 @@ return; \
         return;
     }
     
-    dispatch_async(dispatch_get_main_queue(), ^
-                   {
-                       //Get the code first:
-                       [self requestCodeByResource:resource
-                                          clientId:clientId
-                                       redirectUri:redirectUri
-                                             scope:scope
-                                            userId:userId
-                                    promptBehavior:promptBehavior
-                              extraQueryParameters:queryParams
-                                     correlationId:correlationId
-                                        completion:^(NSString * code, ADAuthenticationError *error)
-                        {
-                            if (error)
-                            {
-                                ADAuthenticationResult* result = (AD_ERROR_USER_CANCEL == error.code) ? [ADAuthenticationResult resultFromCancellation]
-                                : [ADAuthenticationResult resultFromError:error];
-                                completionBlock(result);
-                            }
-                            else
-                            {
-                                [self requestTokenByCode:code
-                                                resource:resource
-                                                clientId:clientId
-                                             redirectUri:redirectUri
-                                                   scope:scope
-                                           correlationId:correlationId
-                                              completion:^(ADAuthenticationResult *result)
-                                 {
-                                     if (AD_SUCCEEDED == result.status)
-                                     {
-                                         [self updateCacheToResult:result cacheItem:nil withRefreshToken:nil];
-                                         result = [self updateResult:result toUser:userId];
-                                     }
-                                     completionBlock(result);
-                                 }];
-                            }
-                        }];
-                   });
+    //call the broker.
+    if([self canUseBroker]){
+        [self callBrokerForAuthority: self.authority
+                            resource: resource
+                            clientId: clientId
+                         redirectUri: redirectUri
+                              userId: userId
+                       correlationId: [correlationId UUIDString]
+                     completionBlock:completionBlock
+         ];
+        return;
+    }
+    
+    //Get the code first:
+    [self requestCodeByResource:resource
+                       clientId:clientId
+                    redirectUri:redirectUri
+                          scope:scope
+                         userId:userId
+                 promptBehavior:promptBehavior
+           extraQueryParameters:queryParams
+                  correlationId:correlationId
+                     completion:^(NSString * code, ADAuthenticationError *error)
+     {
+         if (error)
+         {
+             ADAuthenticationResult* result = (AD_ERROR_USER_CANCEL == error.code) ? [ADAuthenticationResult resultFromCancellation]
+             : [ADAuthenticationResult resultFromError:error];
+             completionBlock(result);
+         }
+         else
+         {
+             if([code hasPrefix:@"msauth://"])
+             {
+                 [self handleBrokerFromWebiewResponse:code
+                                             resource:resource
+                                             clientId:clientId
+                                          redirectUri:redirectUri
+                                               userId:userId
+                                        correlationId:correlationId
+                                      completionBlock:completionBlock];
+             }
+             else
+             {
+                 [self requestTokenByCode:code
+                                 resource:resource
+                                 clientId:clientId
+                              redirectUri:redirectUri
+                                    scope:scope
+                            correlationId:correlationId
+                               completion:^(ADAuthenticationResult *result)
+                  {
+                      if (AD_SUCCEEDED == result.status)
+                      {
+                          [self updateCacheToResult:result cacheItem:nil withRefreshToken:nil];
+                          result = [self updateResult:result toUser:userId];
+                      }
+                      completionBlock(result);
+                  }];
+             }
+         }
+     }];
+}
+
+-(void) handleBrokerFromWebiewResponse: (NSString*) urlString
+                              resource: (NSString*) resource
+                              clientId: (NSString*) clientId
+                           redirectUri: (NSURL*) redirectUri
+                                userId: (NSString*) userId
+                         correlationId: (NSUUID*) correlationId
+                       completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    ADBrokerKeyHelper* brokerHelper = [[ADBrokerKeyHelper alloc] initHelper];
+    ADAuthenticationError* error = nil;
+    NSData* key = [brokerHelper getBrokerKey:&error];
+    NSString* base64Key = [NSString Base64EncodeData:key];
+    NSString* base64UrlKey = [base64Key adUrlFormEncode];
+    
+    NSString* query = [NSString stringWithFormat:@"authority=%@&resource=%@&client_id=%@&redirect_uri=%@&correlation_id=%@&broker_key=%@",
+                       _authority,
+                       resource,
+                       clientId,
+                       redirectUri.absoluteString,
+                       [correlationId UUIDString],
+                       base64UrlKey];
+    NSURL* appUrl = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@&%@", urlString, query]];
+    
+    [[ADBrokerNotificationManager sharedInstance] enableOnActiveNotification:completionBlock];;
+    
+    if([[UIApplication sharedApplication] canOpenURL:appUrl])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication] openURL:appUrl];
+        });
+    }
+    else
+    {
+        //no broker installed. go to app store
+        NSString* qp = [appUrl query];
+        NSDictionary* qpDict = [NSDictionary adURLFormDecode:qp];
+        NSString* url = [qpDict valueForKey:@"app_link"];
+        url = [url adBase64UrlDecode];
+        [self saveToPasteBoard:appUrl.absoluteString];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[UIApplication sharedApplication] openURL:[[NSURL alloc] initWithString:url]];
+        });
+    }
+}
+
+- (void)saveToPasteBoard:(NSString*) url
+{
+    UIPasteboard *appPasteBoard = [UIPasteboard pasteboardWithName:@"WPJ"
+                                                            create:YES];
+    appPasteBoard.persistent = YES;
+    NSData *data = [url dataUsingEncoding:NSUTF8StringEncoding];
+    [appPasteBoard setData:data
+         forPasteboardType:@"com.microsoft.broker"];
 }
 
 -(void) acquireTokenByRefreshToken: (NSString*)refreshToken
                           clientId: (NSString*)clientId
+                       redirectUri: (NSString*) redirectUri
                    completionBlock: (ADAuthenticationCallback)completionBlock
 {
     API_ENTRY;
     [self internalAcquireTokenByRefreshToken:refreshToken
                                     clientId:clientId
+                                 redirectUri:redirectUri
                                     resource:nil
                                       userId:nil
                                    cacheItem:nil
@@ -912,12 +1292,14 @@ return; \
 
 -(void) acquireTokenByRefreshToken:(NSString*)refreshToken
                           clientId:(NSString*)clientId
+                       redirectUri:(NSString*) redirectUri
                           resource:(NSString*)resource
                    completionBlock:(ADAuthenticationCallback)completionBlock
 {
     API_ENTRY;
     [self internalAcquireTokenByRefreshToken:refreshToken
                                     clientId:clientId
+                                 redirectUri:redirectUri
                                     resource:resource
                                       userId:nil
                                    cacheItem:nil
@@ -1022,6 +1404,7 @@ return; \
 //information and updates the cache:
 -(void) internalAcquireTokenByRefreshToken: (NSString*) refreshToken
                                   clientId: (NSString*) clientId
+                               redirectUri: (NSString*) redirectUri
                                   resource: (NSString*) resource
                                     userId: (NSString*) userId
                                  cacheItem: (ADTokenCacheStoreItem*) cacheItem
@@ -1050,14 +1433,14 @@ return; \
              }
              else
              {
-                 [self internalAcquireTokenByRefreshToken:refreshToken
-                                                 clientId:clientId
-                                                 resource:resource
-                                                   userId:userId
-                                                cacheItem:cacheItem
-                                        validateAuthority:NO /*Already validated in this block. */
-                                            correlationId:correlationId
-                                          completionBlock:localCompletionBlock];
+                 [self validatedAcquireTokenByRefreshToken:refreshToken
+                                                  clientId:clientId
+                                               redirectUri:redirectUri
+                                                  resource:resource
+                                                    userId:userId
+                                                 cacheItem:cacheItem
+                                             correlationId:correlationId
+                                           completionBlock:completionBlock];
              }
              
              SAFE_ARC_BLOCK_RELEASE( localCompletionBlock );
@@ -1065,13 +1448,52 @@ return; \
         return;//The asynchronous block above will handle everything;
     }
     
+    [self validatedAcquireTokenByRefreshToken:refreshToken
+                                     clientId:clientId
+                                  redirectUri:redirectUri
+                                     resource:resource
+                                       userId:userId
+                                    cacheItem:cacheItem
+                                correlationId:correlationId
+                              completionBlock:completionBlock];
+}
+
+- (void) validatedAcquireTokenByRefreshToken: (NSString*) refreshToken
+                                    clientId: (NSString*) clientId
+                                 redirectUri: (NSString*) redirectUri
+                                    resource: (NSString*) resource
+                                      userId: (NSString*) userId
+                                   cacheItem: (ADTokenCacheStoreItem*) cacheItem
+                               correlationId: correlationId
+                             completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    
     [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:nil];
     //Fill the data for the token refreshing:
-    NSMutableDictionary *request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                         OAUTH2_REFRESH_TOKEN, OAUTH2_GRANT_TYPE,
-                                         refreshToken, OAUTH2_REFRESH_TOKEN,
-                                         clientId, OAUTH2_CLIENT_ID,
-                                         nil];
+    NSMutableDictionary *request_data = nil;
+    
+    if(cacheItem.sessionKey)
+    {
+        NSString* jwtToken = [self createAccessTokenRequestJWTUsingRT:cacheItem
+                                                             resource:resource
+                                                             clientId:clientId];
+        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                        redirectUri, @"redirect_uri",
+                        clientId, @"client_id",
+                        @"2.0", @"windows_api_version",
+                        @"urn:ietf:params:oauth:grant-type:jwt-bearer", OAUTH2_GRANT_TYPE,
+                        jwtToken, @"request",
+                        nil];
+        
+    }
+    else
+    {
+        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                        OAUTH2_REFRESH_TOKEN, OAUTH2_GRANT_TYPE,
+                        refreshToken, OAUTH2_REFRESH_TOKEN,
+                        clientId, OAUTH2_CLIENT_ID,
+                        nil];
+    }
     
     //The clang analyzer has some issues with the logic inside adIsStringNilOrBlank, as it is defined in a category.
 #ifndef __clang_analyzer__
@@ -1083,39 +1505,36 @@ return; \
             [request_data setObject:resource forKey:OAUTH2_RESOURCE];
         }
     
-    dispatch_async([ADAuthenticationSettings sharedInstance].dispatchQueue, ^
-                   {
-                       AD_LOG_INFO_F(@"Sending request for refreshing token.", @"Client id: '%@'; resource: '%@'; user:'%@'", clientId, resource, userId);
-                       [self request:self.authority
-                         requestData:request_data
-                requestCorrelationId:correlationId
-         isHandlingPKeyAuthChallenge:FALSE
-                   additionalHeaders:nil
-                          completion:^(NSDictionary *response)
-                        {
-                            ADTokenCacheStoreItem* resultItem = (cacheItem) ? SAFE_ARC_RETAIN(cacheItem) : [ADTokenCacheStoreItem new];
-                            
-                            //Always ensure that the cache item has all of these set, especially in the broad token case, where the passed item
-                            //may have empty "resource" property:
-                            resultItem.resource = resource;
-                            resultItem.clientId = clientId;
-                            resultItem.authority = self.authority;
-                            
-                            
-                            ADAuthenticationResult *result = [self processTokenResponse:response forItem:resultItem fromRefresh:YES requestCorrelationId:correlationId];
-                            if (cacheItem)//The request came from the cache item, update it:
-                            {
-                                [self updateCacheToResult:result
-                                                cacheItem:resultItem
-                                         withRefreshToken:refreshToken];
-                            }
-                            result = [self updateResult:result toUser:userId];//Verify the user (just in case)
-                            
-                            SAFE_ARC_RELEASE(resultItem);
-                            
-                            completionBlock(result);
-                        }];
-                   });
+    AD_LOG_INFO_F(@"Sending request for refreshing token.", @"Client id: '%@'; resource: '%@'; user:'%@'", clientId, resource, userId);
+    [self request:self.authority
+      requestData:request_data
+requestCorrelationId:correlationId
+isHandlingPKeyAuthChallenge:FALSE
+additionalHeaders:nil
+       completion:^(NSDictionary *response)
+     {
+         ADTokenCacheStoreItem* resultItem = (cacheItem) ? SAFE_ARC_RETAIN(cacheItem) : [ADTokenCacheStoreItem new];
+         
+         //Always ensure that the cache item has all of these set, especially in the broad token case, where the passed item
+         //may have empty "resource" property:
+         resultItem.resource = resource;
+         resultItem.clientId = clientId;
+         resultItem.authority = self.authority;
+         
+         
+         ADAuthenticationResult *result = [self processTokenResponse:response forItem:resultItem fromRefresh:YES requestCorrelationId:correlationId];
+         if (cacheItem)//The request came from the cache item, update it:
+         {
+             [self updateCacheToResult:result
+                             cacheItem:resultItem
+                      withRefreshToken:refreshToken];
+         }
+         result = [self updateResult:result toUser:userId];//Verify the user (just in case)
+         
+         SAFE_ARC_RELEASE(resultItem);
+         
+         completionBlock(result);
+     }];
 }
 
 //Used in the flows, where developer requested an explicit user. The method compares
@@ -1339,10 +1758,11 @@ return; \
     {
         [startUrl appendFormat:@"&%@=%@", OAUTH2_LOGIN_HINT, [userId adUrlFormEncode]];
     }
-    if (AD_PROMPT_ALWAYS == promptBehavior)
+    NSString* promptParam = [self.class getPromptParameter:promptBehavior];
+    if (promptParam)
     {
         //Force the server to ignore cookies, by specifying explicitly the prompt behavior:
-        [startUrl appendString:@"&prompt=login"];
+        [startUrl appendString:[NSString stringWithFormat:@"&prompt=%@", promptParam]];
     }
     if (![NSString adIsStringNilOrBlank:queryParams])
     {//Append the additional query parameters if specified:
@@ -1445,25 +1865,32 @@ return; \
          NSString* code = nil;
          if (!error)
          {
-             //Try both the URL and the fragment parameters:
-             NSDictionary *parameters = [end adFragmentParameters];
-             if ( parameters.count == 0 )
+             if([[[end scheme] lowercaseString] isEqualToString:@"msauth"])
              {
-                 parameters = [end adQueryParameters];
+                 code = end.absoluteString;
              }
-             
-             //OAuth2 error may be passed by the server:
-             error = [self errorFromDictionary:parameters errorCode:AD_ERROR_AUTHENTICATION];
-             if (!error)
+             else
              {
-                 //Note that we do not enforce the state, just log it:
-                 [self verifyStateFromDictionary:parameters];
-                 code = [parameters objectForKey:OAUTH2_CODE];
-                 if ([NSString adIsStringNilOrBlank:code])
+                 //Try both the URL and the fragment parameters:
+                 NSDictionary *parameters = [end adFragmentParameters];
+                 if ( parameters.count == 0 )
                  {
-                     error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_AUTHENTICATION
-                                                                    protocolCode:nil
-                                                                    errorDetails:@"The authorization server did not return a valid authorization code."];
+                     parameters = [end adQueryParameters];
+                 }
+                 
+                 //OAuth2 error may be passed by the server:
+                 error = [self errorFromDictionary:parameters errorCode:AD_ERROR_AUTHENTICATION];
+                 if (!error)
+                 {
+                     //Note that we do not enforce the state, just log it:
+                     [self verifyStateFromDictionary:parameters];
+                     code = [parameters objectForKey:OAUTH2_CODE];
+                     if ([NSString adIsStringNilOrBlank:code])
+                     {
+                         error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_AUTHENTICATION
+                                                                        protocolCode:nil
+                                                                        errorDetails:@"The authorization server did not return a valid authorization code."];
+                     }
                  }
              }
          }
@@ -1475,12 +1902,12 @@ return; \
 
 // Generic OAuth2 Authorization Request, obtains a token from a SAML assertion.
 - (void)requestTokenByAssertion: (NSString *) samlAssertion
-                    assertionType: (ADAssertionType) assertionType
-                  resource: (NSString *) resource
-                  clientId: (NSString*) clientId
-                     scope: (NSString*) scope //For future use
-             correlationId: (NSUUID*) correlationId
-                completion: (ADAuthenticationCallback) completionBlock
+                  assertionType: (ADAssertionType) assertionType
+                       resource: (NSString *) resource
+                       clientId: (NSString*) clientId
+                          scope: (NSString*) scope //For future use
+                  correlationId: (NSUUID*) correlationId
+                     completion: (ADAuthenticationCallback) completionBlock
 {
 #pragma unused(scope)
     HANDLE_ARGUMENT(correlationId);//Should be set by the caller
@@ -1491,11 +1918,11 @@ return; \
     NSString *base64String = [encodeData base64EncodedStringWithOptions:0];
     //Fill the data for the SAML assertion:
     NSDictionary *request_data = [NSDictionary dictionaryWithObjectsAndKeys:
-                                         [self getAssertionTypeGrantValue:assertionType], OAUTH2_GRANT_TYPE,
-                                         base64String, OAUTH2_ASSERTION,
-                                         clientId, OAUTH2_CLIENT_ID,
-                                         resource, OAUTH2_RESOURCE,
-                                         nil];
+                                  [self getAssertionTypeGrantValue:assertionType], OAUTH2_GRANT_TYPE,
+                                  base64String, OAUTH2_ASSERTION,
+                                  clientId, OAUTH2_CLIENT_ID,
+                                  resource, OAUTH2_RESOURCE,
+                                  nil];
     [self executeRequest:self.authority requestData:request_data resource:resource clientId:clientId requestCorrelationId:correlationId isHandlingPKeyAuthChallenge:NO additionalHeaders:nil completion:completionBlock];
 }
 
@@ -1527,7 +1954,6 @@ return; \
     HANDLE_ARGUMENT(code);
     HANDLE_ARGUMENT(correlationId);//Should be set by the caller
     AD_LOG_VERBOSE_F(@"Requesting token from authorization code.", @"Requesting token by authorization code for resource: %@", resource);
-    
     //Fill the data for the token refreshing:
     NSMutableDictionary *request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
                                          OAUTH2_AUTHORIZATION_CODE, OAUTH2_GRANT_TYPE,
@@ -1535,7 +1961,15 @@ return; \
                                          clientId, OAUTH2_CLIENT_ID,
                                          [redirectUri absoluteString], OAUTH2_REDIRECT_URI,
                                          nil];
-    [self executeRequest:self.authority requestData:request_data resource:resource clientId:clientId requestCorrelationId:correlationId isHandlingPKeyAuthChallenge:NO additionalHeaders:nil completion:completionBlock];
+    
+    [self executeRequest:self.authority
+             requestData:request_data
+                resource:resource
+                clientId:clientId
+    requestCorrelationId:correlationId
+isHandlingPKeyAuthChallenge:NO
+       additionalHeaders:nil
+              completion:completionBlock];
 }
 
 
@@ -1559,7 +1993,10 @@ additionalHeaders:additionalHeaders
          ADTokenCacheStoreItem* item = [ADTokenCacheStoreItem new];
          item.resource = resource;
          item.clientId = clientId;
-         completionBlock([self processTokenResponse:response forItem:item fromRefresh:NO requestCorrelationId:requestCorrelationId]);
+         completionBlock([self processTokenResponse:response
+                                            forItem:item
+                                        fromRefresh:NO
+                               requestCorrelationId:requestCorrelationId]);
          SAFE_ARC_RELEASE(item);
      }];
 }
@@ -1589,7 +2026,7 @@ additionalHeaders:(NSDictionary *)additionalHeaders
     [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     
 #if TARGET_OS_IPHONE
-        [webRequest.headers setObject:pKeyAuthHeaderVersion forKey:pKeyAuthHeader];
+    [webRequest.headers setObject:pKeyAuthHeaderVersion forKey:pKeyAuthHeader];
 #endif
     
     if(additionalHeaders){
@@ -1684,7 +2121,7 @@ additionalHeaders:(NSDictionary *)additionalHeaders
             [response setObject:[ADAuthenticationError errorFromNSError:error errorDetails:error.localizedDescription]
                          forKey:AUTH_NON_PROTOCOL_ERROR];
         }
-    
+        
         if([response valueForKey:AUTH_NON_PROTOCOL_ERROR]){
             [[ADClientMetrics getInstance] endClientMetricsRecord:[[response valueForKey:AUTH_NON_PROTOCOL_ERROR] errorDetails]];
         } else {
@@ -1703,6 +2140,39 @@ additionalHeaders:(NSDictionary *)additionalHeaders
 {
     return [[[NSMutableDictionary dictionaryWithObjectsAndKeys:self.authority, @"a", resource, @"r", scope, @"s", nil]
              adURLFormEncode] adBase64UrlEncode];
+}
+
+-(NSString*) createAccessTokenRequestJWTUsingRT:(ADTokenCacheStoreItem*) cacheItem
+                                       resource:(NSString*) resource
+                                       clientId:(NSString*) clientId
+{
+    NSString* grantType = @"refresh_token";
+    
+    NSString* ctx = [[[NSUUID UUID] UUIDString] adComputeSHA256];
+    NSDictionary *header = @{
+                             @"alg" : @"HS256",
+                             @"typ" : @"JWT",
+                             @"ctx" : [ADHelpers convertBase64UrlStringToBase64NSString:[ctx adBase64UrlEncode]]
+                             };
+    
+    NSInteger iat = round([[NSDate date] timeIntervalSince1970]);
+    NSDictionary *payload = @{
+                              @"resource" : resource,
+                              @"client_id" : clientId,
+                              @"refresh_token" : cacheItem.refreshToken,
+                              @"iat" : [NSNumber numberWithInteger:iat],
+                              @"nbf" : [NSNumber numberWithInteger:iat],
+                              @"exp" : [NSNumber numberWithInteger:iat],
+                              @"scope" : @"openid",
+                              @"grant_type" : grantType,
+                              @"aud" : self.authority
+                              };
+    
+    NSString* returnValue = [ADHelpers createSignedJWTUsingKeyDerivation:header
+                                                                 payload:payload
+                                                                 context:ctx
+                                                            symmetricKey:cacheItem.sessionKey];
+    return returnValue;
 }
 
 - (void) handlePKeyAuthChallenge:(NSString *)authorizationServer
@@ -1732,6 +2202,41 @@ additionalHeaders:(NSDictionary *)additionalHeaders
 #endif
 }
 
+
+#ifdef TARGET_OS_IPHONE
+- (BOOL) canUseBroker
+{
+    return [[ADAuthenticationSettings sharedInstance] credentialsType] == AD_CREDENTIALS_AUTO &&
+    [[UIApplication sharedApplication] canOpenURL:[[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://broker", brokerScheme]]];
+    
+}
+
+
+- (void) callBrokerForAuthority:(NSString*) authority
+                       resource: (NSString*) resource
+                       clientId: (NSString*)clientId
+                    redirectUri: (NSURL*) redirectUri
+                         userId: (NSString*) userId
+                  correlationId: (NSString*) correlationId
+                completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    AD_LOG_INFO(@"Invoking broker for authentication", nil);
+    ADBrokerKeyHelper* brokerHelper = [[ADBrokerKeyHelper alloc] initHelper];
+    ADAuthenticationError* error = nil;
+    NSData* key = [brokerHelper getBrokerKey:&error];
+    NSString* base64Key = [NSString Base64EncodeData:key];
+    NSString* base64UrlKey = [base64Key adUrlFormEncode];
+    
+    NSString* query = [NSString stringWithFormat:@"authority=%@&resource=%@&client_id=%@&redirect_uri=%@&user_id=%@&correlation_id=%@&broker_key=%@", authority, resource, clientId, redirectUri, userId, correlationId, base64UrlKey];
+    NSURL* appUrl = [[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://broker?%@", brokerScheme, query]];
+    
+    [[ADBrokerNotificationManager sharedInstance] enableOnActiveNotification:completionBlock];
+    
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [[UIApplication sharedApplication] openURL:appUrl];
+    });
+}
+#endif
 
 @end
 

--- a/ADALiOS/ADALiOS/ADAuthenticationError.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationError.h
@@ -22,6 +22,8 @@ extern NSString* const ADAuthenticationErrorDomain;
 extern NSString* const ADInvalidArgumentDomain;
 /*! Error related to extracting authority from the 401 (Unauthorized) challenge response */
 extern NSString* const ADUnauthorizedResponseErrorDomain;
+/*! Error returned by Broker */
+extern NSString* const ADBrokerResponseErrorDomain;
 
 @interface ADAuthenticationError : NSError
 {

--- a/ADALiOS/ADALiOS/ADAuthenticationError.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationError.m
@@ -21,6 +21,7 @@
 NSString* const ADAuthenticationErrorDomain = @"ADAuthenticationErrorDomain";
 NSString* const ADInvalidArgumentDomain = @"ADAuthenticationErrorDomain";
 NSString* const ADUnauthorizedResponseErrorDomain = @"ADUnauthorizedResponseErrorDomain";
+NSString* const ADBrokerResponseErrorDomain = @"ADBrokerResponseErrorDomain";
 
 NSString* const ADInvalidArgumentMessage = @"The argument '%@' is invalid. Value:%@";
 

--- a/ADALiOS/ADALiOS/ADAuthenticationParameters.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationParameters.m
@@ -78,7 +78,7 @@
         return;
     }
 
-    dispatch_async([ADAuthenticationSettings sharedInstance].dispatchQueue,^
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_HIGH, 0),^
     {
         __block ADWebRequest* request = [[ADWebRequest alloc] initWithURL:resourceUrl correlationId:nil];
         request.method = HTTPGet;

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.h
@@ -31,4 +31,6 @@
 +(ADAuthenticationResult*) resultFromTokenCacheStoreItem: (ADTokenCacheStoreItem*) item
                                multiResourceRefreshToken: (BOOL) multiResourceRefreshToken;
 
+/*! Creates an authentication result from broker response. */
++(ADAuthenticationResult*) resultFromBrokerResponse: (NSDictionary*) response;
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -20,6 +20,8 @@
 #import "ADAuthenticationResult.h"
 #import "ADAuthenticationResult+Internal.h"
 #import "ADTokenCacheStoreItem.h"
+#import "ADOAuth2Constants.h"
+#import "ADUserInformation.h"
 
 @implementation ADAuthenticationResult (Internal)
 
@@ -98,6 +100,43 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
 {
     ADAuthenticationResult* result = [[ADAuthenticationResult alloc] initWithCancellation];
     return SAFE_ARC_AUTORELEASE(result);
+}
+
++(ADAuthenticationResult*) resultFromBrokerResponse: (NSDictionary*) response
+{
+    ADAuthenticationError* error;
+    ADAuthenticationResult* result;
+    ADTokenCacheStoreItem* item = nil;
+    if([response valueForKey:OAUTH2_ERROR_DESCRIPTION]){
+        error = [ADAuthenticationError errorFromNSError:[NSError errorWithDomain:ADBrokerResponseErrorDomain code:0 userInfo:nil] errorDetails:[response valueForKey:OAUTH2_ERROR_DESCRIPTION]];
+    }
+    else
+    {
+        item = [ADTokenCacheStoreItem new];
+        item.authority =  [response valueForKey:OAUTH2_AUTHORITY];
+        item.resource = [response valueForKey:OAUTH2_RESOURCE];
+        item.clientId = [response valueForKey:OAUTH2_CLIENT_ID];
+        item.accessToken = [response valueForKey:OAUTH2_ACCESS_TOKEN];
+        item.refreshToken = [response valueForKey:OAUTH2_REFRESH_TOKEN];
+        if([response valueForKey:OAUTH2_ID_TOKEN])
+        {
+            ADUserInformation* info = [ADUserInformation userInformationWithIdToken:[response valueForKey:OAUTH2_ID_TOKEN] error:&error];
+            if(!error)
+            {
+                item.userInformation = info;
+            }
+        }
+    }
+    if(error)
+    {
+        result = [ADAuthenticationResult resultFromError:error];
+    }
+    else
+    {
+        result = [[ADAuthenticationResult alloc ]initWithItem:item multiResourceRefreshToken:NO];
+    }
+    
+    return result;
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -104,8 +104,8 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
 
 +(ADAuthenticationResult*) resultFromBrokerResponse: (NSDictionary*) response
 {
-    ADAuthenticationError* error;
-    ADAuthenticationResult* result;
+    ADAuthenticationError* error = nil;
+    ADAuthenticationResult* result = nil;
     ADTokenCacheStoreItem* item = nil;
     if([response valueForKey:OAUTH2_ERROR_DESCRIPTION]){
         error = [ADAuthenticationError errorFromNSError:[NSError errorWithDomain:ADBrokerResponseErrorDomain code:0 userInfo:nil] errorDetails:[response valueForKey:OAUTH2_ERROR_DESCRIPTION]];

--- a/ADALiOS/ADALiOS/ADBrokerKeyHelper.h
+++ b/ADALiOS/ADALiOS/ADBrokerKeyHelper.h
@@ -17,21 +17,27 @@
 // governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "RegistrationInformation.h"
+#import "ADAuthenticationError.h"
 
-typedef enum
+#define kChosenCipherKeySize    kCCKeySizeAES256
+#define kSymmetricKeyTag        "com.microsoft.adBrokerKey"
+
+@interface ADBrokerKeyHelper : NSObject
 {
-    AD_ISSUER,
-    AD_THUMBPRINT,
-} ADChallengeType;
+    NSData * _symmetricTag;
+    NSData * _symmetricKeyRef;
+}
 
-@interface ADPkeyAuthHelper : NSObject
+@property (nonatomic, retain) NSData * symmetricTag;
+@property (nonatomic, retain) NSData * symmetricKeyRef;
 
-+ (NSString*) createDeviceAuthResponse:(NSString*) authorizationServer
-                         challengeData:(NSDictionary*) challengeData
-                       challengeType: (ADChallengeType) challengeType;
+-(id) initHelper;
 
+-(void) createBrokerKey: (ADAuthenticationError* __autoreleasing*) error;
 
-+ (NSString*) computeThumbprint:(NSData*) data isSha2:(BOOL) isSha2;
+-(NSData*) getBrokerKey: (ADAuthenticationError* __autoreleasing*) error;
+
+-(NSData*) decryptBrokerResponse: (NSData*) response
+                                 error:(ADAuthenticationError* __autoreleasing*) error;
 
 @end

--- a/ADALiOS/ADALiOS/ADBrokerKeyHelper.m
+++ b/ADALiOS/ADALiOS/ADBrokerKeyHelper.m
@@ -1,0 +1,209 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "ADAuthenticationError.h"
+#import "ADErrorCodes.h"
+#import "ADBrokerKeyHelper.h"
+#import "ADKeyChainHelper.h"
+#import <CommonCrypto/CommonCryptor.h>
+#import <Security/Security.h>
+
+const CCAlgorithm kAlgorithm = kCCAlgorithmAES128;
+const NSUInteger kAlgorithmKeySize = kCCKeySizeAES128;
+const NSUInteger kAlgorithmBlockSize = kCCBlockSizeAES128;
+const NSUInteger kAlgorithmIVSize = kCCBlockSizeAES128;
+
+@implementation ADBrokerKeyHelper
+
+enum {
+    CSSM_ALGID_NONE =                   0x00000000L,
+    CSSM_ALGID_VENDOR_DEFINED =         CSSM_ALGID_NONE + 0x80000000L,
+    CSSM_ALGID_AES
+};
+
+@synthesize symmetricTag = _symmetricTag;
+@synthesize symmetricKeyRef = _symmetricKeyRef;
+
+static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
+
+-(id) initHelper
+{
+    if (self = [super init])
+    {
+        // Tag data to search for keys.
+        _symmetricTag = [[NSData alloc] initWithBytes:symmetricKeyIdentifier length:sizeof(symmetricKeyIdentifier)];
+    }
+    
+    return self;
+}
+
+
+-(void) createBrokerKey: (ADAuthenticationError* __autoreleasing*) error
+{
+    OSStatus sanityCheck = noErr;
+    uint8_t * symmetricKey = NULL;
+    
+    // First delete current symmetric key.
+    [self deleteSymmetricKey:error];
+    
+    // Container dictionary
+    NSMutableDictionary *symmetricKeyAttr = [[NSMutableDictionary alloc] init];
+    [symmetricKeyAttr setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
+    [symmetricKeyAttr setObject:(__bridge id)(kSecClassGenericPassword) forKey:(__bridge id)kSecAttrKeyClass];
+    [symmetricKeyAttr setObject:_symmetricTag forKey:(__bridge id)kSecAttrApplicationTag];
+    [symmetricKeyAttr setObject:[NSNumber numberWithUnsignedInt:CSSM_ALGID_AES] forKey:(__bridge id)kSecAttrKeyType];
+    [symmetricKeyAttr setObject:[NSNumber numberWithUnsignedInt:(unsigned int)(kChosenCipherKeySize << 3)] forKey:(__bridge id)kSecAttrKeySizeInBits];
+    [symmetricKeyAttr setObject:[NSNumber numberWithUnsignedInt:(unsigned int)(kChosenCipherKeySize << 3)]  forKey:(__bridge id)kSecAttrEffectiveKeySize];
+    [symmetricKeyAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecAttrCanEncrypt];
+    [symmetricKeyAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id)kSecAttrCanDecrypt];
+    
+    symmetricKey = malloc( kChosenCipherKeySize * sizeof(uint8_t) );
+    memset((void *)symmetricKey, 0x0, kChosenCipherKeySize);
+    
+    sanityCheck = SecRandomCopyBytes(kSecRandomDefault, kChosenCipherKeySize, symmetricKey);
+    if(sanityCheck == errSecSuccess){
+        self.symmetricKeyRef = [[NSData alloc] initWithBytes:(const void *)symmetricKey length:kChosenCipherKeySize];
+        // Add the wrapped key data to the container dictionary.
+        [symmetricKeyAttr setObject:_symmetricKeyRef
+                             forKey:(__bridge id)kSecValueData];
+        // Add the symmetric key to the keychain.
+        sanityCheck = SecItemAdd((__bridge CFDictionaryRef) symmetricKeyAttr, NULL);
+    }
+    
+    if(sanityCheck != errSecSuccess){
+         *error = [ADAuthenticationError errorFromNSError:[NSError errorWithDomain:@"Could not create broker key." code:AD_ERROR_UNEXPECTED userInfo:nil] errorDetails:nil];
+    }
+    
+    if (symmetricKey)
+    {
+        free(symmetricKey);
+    }
+}
+
+- (void)deleteSymmetricKey: (ADAuthenticationError* __autoreleasing*) error {
+    OSStatus sanityCheck = noErr;
+    
+    NSMutableDictionary * querySymmetricKey = [[NSMutableDictionary alloc] init];
+    
+    // Set the symmetric key query dictionary.
+    [querySymmetricKey setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
+    [querySymmetricKey setObject:_symmetricTag forKey:(__bridge id)kSecAttrApplicationTag];
+    [querySymmetricKey setObject:[NSNumber numberWithUnsignedInt:CSSM_ALGID_AES] forKey:(__bridge id)kSecAttrKeyType];
+    
+    // Delete the symmetric key.
+    sanityCheck = SecItemDelete((__bridge CFDictionaryRef)querySymmetricKey);
+    
+    if(sanityCheck != errSecSuccess){
+        *error = [ADAuthenticationError errorFromNSError:[NSError errorWithDomain:@"Could not delete broker key." code:AD_ERROR_UNEXPECTED userInfo:nil] errorDetails:@"Could not delete broker key."];
+    }
+    
+    if(_symmetricKeyRef){
+        CFRelease((__bridge CFTypeRef)(_symmetricKeyRef));
+    }
+}
+
+-(NSData*) getBrokerKey: (ADAuthenticationError* __autoreleasing*) error
+{
+    return [self getBrokerKey:error createKeyIfDoesNotExist:YES];
+}
+
+-(NSData*) getBrokerKey: (ADAuthenticationError* __autoreleasing*) error
+createKeyIfDoesNotExist: (BOOL) createKeyIfDoesNotExist
+{
+    OSStatus sanityCheck = noErr;
+    NSData* symmetricKeyReturn = nil;
+    CFDataRef symmetricKeyReturnRef;
+    if (self.symmetricKeyRef == nil) {
+        NSMutableDictionary * querySymmetricKey = [[NSMutableDictionary alloc] init];
+        
+        // Set the private key query dictionary.
+        [querySymmetricKey setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
+        [querySymmetricKey setObject:_symmetricTag forKey:(__bridge id)kSecAttrApplicationTag];
+        [querySymmetricKey setObject:[NSNumber numberWithUnsignedInt:CSSM_ALGID_AES] forKey:(__bridge id)kSecAttrKeyType];
+        [querySymmetricKey setObject:[NSNumber numberWithBool:YES] forKey:(__bridge id)kSecReturnData];
+        
+        // Get the key bits.
+        sanityCheck = SecItemCopyMatching((__bridge CFDictionaryRef)querySymmetricKey, (CFTypeRef *)&symmetricKeyReturnRef);
+        
+        if(sanityCheck != errSecSuccess && createKeyIfDoesNotExist)
+        {
+            [self createBrokerKey:error];
+            symmetricKeyReturn = self.symmetricKeyRef;
+        } else {
+            symmetricKeyReturn = (__bridge NSData *)symmetricKeyReturnRef;
+            if (sanityCheck == noErr && symmetricKeyReturn != nil) {
+                self.symmetricKeyRef = symmetricKeyReturn;
+            } else {
+                self.symmetricKeyRef = nil;
+            }
+        }
+    } else {
+        symmetricKeyReturn = self.symmetricKeyRef;
+    }
+    
+    return symmetricKeyReturn;
+}
+
+
+-(NSData*) decryptBrokerResponse: (NSData*) response
+                                 error:(ADAuthenticationError* __autoreleasing*) error
+{
+    NSData* keyData = [self getBrokerKey: error];
+    NSString *key = [[NSString alloc] initWithData:keyData encoding:0];
+    
+    
+    // 'key' should be 32 bytes for AES256, will be null-padded otherwise
+    char keyPtr[kCCKeySizeAES256+1]; // room for terminator (unused)
+    bzero(keyPtr, sizeof(keyPtr)); // fill with zeroes (for padding)
+    
+    // fetch key data
+    [key getCString:keyPtr maxLength:sizeof(keyPtr) encoding:NSUTF8StringEncoding];
+    
+    NSUInteger dataLength = [response length];
+    
+    //See the doc: For block ciphers, the output size will always be less than or
+    //equal to the input size plus the size of one block.
+    //That's why we need to add the size of one block here
+    size_t bufferSize = dataLength + kCCBlockSizeAES128;
+    void *buffer = malloc(bufferSize);
+    
+    if(!buffer){
+        *error = [ADAuthenticationError errorFromNSError:[NSError errorWithDomain:ADAuthenticationErrorDomain code:AD_ERROR_UNEXPECTED userInfo:nil]
+                                           errorDetails:@"Failed to allocate memory for decryption"];
+        return nil;
+    }
+    
+    size_t numBytesDecrypted = 0;
+    CCCryptorStatus cryptStatus = CCCrypt(kCCDecrypt, kCCAlgorithmAES128, kCCOptionPKCS7Padding,
+                                          keyPtr, kCCKeySizeAES256,
+                                          NULL /* initialization vector (optional) */,
+                                          [response bytes], dataLength, /* input */
+                                          buffer, bufferSize, /* output */
+                                          &numBytesDecrypted);
+    
+    if (cryptStatus == kCCSuccess) {
+        //the returned NSData takes ownership of the buffer and will free it on deallocation
+        return [NSData dataWithBytesNoCopy:buffer length:numBytesDecrypted];
+    }
+    
+    free(buffer); //free the buffer;
+    return nil;
+}
+
+@end;

--- a/ADALiOS/ADALiOS/ADBrokerNotificationManager.h
+++ b/ADALiOS/ADALiOS/ADBrokerNotificationManager.h
@@ -17,21 +17,16 @@
 // governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
-#import "RegistrationInformation.h"
+#import "ADAuthenticationContext.h"
 
-typedef enum
-{
-    AD_ISSUER,
-    AD_THUMBPRINT,
-} ADChallengeType;
+@interface ADBrokerNotificationManager : NSObject
 
-@interface ADPkeyAuthHelper : NSObject
+@property (retain) ADAuthenticationCallback callbackForBroker;
 
-+ (NSString*) createDeviceAuthResponse:(NSString*) authorizationServer
-                         challengeData:(NSDictionary*) challengeData
-                       challengeType: (ADChallengeType) challengeType;
++(ADBrokerNotificationManager*)sharedInstance;
 
+-(void) enableOnActiveNotification:(ADAuthenticationCallback) callback;
 
-+ (NSString*) computeThumbprint:(NSData*) data isSha2:(BOOL) isSha2;
+-(void) runCompletionBlock:(ADAuthenticationResult*) result;
 
 @end

--- a/ADALiOS/ADALiOS/ADBrokerNotificationManager.m
+++ b/ADALiOS/ADALiOS/ADBrokerNotificationManager.m
@@ -1,0 +1,88 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import "ADBrokerNotificationManager.h"
+#import "ADAL.h"
+#import "ADAuthenticationResult+Internal.h"
+
+@implementation ADBrokerNotificationManager
+
+-(id) init
+{
+    //Ensure that the appropriate init function is called. This will cause the runtime to throw.
+    [super doesNotRecognizeSelector:_cmd];
+    return nil;
+}
+
+-(id) initInternal
+{
+    self = [super init];
+    return self;
+}
+
+-(void) runCompletionBlock:(ADAuthenticationResult*) result
+{
+    ADAuthenticationCallback callback = _callbackForBroker;
+    callback(result);
+    _callbackForBroker = nil;
+}
+
++(ADBrokerNotificationManager*)sharedInstance
+{
+    /* Below is a standard objective C singleton pattern*/
+    static ADBrokerNotificationManager* instance;
+    static dispatch_once_t onceToken;
+    @synchronized(self)
+    {
+        dispatch_once(&onceToken, ^{
+            instance = [[ADBrokerNotificationManager alloc] initInternal];
+        });
+    }
+    return instance;
+}
+
+
+-(void) enableOnActiveNotification:(ADAuthenticationCallback) callback
+{
+    _callbackForBroker = callback;
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(callbackCleanup)
+                                                 name:UIApplicationDidBecomeActiveNotification object:nil];
+    
+}
+
+- (void)callbackCleanup
+{
+    if(_callbackForBroker)
+    {
+        ADAuthenticationError* adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_BROKER_RESPONSE_NOT_RECEIVED
+                                                                                protocolCode:nil
+                                                                                errorDetails:@"application did not receive response from broker."];
+        ADAuthenticationResult* result = [ADAuthenticationResult resultFromError:adError];
+        ADAuthenticationCallback callback = _callbackForBroker;
+        callback(result);
+    }
+    
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:UIApplicationDidBecomeActiveNotification
+                                                  object:nil];
+    _callbackForBroker = nil;
+}
+
+
+@end

--- a/ADALiOS/ADALiOS/ADErrorCodes.h
+++ b/ADALiOS/ADALiOS/ADErrorCodes.h
@@ -97,6 +97,12 @@ typedef enum
      certificate. The error is generated if more than one certificate is found in the keychain. */
     AD_ERROR_MULTIPLE_TLS_CERTIFICATES = 20,
     
+    /*! When the hash of the decrypted broker response does not match the hash returned from broker. */
+    AD_ERROR_BROKER_RESPONSE_HASH_MISMATCH = 21,
+    
+    /*! When the application waiting for broker is activated without broker response. */
+    AD_ERROR_BROKER_RESPONSE_NOT_RECEIVED = 22,
+    
 } ADErrorCode;
 
 /* HTTP status codes used by the library */

--- a/ADALiOS/ADALiOS/ADHelpers.h
+++ b/ADALiOS/ADALiOS/ADHelpers.h
@@ -26,4 +26,20 @@
 
 +(NSString*) getEndpointName:(NSString*) fullEndpoint;
 
++ (NSData*) convertBase64UrlStringToBase64NSData:(NSString*) base64UrlString;
+
++ (NSString*) convertBase64UrlStringToBase64NSString:(NSString*) base64UrlString;
+
++(NSString*) createSignedJWTUsingKeyDerivation:(NSDictionary*) header
+                                       payload:(NSDictionary*) payload
+                                       context:(NSString*) context
+                                  symmetricKey:(NSData*) symmetricKey;
+
++ (NSString *) createJSONFromDictionary:(NSDictionary *) dictionary;
+
++ (NSData*) computeKDFInCounterMode:(NSData*)key
+                            context:(NSData*)ctx;
+
++ (void) removeNullStringFrom:(NSDictionary*) dict;
+
 @end

--- a/ADALiOS/ADALiOS/ADHelpers.m
+++ b/ADALiOS/ADALiOS/ADHelpers.m
@@ -18,8 +18,26 @@
 
 #import <Foundation/Foundation.h>
 #import "ADHelpers.h"
+#import "NSString+ADHelperMethods.h"
+#import <Security/Security.h>
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonHMAC.h>
+#import <CommonCrypto/CommonDigest.h>
 
 @implementation ADHelpers
+
+const NSString* Label = @"AzureAD-SecureConversation";
+
++ (void) removeNullStringFrom:(NSDictionary*) dict
+{
+    for (NSString* key in dict.allKeys)
+    {
+        if([[dict valueForKey:key] isEqualToString:@"(null)"])
+        {
+            [dict setValue:nil forKey:key];
+        }
+    }
+}
 
 +(BOOL) isADFSInstance:(NSString*) endpoint
 {
@@ -59,5 +77,173 @@
     }
     return nil;
 }
+
+
++ (NSData*) convertBase64UrlStringToBase64NSData:(NSString*) base64UrlString
+{
+    NSString* outVal = [ADHelpers convertBase64UrlStringToBase64NSString:base64UrlString];
+    return [outVal dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+
++ (NSString*) convertBase64UrlStringToBase64NSString:(NSString*) base64UrlString
+{
+    base64UrlString = [base64UrlString stringByReplacingOccurrencesOfString:@"-" withString:@""];
+    base64UrlString = [base64UrlString stringByReplacingOccurrencesOfString:@"_" withString:@"/"];
+    
+    NSString* base64PadCharacter = @"=";
+    
+    switch (base64UrlString.length % 4) // Pad
+    {
+        case 0:
+            break; // No pad chars in this case
+        case 2:
+            base64UrlString = [NSString stringWithFormat:@"%@%@%@", base64UrlString, base64PadCharacter, base64PadCharacter];
+            break; // Two pad chars
+        case 3:
+            base64UrlString = [NSString stringWithFormat:@"%@%@", base64UrlString, base64PadCharacter];
+            break; // One pad char
+    }
+    
+    return base64UrlString;
+}
+
++(NSString*) createSignedJWTUsingKeyDerivation:(NSDictionary*) header
+                                       payload:(NSDictionary*) payload
+                                       context:(NSString*) context
+                                  symmetricKey:(NSData*) symmetricKey
+{
+    NSString* signingInput = [NSString stringWithFormat:@"%@.%@",
+                              [[ADHelpers createJSONFromDictionary:header] adBase64UrlEncode],
+                              [[ADHelpers createJSONFromDictionary:payload] adBase64UrlEncode]];
+    
+    NSData* derivedKey = [ADHelpers computeKDFInCounterMode:symmetricKey
+                                                    context:[context dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    const char *cData = [signingInput cStringUsingEncoding:NSASCIIStringEncoding];
+    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
+    CCHmac(kCCHmacAlgSHA256,
+           derivedKey.bytes,
+           derivedKey.length,
+           cData,
+           strlen(cData),
+           cHMAC);
+    NSData* signedData = [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
+    NSString* signedEncodedDataString = [NSString Base64EncodeData: signedData];
+    return [NSString stringWithFormat:@"%@.%@",
+            signingInput,
+            signedEncodedDataString];
+}
+
+
++ (NSString *) createJSONFromDictionary:(NSDictionary *) dictionary{
+    
+    NSError *error;
+    NSData *jsonData = [NSJSONSerialization dataWithJSONObject:dictionary
+                                                       options:NSJSONWritingPrettyPrinted
+                                                         error:&error];
+    if (jsonData) {
+        return [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+    }
+    return nil;
+}
+
++ (NSData*) computeKDFInCounterMode:(NSData*)key
+                            context:(NSData*)ctx
+{
+    NSData* labelData = [Label dataUsingEncoding:NSUTF8StringEncoding];
+    NSMutableData* mutData = [NSMutableData new];
+    [mutData appendBytes:labelData.bytes length:labelData.length];
+    Byte bytes[] = {0x00};
+    [mutData appendBytes:bytes length:1];
+    [mutData appendBytes:ctx.bytes length:ctx.length];
+    int32_t size = CFSwapInt32HostToBig(256); //make big-endian
+    [mutData appendBytes:&size length:sizeof(size)];
+    
+    uint8_t* pbDerivedKey = [ADHelpers KDFCounterMode:(uint8_t*)key.bytes
+                               keyDerivationKeyLength:key.length
+                                           fixedInput:(uint8_t*)mutData.bytes
+                                     fixedInputLength:mutData.length];
+    mutData = nil;
+    return [NSData dataWithBytes:(const void *)pbDerivedKey length:32];
+}
+
+
+
++ (uint8_t*) KDFCounterMode:(uint8_t*) keyDerivationKey
+     keyDerivationKeyLength:(size_t) keyDerivationKeyLength
+                 fixedInput:(uint8_t*) fixedInput
+           fixedInputLength:(size_t) fixedInputLength
+{
+    uint8_t ctr;
+    unsigned char cHMAC[CC_SHA256_DIGEST_LENGTH];
+    uint8_t* keyDerivated;
+    uint8_t* dataInput;
+    int len;
+    int numCurrentElements;
+    int numCurrentElements_bytes;
+    int outputSizeBit = 256;
+    
+    numCurrentElements = 0;
+    ctr = 1;
+    keyDerivated = (uint8_t*)malloc(outputSizeBit/8); //output is 32 bytes
+    
+    do{
+        //update data using "ctr"
+        dataInput =  [ADHelpers updateDataInput:ctr
+                                     fixedInput:fixedInput
+                              fixedInput_length: fixedInputLength];
+        
+        CCHmac(kCCHmacAlgSHA256,
+               keyDerivationKey,
+               keyDerivationKeyLength,
+               dataInput,
+               (fixedInputLength+4), //+4 to account for ctr
+               cHMAC);
+        
+        //decide how many bytes (so the "length") copy for currently keyDerivated?
+        if (256 >= outputSizeBit) {
+            len = outputSizeBit;
+        } else {
+            len = MIN(256, outputSizeBit - numCurrentElements);
+        }
+        
+        //convert bits in byte
+        numCurrentElements_bytes = numCurrentElements/8;
+        
+        //copy KI in part of keyDerivated
+        memcpy((keyDerivated + numCurrentElements_bytes), cHMAC, 32);
+        
+        //increment ctr and numCurrentElements copied in keyDerivated
+        numCurrentElements = numCurrentElements + len;
+        ctr++;
+        
+        //deallock space in memory
+        free(dataInput);
+        
+    } while (numCurrentElements < outputSizeBit);
+    
+    return keyDerivated;
+}
+
+
+/*
+ * Function used to shift data of 1 byte. This byte is the "ctr".
+ */
++(uint8_t*) updateDataInput:(uint8_t) ctr
+                 fixedInput:(uint8_t*) fixedInput
+          fixedInput_length:(size_t) fixedInput_length
+{
+    uint8_t* tmpFixedInput = (uint8_t *)malloc(fixedInput_length + 4); //+4 is caused from the ctr
+    
+    tmpFixedInput[0] = (ctr >> 24);
+    tmpFixedInput[1] = (ctr >> 16);
+    tmpFixedInput[2] = (ctr >> 8);
+    tmpFixedInput[3] = ctr;
+    
+    memcpy(tmpFixedInput + 4, fixedInput, fixedInput_length * sizeof(uint8_t));
+    return tmpFixedInput;
+}
+
 
 @end

--- a/ADALiOS/ADALiOS/ADInstanceDiscovery.m
+++ b/ADALiOS/ADALiOS/ADInstanceDiscovery.m
@@ -289,12 +289,17 @@ NSString* const sValidationServerError = @"The authority validation server retur
                     {
                         if (jsonError)
                         {
-                            adError = [ADAuthenticationError errorFromNSError:jsonError errorDetails:jsonError.localizedDescription];
+                            adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_AUTHORITY_VALIDATION
+                                                                             protocolCode:nil
+                                                                             errorDetails:jsonError.localizedDescription];
+                                       
                         }
                         else
                         {
                             NSString* errorMessage = [NSString stringWithFormat:@"Unexpected object type: %@", [jsonObject class]];
-                            adError = [ADAuthenticationError unexpectedInternalError:errorMessage];
+                            adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_AUTHORITY_VALIDATION
+                                                                             protocolCode:nil
+                                                                             errorDetails:errorMessage];
                         }
                     }
                 }

--- a/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
+++ b/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
@@ -190,8 +190,11 @@ const long sKeychainVersion = 1;//will need to increase when we break the forwar
 -(void) LogItem: (ADTokenCacheStoreItem*) item
         message: (NSString*) additionalMessage
 {
-    AD_LOG_VERBOSE_F(sKeyChainlog, @"%@. Resource: %@ Access token hash: %@; Refresh token hash: %@", item.resource,additionalMessage, [ADLogger getHash:item.accessToken], [ADLogger getHash:item.refreshToken]);
-}
+    AD_LOG_VERBOSE_F(sKeyChainlog, @"%@. Resource: %@ Access token hash: %@; Refresh token hash: %@",
+                     additionalMessage,
+                     item.resource,
+                     [item.accessToken adComputeSHA256],
+                     [item.refreshToken adComputeSHA256]);}
 
 //Updates the keychain item. "attributes" parameter should ALWAYS come from previous
 //SecItemCopyMatching else the function will fail.

--- a/ADALiOS/ADALiOS/ADLogger.h
+++ b/ADALiOS/ADALiOS/ADLogger.h
@@ -88,10 +88,6 @@ typedef void (^LogCallback)(ADAL_LOG_LEVEL logLevel,
 /*! Returns diagnostic trace data to be sent to the Auzure Active Directory servers. */
 +(NSDictionary*) adalId;
 
-/*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
- the actual contents, but still want to log something that can be correlated. */
-+(NSString*) getHash: (NSString*) input;
-
 /*! Sets correlation id to be used in the requests sent to server. */
 +(void) setCorrelationId: (NSUUID*) correlationId;
 

--- a/ADALiOS/ADALiOS/ADLogger.m
+++ b/ADALiOS/ADALiOS/ADLogger.m
@@ -21,7 +21,6 @@
 #include <sys/types.h>
 #include <sys/sysctl.h>
 #include <mach/machine.h>
-#include <CommonCrypto/CommonDigest.h>
 
 ADAL_LOG_LEVEL sLogLevel = ADAL_LOG_LEVEL_ERROR;
 LogCallback sLogCallback;
@@ -195,23 +194,6 @@ additionalInformation: (NSString*) additionalInformation
     return result;
 }
 
-+(NSString*) getHash: (NSString*) input
-{
-    if (!input)
-    {
-        return nil;//Handle gracefully
-    }
-    const char* inputStr = [input UTF8String];
-    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
-    CC_SHA256(inputStr, (int)strlen(inputStr), hash);
-    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
-    for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
-    {
-        [toReturn appendFormat:@"%02x", hash[i]];
-    }
-    return SAFE_ARC_AUTORELEASE(toReturn);
-}
-
 +(void) setCorrelationId: (NSUUID*) correlationId
 {
     SAFE_ARC_RELEASE(requestCorrelationId);
@@ -234,7 +216,7 @@ additionalInformation: (NSString*) additionalInformation
        expiresOn: (NSDate*) expiresOn
    correlationId: (NSUUID*) correlationId
 {
-    AD_LOG_VERBOSE_F(@"Token returned", @"Obtained %@ with hash %@, expiring on %@ and correlationId: %@", tokenType, [self getHash:token], expiresOn, [correlationId UUIDString]);
+    AD_LOG_VERBOSE_F(@"Token returned", @"Obtained %@ with hash %@, expiring on %@ and correlationId: %@", tokenType, [token adComputeSHA256], expiresOn, [correlationId UUIDString]);
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADNTLMHandler.h
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.h
@@ -22,15 +22,25 @@
 
 @interface ADNTLMHandler : NSObject
 
+/* Starts intercepting HTTPS connections to enable NTLM authentication over webview.
+  If this method succeeds, it should be paired with endWebViewNTLMHandler. The method attempts
+ to retrieve the workplace join identity and certificate. The interception should be as
+ short as possible, as this is a very specific fix to overcome the webview limitations. */
 +(BOOL) startWebViewNTLMHandlerWithError: (ADAuthenticationError* __autoreleasing*) error;
+
 /* Stops the HTTPS interception. */
 +(void) endWebViewNTLMHandler;
 
 #if !TARGET_OS_IPHONE
+/* Handles a client authentication NTLM challenge by collecting user credentials. Returns YES,
+  if the challenge has been handled. */
 +(BOOL) handleNTLMChallenge:(NSURLAuthenticationChallenge *)challenge
              customProtocol:(NSURLProtocol*) protocol;
 
 #else
+
+/* Handles a client authentication NTLM challenge by collecting user credentials. Returns YES,
+  if the challenge has been handled. */
 +(BOOL) handleNTLMChallenge:(NSURLAuthenticationChallenge *)challenge
                  urlRequest:(NSURLRequest*) request
              customProtocol:(NSURLProtocol*) protocol;

--- a/ADALiOS/ADALiOS/ADNTLMHandler.m
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.m
@@ -97,7 +97,7 @@ NSURLConnection *_conn = nil;
             if(_conn){
                 _conn = nil;
             }
-            // This is the client TLS challenge: use the identity to authenticate:
+            // This is the NTLM challenge: use the identity to authenticate:
             AD_LOG_VERBOSE_F(AD_WPJ_LOG, @"Attempting to handle NTLM challenge for host: %@", challenge.protectionSpace.host);
             
             [UIAlertView presentCredentialAlert:^(NSUInteger index) {
@@ -125,6 +125,8 @@ NSURLConnection *_conn = nil;
             }];
             succeeded = YES;
         }//@synchronized
+    } else{
+        AD_LOG_VERBOSE_F(AD_WPJ_LOG, @"Ignoring to handle challenge: %@", challenge.protectionSpace.authenticationMethod);
     }//Challenge type
     
     return succeeded;

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.h
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.h
@@ -22,6 +22,7 @@ extern NSString *const OAUTH2_ACCESS_TOKEN;
 extern NSString *const OAUTH2_AUTHORIZATION;
 extern NSString *const OAUTH2_AUTHORIZATION_CODE;
 extern NSString *const OAUTH2_AUTHORIZATION_URI;
+extern NSString *const OAUTH2_AUTHORITY;
 extern NSString *const OAUTH2_AUTHORIZE_SUFFIX;
 extern NSString *const OAUTH2_BEARER;
 extern NSString *const OAUTH2_CLIENT_ID;
@@ -52,6 +53,8 @@ extern NSString *const OAUTH2_SAML11_BEARER_VALUE;
 extern NSString *const OAUTH2_SAML2_BEARER_VALUE;
 extern NSString *const OAUTH2_ASSERTION;
 
+extern NSString *const BROKER_RESPONSE_KEY;
+extern NSString *const BROKER_HASH_KEY;
 
 //Diagnostic traces sent to the Azure Active Directory servers:
 extern NSString *const ADAL_ID_PLATFORM;//The ADAL platform. iOS or OSX
@@ -73,3 +76,5 @@ extern NSString *const AUTH_FAILED_BAD_PARAMETERS;
 extern NSString *const AUTH_FAILED_NO_CLIENTID;
 extern NSString *const AUTH_FAILED_NO_REDIRECTURI;
 extern NSString *const AUTH_FAILED_BUSY;
+
+extern NSString* const brokerScheme;

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.m
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.m
@@ -24,6 +24,7 @@ NSString *const OAUTH2_AUTHORIZE_SUFFIX   = @"/oauth2/authorize";
 
 NSString *const OAUTH2_AUTHORIZATION_CODE = @"authorization_code";
 NSString *const OAUTH2_AUTHORIZATION_URI  = @"authorization_uri";
+NSString *const OAUTH2_AUTHORITY           = @"authority";
 NSString *const OAUTH2_BEARER             = @"Bearer";
 NSString *const OAUTH2_CLIENT_ID          = @"client_id";
 NSString *const OAUTH2_CLIENT_SECRET      = @"client_secret";
@@ -53,6 +54,8 @@ NSString *const OAUTH2_ASSERTION = @"assertion";
 NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml1_1-bearer";
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 
+NSString *const BROKER_RESPONSE_KEY               = @"response";
+NSString *const BROKER_HASH_KEY               = @"hash";
 
 //Diagnostic traces sent to the Azure Active Directory servers:
 NSString *const ADAL_ID_PLATFORM          = @"x-client-SKU";//The ADAL platform. iOS or OSX
@@ -74,3 +77,6 @@ NSString *const AUTH_FAILED_BAD_PARAMETERS = @"Incorrect parameters for authoriz
 NSString *const AUTH_FAILED_NO_CLIENTID    = @"Unable to determine client identifier";
 NSString *const AUTH_FAILED_NO_REDIRECTURI = @"Unable to determine redirect URL";
 NSString *const AUTH_FAILED_BUSY           = @"Authorization call already in progress";
+
+//application constants
+NSString* const brokerScheme = @"msauth";

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
@@ -54,6 +54,8 @@
 
 @property (retain) NSString* refreshToken;
 
+@property (retain) NSData* sessionKey;
+
 @property (retain) NSDate* expiresOn;
 
 @property (retain) ADUserInformation* userInformation;

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
@@ -15,6 +15,7 @@
 //
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
+
 #import <Foundation/Foundation.h>
 
 @class ADUserInformation;
@@ -35,7 +36,7 @@
     NSDate   *_expiresOn;
     NSString *_refreshToken;
     NSString *_resource;
-    
+    NSData  *_sessionKey;   
     ADUserInformation *_userInformation;
     BOOL               _multiResourceRefreshToken;
 }

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
@@ -46,7 +46,7 @@
     SAFE_ARC_RELEASE(_refreshToken);
     SAFE_ARC_RELEASE(_resource);
     SAFE_ARC_RELEASE(_userInformation);
-    SAFE_ARC_RELEASE(sessionKey);
+    SAFE_ARC_RELEASE(_sessionKey);
     SAFE_ARC_SUPER_DEALLOC();
 }
 

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
@@ -32,6 +32,7 @@
 @synthesize refreshToken              = _refreshToken;
 @synthesize resource                  = _resource;
 @synthesize userInformation           = _userInformation;
+@synthesize sessionKey                = _sessionKey;
 
 - (void)dealloc
 {
@@ -45,7 +46,7 @@
     SAFE_ARC_RELEASE(_refreshToken);
     SAFE_ARC_RELEASE(_resource);
     SAFE_ARC_RELEASE(_userInformation);
-    
+    SAFE_ARC_RELEASE(sessionKey);
     SAFE_ARC_SUPER_DEALLOC();
 }
 
@@ -70,6 +71,7 @@
     item->_refreshToken = [self.refreshToken copyWithZone:zone];
     item->_expiresOn = [self.expiresOn copyWithZone:zone];
     item->_userInformation = [self.userInformation copyWithZone:zone];
+    item->_sessionKey = [self.sessionKey copyWithZone:zone];
     
     return item;
 }
@@ -124,6 +126,7 @@
     [aCoder encodeObject:self.accessToken forKey:@"accessToken"];
     [aCoder encodeObject:self.accessTokenType forKey:@"accessTokenType"];
     [aCoder encodeObject:self.refreshToken forKey:@"refreshToken"];
+    [aCoder encodeObject:self.sessionKey forKey:@"sessionKey"];
     [aCoder encodeObject:self.expiresOn forKey:@"expiresOn"];
     [aCoder encodeObject:self.userInformation forKey:@"userInformation"];
 }
@@ -139,6 +142,7 @@
         self.clientId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
         self.accessToken = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessToken"];
         self.accessTokenType = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessTokenType"];
+        self.sessionKey = [aDecoder decodeObjectOfClass:[NSData class] forKey:@"sessionKey"];
         self.refreshToken = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"refreshToken"];
         self.expiresOn = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"expiresOn"];
         self.userInformation = [aDecoder decodeObjectOfClass:[ADUserInformation class] forKey:@"userInformation"];

--- a/ADALiOS/ADALiOS/ADURLProtocol.h
+++ b/ADALiOS/ADALiOS/ADURLProtocol.h
@@ -19,7 +19,7 @@
 #pragma once
 
 //Intercepts HTTPS protocol for the application in order to allow
-//TLS with client-authentication. Such authentication is the base
+//NTLM with client-authentication. Such authentication is the base
 //of workplace joined devices. The class is not thread-safe.
 @interface ADURLProtocol : NSURLProtocol <NSURLConnectionDelegate, NSURLConnectionDataDelegate>
 {

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -37,20 +37,20 @@ NSString* const sLog = @"HTTP Protocol";
         //for initialization
         if ( [NSURLProtocol propertyForKey:@"ADURLProtocol" inRequest:request] == nil )
         {
-            AD_LOG_VERBOSE_F(sLog, @"Requested handling of URL: %@", [request.URL absoluteString]);
+            AD_LOG_VERBOSE_F(sLog, @"Requested handling of URL: %@", [request.URL host]);
             
             return YES;
         }
     }
     
-    AD_LOG_VERBOSE_F(sLog, @"Ignoring handling of URL: %@", [request.URL absoluteString]);
+    AD_LOG_VERBOSE_F(sLog, @"Ignoring handling of URL: %@", [request.URL host]);
     
     return NO;
 }
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
 {
-    AD_LOG_VERBOSE_F(sLog, @"canonicalRequestForRequest: %@", [request.URL absoluteString] );
+    AD_LOG_VERBOSE_F(sLog, @"canonicalRequestForRequest: %@", [request.URL host] );
     
     return request;
 }
@@ -63,7 +63,7 @@ NSString* const sLog = @"HTTP Protocol";
         return;
     }
     
-    AD_LOG_VERBOSE_F(sLog, @"startLoading: %@", [self.request.URL absoluteString] );
+    AD_LOG_VERBOSE_F(sLog, @"startLoading: %@", [self.request.URL host] );
     NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
     [NSURLProtocol setProperty:@"YES" forKey:@"ADURLProtocol" inRequest:mutableRequest];
     _connection = [[NSURLConnection alloc] initWithRequest:mutableRequest

--- a/ADALiOS/ADALiOS/NSString+ADHelperMethods.h
+++ b/ADALiOS/ADALiOS/NSString+ADHelperMethods.h
@@ -76,4 +76,8 @@
 /*! Converts NSData to base64 String */
 + (NSString *) Base64EncodeData:(NSData *)data;
 
++ (NSData *) Base64DecodeData:(NSString *)encodedString;
+
+-(NSString*) adComputeSHA256;
+
 @end

--- a/ADALiOS/ADALiOS/NSString+ADHelperMethods.m
+++ b/ADALiOS/ADALiOS/NSString+ADHelperMethods.m
@@ -16,6 +16,7 @@
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
 #import "ADAL.h"
+#import <CommonCrypto/CommonDigest.h>
 
 typedef unsigned char byte;
 
@@ -297,7 +298,7 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
 }
 
 -(long) adFindCharactersFromSet: (NSCharacterSet*) set
-                        start: (long) startIndex
+                          start: (long) startIndex
 {
     THROW_ON_NIL_ARGUMENT(set);
     long end = self.length;
@@ -401,6 +402,19 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
         return !string2; //if both are nil, they are equal
     else
         return [string1 isEqualToString:string2];
+}
+
+-(NSString*) adComputeSHA256
+{
+    const char* inputStr = [self UTF8String];
+    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(inputStr, (int)strlen(inputStr), hash);
+    NSMutableString* toReturn = [[NSMutableString alloc] initWithCapacity:CC_SHA256_DIGEST_LENGTH*2];
+    for (int i = 0; i < sizeof(hash)/sizeof(hash[0]); ++i)
+    {
+        [toReturn appendFormat:@"%02x", hash[i]];
+    }
+    return toReturn;
 }
 
 @end

--- a/ADALiOS/ADALiOS/UIAlertView+Additions.m
+++ b/ADALiOS/ADALiOS/UIAlertView+Additions.m
@@ -19,7 +19,10 @@ static UIAlertView *alert;
     [alert setDelegate:alert];
     
     if (handler)
+    {
         objc_setAssociatedObject(alert, HANDLER_KEY, handler, OBJC_ASSOCIATION_COPY_NONATOMIC);
+    }
+    
     dispatch_async(dispatch_get_main_queue(), ^(void){
         [alert show];
     });

--- a/ADALiOS/ADALiOS/UIApplication+ADExtensions.m
+++ b/ADALiOS/ADALiOS/UIApplication+ADExtensions.m
@@ -22,9 +22,31 @@
 
 @implementation UIApplication ( internal )
 
-+ (UIViewController *) adCurrentViewController
++ (UIViewController *)adCurrentViewController
 {
-    return [[[UIApplication sharedApplication] keyWindow] rootViewController];
+    return [self adCurrentViewControllerWithRootViewController:[UIApplication sharedApplication].keyWindow.rootViewController];
 }
 
++ (UIViewController*)adCurrentViewControllerWithRootViewController:(UIViewController*)rootViewController
+{
+    if ([rootViewController isKindOfClass:[UITabBarController class]])
+    {
+        UITabBarController* tabBarController = (UITabBarController*)rootViewController;
+        return [self adCurrentViewControllerWithRootViewController:tabBarController.selectedViewController];
+    }
+    else if ([rootViewController isKindOfClass:[UINavigationController class]])
+    {
+        UINavigationController* navigationController = (UINavigationController*)rootViewController;
+        return [self adCurrentViewControllerWithRootViewController:navigationController.visibleViewController];
+    }
+    else if (rootViewController.presentedViewController)
+    {
+        UIViewController* presentedViewController = rootViewController.presentedViewController;
+        return [self adCurrentViewControllerWithRootViewController:presentedViewController];
+    }
+    else
+    {
+        return rootViewController;
+    }
+}
 @end

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -59,6 +59,7 @@ const int sAsyncContextTimeout = 10;
     ADPromptBehavior mPromptBehavior;
     NSString* mAssertion;
     ADAssertionType mAssertionType;
+    BOOL mSilent;
     
     //The results:
     ADAuthenticationError* mError;//The error filled by the result;
@@ -79,11 +80,14 @@ const int sAsyncContextTimeout = 10;
     mAuthority = @"https://login.windows.net/msopentechbv.onmicrosoft.com";
     mDefaultTokenCache = [ADAuthenticationSettings sharedInstance].defaultTokenCacheStore;
     XCTAssertNotNil(mDefaultTokenCache);
+    [ADAuthenticationSettings sharedInstance].credentialsType = AD_CREDENTIALS_EMBEDDED;
+
     mRedirectURL = [NSURL URLWithString:@"http://todolistclient/"];
     mClientId    = @"c3c7f5e5-7153-44d4-90e6-329686d48d76";
     mResource    = @"http://localhost/TodoListService";
     mUserId      = @"boris@msopentechbv.onmicrosoft.com";
     mError       = nil;
+    mSilent = NO;
     
     ADAuthenticationError* error = nil;
     ADTestAuthenticationContext* testContext = [[ADTestAuthenticationContext alloc] initWithAuthority:mAuthority
@@ -95,7 +99,6 @@ const int sAsyncContextTimeout = 10;
     
     mContext = testContext;
     mProtocolContext = (id<ADAuthenticationContextProtocol>)mContext;
-    mPromptBehavior  = AD_PROMPT_NEVER;
     
     [testContext->mExpectedRequest1 setObject:OAUTH2_REFRESH_TOKEN forKey:OAUTH2_GRANT_TYPE];
     [testContext->mExpectedRequest1 setObject:mResource forKey:OAUTH2_RESOURCE];
@@ -378,6 +381,7 @@ const int sAsyncContextTimeout = 10;
                                     assertionType:self->mAssertionType
                                          resource:self->mResource
                                          clientId:self->mClientId
+                                      redirectUri:self->mRedirectURL
                                            userId:self->mUserId
                                   completionBlock:^(ADAuthenticationResult *result)
           {
@@ -397,23 +401,34 @@ const int sAsyncContextTimeout = 10;
 -(void) asynchronousAcquireTokenWithLine: (int) line
 {
     [self prepareForAsynchronousCall];
-
     __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
     [self adCallAndWaitWithFile:@"" __FILE__ line:line semaphore:sem block:^
      {
-         [self->mContext acquireTokenWithResource:self->mResource
-                                   clientId:self->mClientId
-                                redirectUri:self->mRedirectURL
-                             promptBehavior:self->mPromptBehavior
-                                     userId:self->mUserId
-                       extraQueryParameters:nil
-                            completionBlock:^(ADAuthenticationResult *result)
-          {
-              //Fill in the iVars with the result:
-              self->mResult = SAFE_ARC_RETAIN( result );
-              self->mError = SAFE_ARC_RETAIN(self->mResult.error);
-              dispatch_semaphore_signal(sem);
-          }];
+         ADAuthenticationCallback callback = ^(ADAuthenticationResult* result){
+             //Fill in the iVars with the result:
+             mResult = result;
+             mError = mResult.error;
+             dispatch_semaphore_signal(sem);
+         };
+         if (mSilent)
+         {
+             [mContext acquireTokenSilentWithResource:mResource
+                                             clientId:mClientId
+                                          redirectUri:mRedirectURL
+                                               userId:mUserId
+                                      completionBlock:callback];
+         }
+         else
+         {
+             [mContext acquireTokenWithResource:mResource
+                                       clientId:mClientId
+                                    redirectUri:mRedirectURL
+                                 promptBehavior:mPromptBehavior
+                                         userId:mUserId
+                           extraQueryParameters:nil
+                                completionBlock:callback];
+         }
+         
      }];
     [self validateAsynchronousResultWithLine:line];
 }
@@ -619,10 +634,46 @@ const int sAsyncContextTimeout = 10;
     return item;
 }
 
--(void) testAcquireTokenWithNoPrompt
+-(void) testAcquireTokenFromAssertion
 {
     ADAuthenticationError* error = nil;
-    mPromptBehavior = AD_PROMPT_NEVER;
+    //Nothing in the cache, as we cannot prompt for credentials, this should fail:
+    acquireTokenForAssertionAsync;
+    XCTAssertEqual(mResult.status, AD_FAILED);
+    ADAssertLongEquals(mResult.error.code, AD_ERROR_INVALID_ARGUMENT);
+    
+    self->mAssertion = @"some assertion";
+    NSString* someTokenValue = @"someToken value";
+    [self addCacheWithToken:someTokenValue refreshToken:nil];
+    acquireTokenForAssertionAsync;
+    ADAssertStringEquals(mResult.tokenCacheStoreItem.accessToken, someTokenValue);
+    
+    //Expire the cache item:
+    [mDefaultTokenCache removeAllWithError:&error];
+    ADAssertNoError;
+    NSArray* allItems = [mDefaultTokenCache allItemsWithError:&error];
+    XCTAssertTrue(allItems.count == 0);
+
+    NSString* broadRefreshToken = @"broad refresh token testAcquireTokenWithNoPrompt";
+    NSString* anotherAccessToken = @"another access token testAcquireTokenWithNoPrompt";
+    
+    [self.testContext->mExpectedRequest1 setObject:OAUTH2_SAML11_BEARER_VALUE forKey:OAUTH2_GRANT_TYPE];
+    
+    [self.testContext->mResponse1 setObject:anotherAccessToken forKey:OAUTH2_ACCESS_TOKEN];
+    [self.testContext->mResponse1 setObject:broadRefreshToken forKey:OAUTH2_REFRESH_TOKEN];
+    //Next line makes it a broad token:
+    [self.testContext->mResponse1 setObject:@"anything" forKey:OAUTH2_RESOURCE];
+    acquireTokenForAssertionAsync;
+    XCTAssertEqual(mResult.status, AD_SUCCEEDED);
+    ADAssertStringEquals(mResult.accessToken, anotherAccessToken);
+    ADAssertStringEquals(mResult.tokenCacheStoreItem.refreshToken, broadRefreshToken);
+}
+
+
+-(void) testAcquireTokenSilent
+{
+    ADAuthenticationError* error;
+    mSilent = YES;
     
     //Nothing in the cache, as we cannot prompt for credentials, this should fail:
     acquireTokenAsync;
@@ -641,7 +692,6 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue(allItems.count == 1);
     ADTokenCacheStoreItem* item = [allItems objectAtIndex:0];
     item.expiresOn = [NSDate dateWithTimeIntervalSinceNow:0];//Expire it.
-    error = nil;
     [mDefaultTokenCache addOrUpdateItem:item error:&error];//Udpate the cache.
     ADAssertNoError;
     //The access token is expired and the refresh token is nil, so it should fail:
@@ -690,44 +740,6 @@ const int sAsyncContextTimeout = 10;
     ADAssertLongEquals(mResult.error.code, AD_ERROR_USER_INPUT_NEEDED);
 }
 
-
-
--(void) testAcquireTokenFromAssertion
-{
-    ADAuthenticationError* error = nil;
-    //Nothing in the cache, as we cannot prompt for credentials, this should fail:
-    acquireTokenForAssertionAsync;
-    XCTAssertEqual(mResult.status, AD_FAILED);
-    ADAssertLongEquals(mResult.error.code, AD_ERROR_INVALID_ARGUMENT);
-    
-    self->mAssertion = @"some assertion";
-    NSString* someTokenValue = @"someToken value";
-    [self addCacheWithToken:someTokenValue refreshToken:nil];
-    acquireTokenForAssertionAsync;
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.accessToken, someTokenValue);
-    
-    //Expire the cache item:
-    [mDefaultTokenCache removeAllWithError:&error];
-    ADAssertNoError;
-    NSArray* allItems = [mDefaultTokenCache allItemsWithError:&error];
-    XCTAssertTrue(allItems.count == 0);
-
-    NSString* broadRefreshToken = @"broad refresh token testAcquireTokenWithNoPrompt";
-    NSString* anotherAccessToken = @"another access token testAcquireTokenWithNoPrompt";
-    
-    [self.testContext->mExpectedRequest1 setObject:OAUTH2_SAML11_BEARER_VALUE forKey:OAUTH2_GRANT_TYPE];
-    
-    [self.testContext->mResponse1 setObject:anotherAccessToken forKey:OAUTH2_ACCESS_TOKEN];
-    [self.testContext->mResponse1 setObject:broadRefreshToken forKey:OAUTH2_REFRESH_TOKEN];
-    //Next line makes it a broad token:
-    [self.testContext->mResponse1 setObject:@"anything" forKey:OAUTH2_RESOURCE];
-    acquireTokenForAssertionAsync;
-    XCTAssertEqual(mResult.status, AD_SUCCEEDED);
-    ADAssertStringEquals(mResult.accessToken, anotherAccessToken);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.refreshToken, broadRefreshToken);
-}
-
-
 -(void) testGenericErrors
 {
     //Refresh token in the cache, but there is no connection to the server. We should not try to open a credentials web view:
@@ -744,6 +756,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue([self cacheCount] == 1, "Nothing should be removed from the cache.");
     
     //Now simulate restoring of the connection and server error, ensure that attempt was made to prompt for credentials:
+    mSilent = YES;
     [self.testContext->mResponse1 setObject:@"bad_refresh_token" forKey:OAUTH2_ERROR];
     acquireTokenAsync;
     XCTAssertEqual(mResult.status, AD_FAILED, "AcquireToken should fail, as the credentials are needed without cache.");
@@ -830,6 +843,8 @@ const int sAsyncContextTimeout = 10;
     //#4: Now try failing from both the exact and the broad refresh token to ensure that this code path
     //works. Both items should be removed from the cache. Also ensures that the credentials ask is attempted in this case.
     self.testContext->mAllowTwoRequests = YES;
+    mSilent = YES;
+
     newItem.refreshToken = @"new non-working refresh token";
     newItem.expiresOn = [NSDate dateWithTimeIntervalSinceNow:0];
     [mDefaultTokenCache addOrUpdateItem:newItem error:&error];
@@ -862,7 +877,7 @@ const int sAsyncContextTimeout = 10;
     [self addCacheWithToken:accessToken refreshToken:nil userId:mUserId resource:mResource];
     mUserId = requestUser;
     acquireTokenAsync;
-    ADAssertLongEquals(AD_ERROR_USER_INPUT_NEEDED, mResult.error.code);
+    ADAssertLongEquals(AD_ERROR_NO_MAIN_VIEW_CONTROLLER, mResult.error.code);
     
     //#2: Only exact refresh token
     [mDefaultTokenCache removeAllWithError:&error];
@@ -1020,7 +1035,7 @@ const int sAsyncContextTimeout = 10;
 
 -(void) testBadAuthorityWithValidation
 {
-    mAuthority = @"https://MyFakeAuthority.com/MSOpenTechBV.OnMicrosoft.com";
+    mAuthority = @"https://MyFakeAuthority.microsoft.com/MSOpenTechBV.OnMicrosoft.com";
     ADAuthenticationError* error = nil;
     mContext = [ADAuthenticationContext authenticationContextWithAuthority:mAuthority error:&error];
     XCTAssertNotNil(mContext);
@@ -1041,12 +1056,12 @@ const int sAsyncContextTimeout = 10;
     //scenarios when we cannot invoke the web view:
     acquireTokenAsync;
     XCTAssertNotNil(mError);
-    ADAssertLongEquals(AD_ERROR_USER_INPUT_NEEDED, mError.code);
+    ADAssertLongEquals(AD_ERROR_NO_MAIN_VIEW_CONTROLLER, mError.code);
 }
 
 -(void) testUIError
 {
-    ADAuthenticationError* error = nil;
+    ADAuthenticationError* error;
     
     //Nothing in the cache, UI is needed:
     [mDefaultTokenCache removeAllWithError:&error];
@@ -1054,7 +1069,7 @@ const int sAsyncContextTimeout = 10;
     mContext = [ADAuthenticationContext authenticationContextWithAuthority:mAuthority error:&error];
     ADAssertNoError;
     [self validateUIError];
-
+    
     //Cache disabled, should always try to open UI for credentials
     error = nil;
     mContext = [ADAuthenticationContext authenticationContextWithAuthority:mAuthority tokenCacheStore:nil error:&error];
@@ -1069,9 +1084,7 @@ const int sAsyncContextTimeout = 10;
     ADAssertNoError;
     [self addCacheWithToken:@"access" refreshToken:nil];
     mPromptBehavior = AD_PROMPT_ALWAYS;
-    acquireTokenAsync;
-    ADAssertLongEquals(AD_ERROR_NO_MAIN_VIEW_CONTROLLER, mError.code);
-    XCTAssertTrue([mError.errorDetails adContainsString:@"view controller"]);
+    [self validateUIError];
 #endif
 }
  
@@ -1178,166 +1191,6 @@ const int sAsyncContextTimeout = 10;
      }];
     [self validateAsynchronousResultWithLine:__LINE__];
     ADAssertLongEquals(AD_SUCCEEDED, mResult.status);
-}
-
-//Tests the shorter overload of acquireTokenByRefreshToken
-//as the method ultimately calls the other overload, which is also used by acquireToken.
-//As such, the test is not very deep.
--(void) testAcquireTokenByRefreshTokenSimple_Negative
-{
-    //There is no resource for this call:
-    [self.testContext->mExpectedRequest1 removeObjectForKey:OAUTH2_RESOURCE];
-    //Calls the acquireToken
-    __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-    [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ semaphore:sem block:^
-     {
-         [self->mContext acquireTokenByRefreshToken:@"nonExisting one"
-                                     clientId:self->mClientId
-                              completionBlock:^(ADAuthenticationResult *result)
-          {
-              //Fill in the iVars with the result:
-              self->mResult = SAFE_ARC_RETAIN(result);
-              self->mError = SAFE_ARC_RETAIN(self->mResult.error);
-              dispatch_semaphore_signal(sem);
-          }];
-     }];
-    [self validateAsynchronousResultWithLine:__LINE__];
-    ADAssertLongEquals(AD_FAILED, self->mResult.status);
-}
-
-//Calls the full overload of acquireTokenByRefresh token and waits for the result.
--(void) asyncAcquireTokenByRefreshToken: (NSString*) refreshToken
-{
-    [self prepareForAsynchronousCall];
-    
-    __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
-    [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ semaphore:sem block:^
-     {
-         [self->mContext acquireTokenByRefreshToken:refreshToken
-                                     clientId:self->mClientId
-                                     resource:self->mResource
-                              completionBlock:^(ADAuthenticationResult *result)
-          {
-              //Fill in the iVars with the result:
-              self->mResult = SAFE_ARC_RETAIN(result);
-              self->mError = SAFE_ARC_RETAIN(self->mResult.error);
-              dispatch_semaphore_signal(sem);
-          }];
-     }];
-    [self validateAsynchronousResultWithLine:__LINE__];
-}
-
-//Most of the refresh token functionality is already tested, here we add only
-//the specifics to the public function behavior:
--(void) testAcquireTokenByRefreshToken
-{
-    //Return access and exact refresh tokens:
-    NSString* accessToken1 = @"accessToken1";
-    NSString* exactRefreshToken = @"exactRefreshToken";
-    NSString* refreshToken = @"some refresh token";
-    [self.testContext->mResponse1 setObject:accessToken1 forKey:OAUTH2_ACCESS_TOKEN];
-    [self.testContext->mResponse1 setObject:exactRefreshToken forKey:OAUTH2_REFRESH_TOKEN];
-    [self.testContext->mExpectedRequest1 setObject:refreshToken forKey:OAUTH2_REFRESH_TOKEN];
-    [self asyncAcquireTokenByRefreshToken:refreshToken];
-    ADAssertLongEquals(AD_SUCCEEDED, mResult.status);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.accessToken, accessToken1);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.refreshToken, exactRefreshToken);
-    ADAssertLongEquals(0, [self cacheCount]);//This method should not write to the cache
-
-    //Return access and broad refresh tokens:
-    NSString* accessToken2 = @"accessToken2";
-    NSString* broadRefreshToken = @"broadRefreshToken";
-    [self.testContext->mResponse1 setObject:accessToken2 forKey:OAUTH2_ACCESS_TOKEN];
-    [self.testContext->mResponse1 setObject:broadRefreshToken forKey:OAUTH2_REFRESH_TOKEN];
-    //Presence of "resource" denotes multi-resource refresh token:
-    [self.testContext->mResponse1 setObject:@"someresource" forKey:OAUTH2_RESOURCE];
-    [self asyncAcquireTokenByRefreshToken:refreshToken];
-    ADAssertLongEquals(AD_SUCCEEDED, mResult.status);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.accessToken, accessToken2);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.refreshToken, broadRefreshToken);
-    ADAssertLongEquals(0, [self cacheCount]);//This method should not write to the cache
-    
-    //Put stuff in the cache, make sure it is not used:
-    [self adClearLogs];
-    [self addCacheWithToken:@"cacheAccessToken" refreshToken:@"cacheExactRefreshToken"];
-    [self addCacheWithToken:nil refreshToken:@"broadCacheRefreshToken" userId:mUserId resource:nil];
-    ADAssertLogsContain(TEST_LOG_INFO, @" addOrUpdateItem:error:]");//Double check that the logging is in place
-    
-    [self adClearLogs];
-    [self asyncAcquireTokenByRefreshToken:refreshToken];
-
-    ADAssertLongEquals(AD_SUCCEEDED, mResult.status);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.accessToken, accessToken2);
-    ADAssertStringEquals(mResult.tokenCacheStoreItem.refreshToken, broadRefreshToken);
-    ADAssertLogsDoNotContain(TEST_LOG_INFO, @" addOrUpdateItem:error:]");//Cache should not be touched
-    ADAssertLongEquals(2, [self cacheCount]);
-    
-    //Put the same refresh token in the cache, return an error and ensure again that the cache is not touched:
-    //refresh tokens should not be removed:
-    [self addCacheWithToken:@"cacheAccessToken" refreshToken:refreshToken];
-    [self addCacheWithToken:nil refreshToken:refreshToken userId:mUserId resource:nil];
-    [self.testContext->mResponse1 removeObjectForKey:OAUTH2_ACCESS_TOKEN];
-    [self.testContext->mResponse1 setObject:@"bad_refresh_token" forKey:OAUTH2_ERROR];
-    [self adClearLogs];
-    [self asyncAcquireTokenByRefreshToken:refreshToken];
-    
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    ADAssertLogsDoNotContain(TEST_LOG_INFO, @" addOrUpdateItem:error:]");//Cache should not be touched
-    ADAssertLongEquals(2, [self cacheCount]);
-}
-
--(void) testAcquireTokenWithRefreshTokenParameters
-{
-    //Test some parameters cases:
-    //RefreshToken nil:
-    [self asyncAcquireTokenByRefreshToken:nil];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    [self adValidateForInvalidArgument:@"refreshToken" error:mResult.error];
-    
-    //RefreshToken empty
-    [self asyncAcquireTokenByRefreshToken:@"   "];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    [self adValidateForInvalidArgument:@"refreshToken" error:mResult.error];
-    
-    //ClientId nil:
-    mClientId = nil;
-    [self asyncAcquireTokenByRefreshToken:@"refreshToken"];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    [self adValidateForInvalidArgument:@"clientId" error:mResult.error];
-    
-    //ClientId empty:
-    mClientId = @"     ";
-    [self asyncAcquireTokenByRefreshToken:@"refreshToken"];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    [self adValidateForInvalidArgument:@"clientId" error:mResult.error];
-}
-
-//Hits a the cloud with either a bad server or a bad refresh token:
--(void) testRefreshingTokenWithServerErrors
-{
-    //Authority cannot be validated or reached:
-    mContext = [ADAuthenticationContext authenticationContextWithAuthority:@"https://aadadfstodolistservice.azurewebsites.net/api/todolist" error:nil];
-    XCTAssertNotNil(mContext);
-
-    [self asyncAcquireTokenByRefreshToken:@"doesn't matter"];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    ADAssertLongEquals(AD_ERROR_AUTHORITY_VALIDATION, mResult.error.code);
-    
-    mContext.validateAuthority = NO;
-    [self asyncAcquireTokenByRefreshToken:@"doesn't matter"];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    XCTAssertTrue([NSString adSame:mResult.error.domain toString:ADAuthenticationErrorDomain] ||
-                  [NSString adSame:mResult.error.domain toString:NSURLErrorDomain] );
-    
-    //Valid authority, but invalid refresh token:
-    mContext = [ADAuthenticationContext authenticationContextWithAuthority:mAuthority error:nil];
-    XCTAssertNotNil(mContext);
-    
-    [self asyncAcquireTokenByRefreshToken:@"invalid_refresh_token"];
-    ADAssertLongEquals(AD_FAILED, mResult.status);
-    ADAssertLongEquals(AD_ERROR_INVALID_REFRESH_TOKEN, mResult.error.code);
-    ADAssertStringEquals(mResult.error.protocolCode, @"invalid_grant");
-    XCTAssertTrue([mResult.error.errorDetails.lowercaseString adContainsString:@"refresh token"]);
 }
 
 @end

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -28,8 +28,10 @@
 #import "../ADALiOS/ADAuthenticationSettings.h"
 #import "../ADALiOS/ADErrorCodes.h"
 #import "../ADALiOS/NSString+ADHelperMethods.h"
-#import "ADMemoryTokenCacheStore.h"
 
+#if !TARGET_OS_IPHONE
+#import "ADMemoryTokenCacheStore.h"
+#endif
 const int sAsyncContextTimeout = 10;
 
 //A simple protocol to expose private methods:
@@ -78,7 +80,9 @@ const int sAsyncContextTimeout = 10;
     [super setUp];
     [self adTestBegin:ADAL_LOG_LEVEL_ERROR];//Majority of the tests rely on errors
     mAuthority = @"https://login.windows.net/msopentechbv.onmicrosoft.com";
+    #if !TARGET_OS_IPHONE
     [ADAuthenticationSettings sharedInstance].defaultTokenCacheStore = [ADMemoryTokenCacheStore new];
+#endif
     mDefaultTokenCache = [ADAuthenticationSettings sharedInstance].defaultTokenCacheStore;
     XCTAssertNotNil(mDefaultTokenCache);
     [ADAuthenticationSettings sharedInstance].credentialsType = AD_CREDENTIALS_EMBEDDED;

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -28,7 +28,7 @@
 #import "../ADALiOS/ADAuthenticationSettings.h"
 #import "../ADALiOS/ADErrorCodes.h"
 #import "../ADALiOS/NSString+ADHelperMethods.h"
-//#import "../ADALiOS/ADKeychainTokenCacheStore.h"
+#import "ADMemoryTokenCacheStore.h"
 
 const int sAsyncContextTimeout = 10;
 
@@ -78,6 +78,7 @@ const int sAsyncContextTimeout = 10;
     [super setUp];
     [self adTestBegin:ADAL_LOG_LEVEL_ERROR];//Majority of the tests rely on errors
     mAuthority = @"https://login.windows.net/msopentechbv.onmicrosoft.com";
+    [ADAuthenticationSettings sharedInstance].defaultTokenCacheStore = [ADMemoryTokenCacheStore new];
     mDefaultTokenCache = [ADAuthenticationSettings sharedInstance].defaultTokenCacheStore;
     XCTAssertNotNil(mDefaultTokenCache);
     [ADAuthenticationSettings sharedInstance].credentialsType = AD_CREDENTIALS_EMBEDDED;

--- a/ADALiOS/ADALiOSTests/ADAuthenticationParametersTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationParametersTests.m
@@ -42,6 +42,7 @@
     // Runs before each test case. Just in case, set them to nil.
     mParameters = nil;
     mError = nil;
+    [ADAuthenticationSettings sharedInstance].requestTimeOut = 5;
 }
 
 - (void)tearDown

--- a/ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m
+++ b/ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m
@@ -108,6 +108,8 @@ const int sAsyncTimeout = 10;//in seconds
         [mValidatedAuthorities addObject:sAlwaysTrusted];
         XCTAssertTrue(mValidatedAuthorities.count == 1);
     }
+    
+    [ADAuthenticationSettings sharedInstance].requestTimeOut = 5;
 }
 
 - (void)tearDown
@@ -431,11 +433,10 @@ const int sAsyncTimeout = 10;//in seconds
 {
     [self adSetLogTolerance:ADAL_LOG_LEVEL_ERROR];
     NSUUID* correlationId = [NSUUID UUID];
-    [self validateAuthority:@"https://MyFakeAuthority.com/MSOpenTechBV.onmicrosoft.com" correlationId:correlationId line:__LINE__];
+    [self validateAuthority:@"https://MyFakeAuthority.microsoft.com/MSOpenTechBV.onmicrosoft.com" correlationId:correlationId line:__LINE__];
     XCTAssertFalse(mValidated);
     XCTAssertNotNil(mError);
     ADAssertLongEquals(AD_ERROR_AUTHORITY_VALIDATION, mError.code);
-    XCTAssertTrue([mError.errorDetails adContainsString:[correlationId UUIDString].lowercaseString]);
 }
 
 -(void) testUnreachableServer

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
@@ -47,7 +47,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
 
 /*! See header for comments */
 -(void) adAssertValidText: (NSString*) text
-                message: (NSString*) message
+                  message: (NSString*) message
 {
     //The pragmas here are copied directly from the XCTAssertNotNil:
     _Pragma("clang diagnostic push")
@@ -61,7 +61,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
 
 /* See header for details. */
 -(void) adValidateForInvalidArgument: (NSString*) argument
-                             error: (ADAuthenticationError*) error
+                               error: (ADAuthenticationError*) error
 {
     XCTAssertNotNil(argument, "Internal test error: please specify the expected parameter.");
     
@@ -80,8 +80,8 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
 
 /* See header for details.*/
 -(void) adValidateFactoryForInvalidArgument: (NSString*) argument
-                           returnedObject: (id) returnedObject
-                                    error: (ADAuthenticationError*) error
+                             returnedObject: (id) returnedObject
+                                      error: (ADAuthenticationError*) error
 {
     XCTAssertNil(returnedObject, "Creator should have returned nil. Object: %@", returnedObject);
     
@@ -101,21 +101,21 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     @synchronized(self.class)
     {
         static dispatch_once_t once = 0;
-
+        
         dispatch_once(&once, ^{
             sLogLevelsLog = [NSMutableString new];
             sMessagesLog = [NSMutableString new];
             sInformationLog = [NSMutableString new];
             sErrorCodesLog = [NSMutableString new];
         });
-
+        
         //Note beginning of the test:
         [sLogLevelsLog appendString:sTestBegin];
         [sMessagesLog appendString:sTestBegin];
         [sInformationLog appendString:sTestBegin];
         [sErrorCodesLog appendString:sTestBegin];
     }
-
+    
     LogCallback logCallback = ^(ADAL_LOG_LEVEL logLevel,
                                 NSString* message,
                                 NSString* additionalInformation,
@@ -138,7 +138,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
             }
         }
     };
-
+    
     
     [ADLogger setLogCallBack:logCallback];
     [ADLogger setLevel:ADAL_LOG_LAST];//Log everything by default. Tests can change this.
@@ -343,6 +343,7 @@ extern void __gcov_flush(void);
     item.clientId = @"client id";
     item.accessToken = @"access token";
     item.refreshToken = @"refresh token";
+    item.sessionKey = nil;
     //1hr into the future:
     item.expiresOn = [NSDate dateWithTimeIntervalSinceNow:3600];
     item.userInformation = [self adCreateUserInformation];
@@ -363,7 +364,7 @@ extern void __gcov_flush(void);
     ADUserInformation* userInfo = [ADUserInformation userInformationWithIdToken:id_token error:&error];
     ADAssertNoError;
     XCTAssertNotNil(userInfo, "Nil user info returned.");
-
+    
     //Check the standard properties:
     ADAssertStringEquals(userInfo.userId, @"boris@msopentechbv.onmicrosoft.com");
     ADAssertStringEquals(userInfo.givenName, @"Boriss");
@@ -402,13 +403,13 @@ extern void __gcov_flush(void);
     
     //Add here calculated properties that cannot be initialized and shouldn't be checked for initialization:
     NSDictionary* const exceptionProperties = @{
-        NSStringFromClass([ADTokenCacheStoreItem class]):[NSSet setWithObjects:@"multiResourceRefreshToken", nil],
-    };
+                                                NSStringFromClass([ADTokenCacheStoreItem class]):[NSSet setWithObjects:@"multiResourceRefreshToken",
+                                                                                                  @"sessionKey",nil], };
     
     //Enumerate all properties and ensure that they are set to non-default values:
     unsigned int propertyCount;
     objc_property_t* properties = class_copyPropertyList([object class], &propertyCount);
-
+    
     for (int i = 0; i < propertyCount; ++i)
     {
         NSString* propertyName = [NSString stringWithCString:property_getName(properties[i])
@@ -438,7 +439,7 @@ extern void __gcov_flush(void);
 }
 
 -(void) adVerifyPropertiesAreSame: (NSObject*) object1
-                         second: (NSObject*) object2
+                           second: (NSObject*) object2
 {
     if ((nil == object1) != (nil == object1))
     {

--- a/MyTestMacOSApp/MyTestMacOSApp/BVAppDelegate.m
+++ b/MyTestMacOSApp/MyTestMacOSApp/BVAppDelegate.m
@@ -288,14 +288,11 @@
         [self appendStatus:error.errorDetails];
         return;
     }
-    
-    [context acquireTokenWithResource:aadInstance.resource
-                             clientId:aadInstance.clientId
-                          redirectUri:[NSURL URLWithString:aadInstance.redirectUri]
-                       promptBehavior:AD_PROMPT_NEVER
-                               userId:aadInstance.userId
-                 extraQueryParameters: aadInstance.extraQueryParameters
-                      completionBlock:^(ADAuthenticationResult *result)
+     
+     [context acquireTokenSilentWithResource:aadInstance.resource
+                                    clientId:aadInstance.clientId
+                                 redirectUri:[NSURL URLWithString:aadInstance.redirectUri]
+                             completionBlock:^(ADAuthenticationResult *result)
      {
          if (result.status != AD_SUCCEEDED)
          {

--- a/MyTestMacOSApp/MyTestMacOSApp/main.m
+++ b/MyTestMacOSApp/MyTestMacOSApp/main.m
@@ -1,10 +1,20 @@
+// Copyright © Microsoft Open Technologies, Inc.
 //
-//  main.m
-//  MyTestMacOSApp
+// All Rights Reserved
 //
-//  Created by Boris Vidolov on 3/6/14.
-//  Copyright (c) 2014 Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
 
 #import <Cocoa/Cocoa.h>
 


### PR DESCRIPTION
move broker changes to OSXUniversal
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RPangrle-MS%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23issuecomment-98897908%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-05-05T01%3A11%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f906fd83f3140a11e28983fa3382b6ee0f431581%20ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m%2015%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29638614%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22I%20look%20forward%20to%20the%20day%20that%20someone%20registers%20myfakeauthority.microsoft.com%20for%20something.%22%2C%20%22created_at%22%3A%20%222015-05-05T01%3A09%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-05-05T18%3A26%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m%3AL433-443%22%7D%2C%20%22Pull%20f906fd83f3140a11e28983fa3382b6ee0f431581%20ADALiOS/ADALiOS/ADAuthenticationContext.m%20647%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29638436%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22self.class%20looks%20REALLY%20weird%20here%2C%20unless%20you%20want%20this%20to%20be%20overridable%20in%20a%20subclass%20I%20would%20use%20ADAuthenticationContext%20%28or%20whatever%20class%20that%27s%20in...%29%20instead.%22%2C%20%22created_at%22%3A%20%222015-05-05T01%3A04%3A04Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-05-05T18%3A26%3A46Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext.m%3AL1089-1096%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23issuecomment-98897908%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29638436%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29638614%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29697585%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310%23discussion_r29697586%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RPangrle-MS'><img src='https://avatars.githubusercontent.com/u/7004783?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull f906fd83f3140a11e28983fa3382b6ee0f431581 ADALiOS/ADALiOS/ADAuthenticationContext.m 647'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310#discussion_r29638436'>File: ADALiOS/ADALiOS/ADAuthenticationContext.m:L1089-1096</a></b>
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> self.class looks REALLY weird here, unless you want this to be overridable in a subclass I would use ADAuthenticationContext (or whatever class that's in...) instead.
- [x] <a href='#crh-comment-Pull f906fd83f3140a11e28983fa3382b6ee0f431581 ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m 15'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310#discussion_r29638614'>File: ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m:L433-443</a></b>
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I look forward to the day that someone registers myfakeauthority.microsoft.com for something.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/310?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/310?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/310?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/310'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>