### PR TITLE
Insert the x-client-Ver query param in ALL THE PLACES!!!!!

### DIFF
--- a/ADALiOS/ADALiOS/ADALiOS.h
+++ b/ADALiOS/ADALiOS/ADALiOS.h
@@ -18,9 +18,16 @@
 
 //iOS does not support resources in client libraries. Hence putting the
 //version in static define until we identify a better place:
-#define ADAL_VER_HIGH   2
-#define ADAL_VER_LOW    0
-#define ADAL_VER_PATCH  0
+#define ADAL_VER_HIGH       2
+#define ADAL_VER_LOW        0
+#define ADAL_VER_PATCH      0
+
+#define STR_ADAL_VER_HIGH   "2"
+#define STR_ADAL_VER_LOW    "0"
+#define STR_ADAL_VER_PATCH  "0"
+
+#define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
+#define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
 
 #import "ADLogger.h"
 #import "ADErrorCodes.h"

--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
@@ -29,6 +29,7 @@
 #import "ADAuthenticationSettings.h"
 #import "ADNTLMHandler.h"
 #import "ADBrokerKeyHelper.h"
+#import "ADHelpers.h"
 
 @implementation ADAuthenticationWebViewController
 {
@@ -79,7 +80,7 @@ NSTimer *timer;
 
 - (void)start
 {
-    NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:_startURL];
+    NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[ADHelpers addClientVersionToURL:_startURL]];
     [_webView loadRequest:request];
 }
 
@@ -95,7 +96,7 @@ NSTimer *timer;
     NSArray * parts = [challengeUrl componentsSeparatedByString:@"?"];
     NSString *qp = [parts objectAtIndex:1];
     NSDictionary* queryParamsMap = [NSDictionary adURLFormDecode:qp];
-    NSString* value = [queryParamsMap valueForKey:@"SubmitUrl"];
+    NSString* value = [ADHelpers addClientVersionToURLString:[queryParamsMap valueForKey:@"SubmitUrl"]];
     
     NSArray * authorityParts = [value componentsSeparatedByString:@"?"];
     NSString *authority = [authorityParts objectAtIndex:0];

--- a/ADALiOS/ADALiOS/ADHelpers.h
+++ b/ADALiOS/ADALiOS/ADHelpers.h
@@ -42,4 +42,7 @@
 
 + (void) removeNullStringFrom:(NSDictionary*) dict;
 
++ (NSURL*)addClientVersionToURL:(NSURL*)url;
++ (NSString*)addClientVersionToURLString:(NSString*)url;
+
 @end

--- a/ADALiOS/ADALiOS/ADHelpers.m
+++ b/ADALiOS/ADALiOS/ADHelpers.m
@@ -260,10 +260,6 @@
         return nil;
     }
     
-    static NSString* adalClient = nil;
-    if (!adalClient)
-        adalClient = [NSString stringWithFormat:@"%@=%@", ADAL_ID_VERSION, ADAL_VERSION_NSSTRING];
-    
     NSString* query = [components query];
     // Don't bother adding it if it's already there
     if (query && [query containsString:ADAL_ID_VERSION])
@@ -273,11 +269,11 @@
     
     if (query)
     {
-        [components setQuery:[query stringByAppendingString:adalClient]];
+        [components setQuery:[query stringByAppendingString:[NSString stringWithFormat:@"&%@=%@", ADAL_ID_VERSION, ADAL_VERSION_NSSTRING]]];
     }
     else
     {
-        [components setQuery:adalClient];
+        [components setQuery:[NSString stringWithFormat:@"%@=%@", ADAL_ID_VERSION, ADAL_VERSION_NSSTRING]];
     }
     
     return [components URL];
@@ -286,7 +282,9 @@
 + (NSString*)addClientVersionToURLString:(NSString*)url
 {
     if (url == nil)
+    {
         return nil;
+    }
     
     return [[self addClientVersionToURL:[NSURL URLWithString:url]] absoluteString];
 }

--- a/ADALiOS/ADALiOS/ADHelpers.m
+++ b/ADALiOS/ADALiOS/ADHelpers.m
@@ -25,6 +25,7 @@
 #import <CommonCrypto/CommonDigest.h>
 
 #include "ADOauth2Constants.h"
+#include "ADALiOS.h"
 
 @implementation ADHelpers
 
@@ -245,5 +246,39 @@
     return tmpFixedInput;
 }
 
++ (NSURL*)addClientVersionToURL:(NSURL*)url
+{
+    if (!url)
+        return nil;
+    
+    // Pull apart the request URL and add the ADAL Client version to the query parameters
+    NSURLComponents* components = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
+    if (!components)
+        return nil;
+    
+    static NSString* adalClient = nil;
+    if (!adalClient)
+        adalClient = [NSString stringWithFormat:@"%@=%@", ADAL_ID_VERSION, ADAL_VERSION_NSSTRING];
+    
+    NSString* query = [components query];
+    // Don't bother adding it if it's already there
+    if (query && [query containsString:ADAL_ID_VERSION])
+        return url;
+    
+    if (query)
+        [components setQuery:[query stringByAppendingString:adalClient]];
+    else
+        [components setQuery:adalClient];
+    
+    return [components URL];
+}
+
++ (NSString*)addClientVersionToURLString:(NSString*)url
+{
+    if (url == nil)
+        return nil;
+    
+    return [[self addClientVersionToURL:[NSURL URLWithString:url]] absoluteString];
+}
 
 @end

--- a/ADALiOS/ADALiOS/ADHelpers.m
+++ b/ADALiOS/ADALiOS/ADHelpers.m
@@ -249,12 +249,16 @@
 + (NSURL*)addClientVersionToURL:(NSURL*)url
 {
     if (!url)
+    {
         return nil;
+    }
     
     // Pull apart the request URL and add the ADAL Client version to the query parameters
     NSURLComponents* components = [[NSURLComponents alloc] initWithURL:url resolvingAgainstBaseURL:NO];
     if (!components)
+    {
         return nil;
+    }
     
     static NSString* adalClient = nil;
     if (!adalClient)
@@ -263,12 +267,18 @@
     NSString* query = [components query];
     // Don't bother adding it if it's already there
     if (query && [query containsString:ADAL_ID_VERSION])
+    {
         return url;
+    }
     
     if (query)
+    {
         [components setQuery:[query stringByAppendingString:adalClient]];
+    }
     else
+    {
         [components setQuery:adalClient];
+    }
     
     return [components URL];
 }

--- a/ADALiOS/ADALiOS/ADLogger.m
+++ b/ADALiOS/ADALiOS/ADLogger.m
@@ -194,10 +194,9 @@ additionalInformation: (NSString*) additionalInformation
     return requestCorrelationId;
 }
 
-
 +(NSString*) getAdalVersion
 {
-    return [NSString stringWithFormat:@"%d.%d.%d", ADAL_VER_HIGH, ADAL_VER_LOW, ADAL_VER_PATCH];
+    return ADAL_VERSION_NSSTRING;
 }
 
 +(void) logToken: (NSString*) token

--- a/ADALiOS/ADALiOS/ADWebRequest.m
+++ b/ADALiOS/ADALiOS/ADWebRequest.m
@@ -24,6 +24,7 @@
 #import "ADWebRequest.h"
 #import "ADWebResponse.h"
 #import "ADAuthenticationSettings.h"
+#import "ADHelpers.h"
 
 NSString *const HTTPGet  = @"GET";
 NSString *const HTTPPost = @"POST";
@@ -163,9 +164,12 @@ static NSOperationQueue *s_queue;
         [_requestHeaders setValue:[NSString stringWithFormat:@"%ld", (unsigned long)_requestData.length] forKey:@"Content-Length"];
     }
     
-    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:_requestURL
+    NSURL* requestURL = [ADHelpers addClientVersionToURL:_requestURL];
+    
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestURL
                                                                 cachePolicy:NSURLRequestReloadIgnoringCacheData
                                                             timeoutInterval:_timeout];
+    
     request.HTTPMethod          = _requestMethod;
     request.allHTTPHeaderFields = _requestHeaders;
     request.HTTPBody            = _requestData;
@@ -237,9 +241,12 @@ static NSOperationQueue *s_queue;
 {
 #pragma unused(connection)
 #pragma unused(redirectResponse)
+    NSURL* requestURL = [request URL];
+    NSURL* modifiedURL = [ADHelpers addClientVersionToURL:requestURL];
+    if (modifiedURL == requestURL)
+        return request;
     
-    // Allow redirects
-    return request;
+    return [NSURLRequest requestWithURL:modifiedURL];
 }
 
 - (void)connectionDidFinishLoading:(NSURLConnection *)connection


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23issuecomment-108672973%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31750622%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31751012%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31752581%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31752897%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31754999%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31755383%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31774906%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23issuecomment-108672973%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40RPangrle-MS__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3EYou%27ve%20already%20signed%20the%20contribution%20license%20agreement.%20Thanks%21%3C/span%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%3Cp%3EThe%20agreement%20was%20validated%20by%20Microsoft%20Open%20Technologies%2C%20Inc.%20and%20real%20humans%20are%20currently%20evaluating%20your%20PR.%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-04T01%3A35%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2014627672b90a2f5d8c6b02f690553413a7e393dc%20ADALiOS/ADALiOS/ADHelpers.m%2014%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31750622%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20will%20be%20better%20to%20have%20single%20line%20or%20use%20parentheses.%5Cr%5Cn%5Cr%5CnOther%20lines%20also%20need%20modification%20for%20that.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-04T18%3A33%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22Are%20you%20saying%20you%27d%20prefer%20to%20see%3A%5Cr%5Cnif%20%28%21url%29%20return%20nil%3B%5Cr%5Cnall%20on%20a%20single%20line%3F%5Cr%5Cn%5Cr%5CnWhen%20it%27s%20just%20simple%20error-check/return%20I%20prefer%20to%20keep%20it%20to%20two%20lines%2C%20otherwise%20they%20can%20start%20to%20crowd%20out%20the%20business%20logic%20code%22%2C%20%22created_at%22%3A%20%222015-06-04T18%3A53%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22Please%20use%20%7B%7D%20and%20multiple%20lines%20-%20There%20is%20no%20exception%20for%20this%20rule.%22%2C%20%22created_at%22%3A%20%222015-06-04T19%3A14%3A56Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8271516%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/sdabbiru%22%7D%7D%2C%20%7B%22body%22%3A%20%22%2B1%20for%20%40sdabbiru%27s%20comment%22%2C%20%22created_at%22%3A%20%222015-06-04T19%3A19%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/5713915%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/kpanwar%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-04T23%3A03%3A20Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADHelpers.m%3AL246-285%22%7D%2C%20%22Pull%2014627672b90a2f5d8c6b02f690553413a7e393dc%20ADALiOS/ADALiOS/ADWebRequest.m%2028%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332%23discussion_r31751012%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20it%20say%20equal%20for%20%5C%22http%3A//somesite.com%5C%22%20and%20%5C%22http%3A//somesite.com/%5C%22%20%3F%20You%20may%20need%20to%20normalize%20the%20url%20before%20comparing.%22%2C%20%22created_at%22%3A%20%222015-06-04T18%3A37%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20%3D%3D%20is%20pointer%20equality%2C%20if%20the%20pointer%20didn%27t%20change%20then%20I%20didn%27t%20change%20the%20URL.%20There%27s%20no%20operator%20overloading%20in%20ObjC%22%2C%20%22created_at%22%3A%20%222015-06-04T18%3A51%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADWebRequest.m%3AL241-253%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332#issuecomment-108672973'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@RPangrle-MS__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>You've already signed the contribution license agreement. Thanks!</span>
<p>The agreement was validated by Microsoft Open Technologies, Inc. and real humans are currently evaluating your PR.</p>
TTYL, MSOTBOT;
- [ ] <a href='#crh-comment-Pull 14627672b90a2f5d8c6b02f690553413a7e393dc ADALiOS/ADALiOS/ADWebRequest.m 28'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332#discussion_r31751012'>File: ADALiOS/ADALiOS/ADWebRequest.m:L241-253</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> Does it say equal for "http://somesite.com" and "http://somesite.com/" ? You may need to normalize the url before comparing.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> That == is pointer equality, if the pointer didn't change then I didn't change the URL. There's no operator overloading in ObjC
- [x] <a href='#crh-comment-Pull 14627672b90a2f5d8c6b02f690553413a7e393dc ADALiOS/ADALiOS/ADHelpers.m 14'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332#discussion_r31750622'>File: ADALiOS/ADALiOS/ADHelpers.m:L246-285</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It will be better to have single line or use parentheses.
Other lines also need modification for that.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Are you saying you'd prefer to see:
if (!url) return nil;
all on a single line?
When it's just simple error-check/return I prefer to keep it to two lines, otherwise they can start to crowd out the business logic code
- <a href='https://github.com/sdabbiru'><img border=0 src='https://avatars.githubusercontent.com/u/8271516?v=3' height=16 width=16'></a> Please use {} and multiple lines - There is no exception for this rule.
- <a href='https://github.com/kpanwar'><img border=0 src='https://avatars.githubusercontent.com/u/5713915?v=3' height=16 width=16'></a> +1 for @sdabbiru's comment


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/332?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/332?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/332'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>