### PR TITLE
silent network calls

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.h
@@ -57,6 +57,19 @@
                     correlationId: (NSUUID*) correlationId
                   completionBlock: (ADAuthenticationCallback)completionBlock;
 
+// This version allows "silent" requests where it will attempt to make the network call and fail if any user interaction
+// is required
+- (void) requestTokenWithResource: (NSString*) resource
+                         clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
+                   promptBehavior: (ADPromptBehavior) promptBehavior
+                      allowSilent: (BOOL) allowSilent
+                           userId: (NSString*) userId
+                            scope: (NSString*) scope
+             extraQueryParameters: (NSString*) queryParams
+                    correlationId: (NSUUID*) correlationId
+                  completionBlock: (ADAuthenticationCallback)completionBlock;
+
 // Generic OAuth2 Authorization Request, obtains a token from an authorization code.
 - (void)requestTokenByCode:(NSString *)code
                   resource:(NSString *)resource

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.m
@@ -156,6 +156,7 @@
                     correlationId: (NSUUID*) correlationId
                   completionBlock: (ADAuthenticationCallback)completionBlock
 {
+#if !AD_BROKER
     if (silent)
     {
         //The cache lookup and refresh token attempt have been unsuccessful,
@@ -169,7 +170,32 @@
         completionBlock(result);
         return;
     }
+#endif
     
+    [self requestTokenWithResource:resource
+                          clientId:clientId
+                       redirectUri:redirectUri
+                    promptBehavior:promptBehavior
+                       allowSilent:silent
+                            userId:userId
+                             scope:scope
+              extraQueryParameters:queryParams
+                     correlationId:correlationId
+                   completionBlock:completionBlock];
+}
+
+- (void) requestTokenWithResource: (NSString*) resource
+                         clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
+                   promptBehavior: (ADPromptBehavior) promptBehavior
+                      allowSilent: (BOOL) allowSilent
+                           userId: (NSString*) userId
+                            scope: (NSString*) scope
+             extraQueryParameters: (NSString*) queryParams
+                    correlationId: (NSUUID*) correlationId
+                  completionBlock: (ADAuthenticationCallback)completionBlock
+{
+#if !AD_BROKER
     //call the broker.
     if([ADAuthenticationContext canUseBroker]){
         [self callBrokerForAuthority:self.authority
@@ -183,6 +209,7 @@
          ];
         return;
     }
+#endif
     
     //Get the code first:
     [self requestCodeByResource:resource
@@ -192,6 +219,8 @@
                          userId:userId
                  promptBehavior:promptBehavior
            extraQueryParameters:queryParams
+         refreshTokenCredential:nil
+                         silent:allowSilent
                   correlationId:correlationId
                      completion:^(NSString * code, ADAuthenticationError *error)
      {

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.h
@@ -65,4 +65,16 @@
                 correlationId:(NSUUID*)correlationId
                    completion:(ADAuthorizationCodeCallback)completionBlock;
 
+- (void)requestCodeByResource:(NSString*)resource
+                     clientId:(NSString*)clientId
+                  redirectUri:(NSURL*)redirectUri
+                        scope:(NSString*)scope /*for future use */
+                       userId:(NSString*)userId
+               promptBehavior:(ADPromptBehavior)promptBehavior
+         extraQueryParameters:(NSString*)queryParams
+       refreshTokenCredential:(NSString*)refreshTokenCredential
+                       silent:(BOOL)silent
+                correlationId:(NSUUID*)correlationId
+                   completion:(ADAuthorizationCodeCallback)completionBlock;
+
 @end

--- a/ADALiOS/ADALiOS/ADWebResponse.h
+++ b/ADALiOS/ADALiOS/ADWebResponse.h
@@ -18,10 +18,12 @@
 
 @interface ADWebResponse : NSObject
 
-@property (strong, readonly) NSDictionary *headers;
-@property (strong, readonly) NSData       *body;
-@property (readonly) NSInteger     statusCode;
+@property (strong, readonly) NSDictionary * headers;
+@property (strong, readonly) NSData * body;
+@property (readonly) NSInteger statusCode;
 
 - (id)initWithResponse:(NSHTTPURLResponse *)response data:(NSData *)data;
+
+- (NSURL*)URL;
 
 @end

--- a/ADALiOS/ADALiOS/ADWebResponse.m
+++ b/ADALiOS/ADALiOS/ADWebResponse.m
@@ -60,4 +60,9 @@
     return _response.statusCode;
 }
 
+- (NSURL*)URL
+{
+    return [_response URL];
+}
+
 @end


### PR DESCRIPTION
Add the ability (in broker only) for the acquireTokenSilent calls to perform a NSURLRequest to see if it's able to get codes without user interaction using any cookie or session statement that might be around.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/333%23issuecomment-110539693%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/333%23issuecomment-110937493%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/333%23issuecomment-110539693%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40RPangrle-MS__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3EYou%27ve%20already%20signed%20the%20contribution%20license%20agreement.%20Thanks%21%3C/span%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%3Cp%3EThe%20agreement%20was%20validated%20by%20Microsoft%20Open%20Technologies%2C%20Inc.%20and%20real%20humans%20are%20currently%20evaluating%20your%20PR.%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-10T00%3A07%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-10T22%3A37%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/omercs%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/omercs'><img src='https://avatars.githubusercontent.com/u/466805?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/333#issuecomment-110539693'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@RPangrle-MS__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>You've already signed the contribution license agreement. Thanks!</span>
<p>The agreement was validated by Microsoft Open Technologies, Inc. and real humans are currently evaluating your PR.</p>
TTYL, MSOTBOT;


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/333?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/333?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/333?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/333'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>