### PR TITLE
ADUserIdentifier support

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -94,6 +94,8 @@
 		D6E43A701B040A9C000F5BE2 /* ADAuthenticationContext+AcquireAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A6F1B040A9C000F5BE2 /* ADAuthenticationContext+AcquireAssertion.m */; };
 		D6E43A731B040ED5000F5BE2 /* ADAuthenticationContext+WebRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A721B040ED5000F5BE2 /* ADAuthenticationContext+WebRequest.m */; };
 		D6E43A761B04142C000F5BE2 /* ADAuthenticationContext+Broker.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A751B04142C000F5BE2 /* ADAuthenticationContext+Broker.m */; };
+		D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
+		D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */ = {isa = PBXBuildFile; fileRef = D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -104,6 +106,13 @@
 			remoteGlobalIDString = 8B0965A917F25770002BDFB8;
 			remoteInfo = ADALiOS;
 		};
+		D6FB3E3E1B3101150032F883 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B0965B917F25770002BDFB8;
+			remoteInfo = ADALiOSTests;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -113,6 +122,7 @@
 			dstPath = "Headers/$(PRODUCT_NAME)";
 			dstSubfolderSpec = 16;
 			files = (
+				D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */,
 				97DFE4671AE38903008109E1 /* ADAL.h in Copy Files */,
 				8BBE6FAE193EA1C60039C23E /* ADAuthenticationBroker.h in Copy Files */,
 				8B79592118F5ECA700EBF96E /* ADLogger.h in Copy Files */,
@@ -272,6 +282,8 @@
 		D6E43A721B040ED5000F5BE2 /* ADAuthenticationContext+WebRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationContext+WebRequest.m"; sourceTree = "<group>"; };
 		D6E43A741B04142C000F5BE2 /* ADAuthenticationContext+Broker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+Broker.h"; sourceTree = "<group>"; };
 		D6E43A751B04142C000F5BE2 /* ADAuthenticationContext+Broker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationContext+Broker.m"; sourceTree = "<group>"; };
+		D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADUserIdentifier.h; sourceTree = "<group>"; };
+		D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADUserIdentifier.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -411,6 +423,8 @@
 				9727D4D21A8753C300774236 /* ADJwtHelper.m */,
 				971C56BC1AF2278C0034820F /* ADBrokerNotificationManager.h */,
 				971C56BD1AF2278C0034820F /* ADBrokerNotificationManager.m */,
+				D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */,
+				D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */,
 			);
 			path = ADALiOS;
 			sourceTree = "<group>";
@@ -592,6 +606,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				D6FB3E3F1B3101150032F883 /* PBXTargetDependency */,
 			);
 			name = ADALiOS;
 			productName = ADALiOS;
@@ -730,6 +745,7 @@
 				D6E43A671B04015A000F5BE2 /* ADAuthenticationContext+AcquireToken.m in Sources */,
 				8BB8346218074CFA007F9F0D /* ADAuthenticationParameters.m in Sources */,
 				8B8FD79B188223770070B1BE /* ADKeychainTokenCacheStore.m in Sources */,
+				D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */,
 				8B92DB70181B2335004AAB0E /* ADLogger.m in Sources */,
 				8B5989551811B89800744AEE /* ADTokenCacheStoreKey.m in Sources */,
 				8B0DA7DE182AD01100CF5E1E /* ADAuthenticationResult+Internal.m in Sources */,
@@ -791,6 +807,11 @@
 			isa = PBXTargetDependency;
 			target = 8B0965A917F25770002BDFB8 /* ADALiOS */;
 			targetProxy = 8B0965C017F25770002BDFB8 /* PBXContainerItemProxy */;
+		};
+		D6FB3E3F1B3101150032F883 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 8B0965B917F25770002BDFB8 /* ADALiOSTests */;
+			targetProxy = D6FB3E3E1B3101150032F883 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -106,13 +106,6 @@
 			remoteGlobalIDString = 8B0965A917F25770002BDFB8;
 			remoteInfo = ADALiOS;
 		};
-		D6FB3E3E1B3101150032F883 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8B0965B917F25770002BDFB8;
-			remoteInfo = ADALiOSTests;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -606,7 +599,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				D6FB3E3F1B3101150032F883 /* PBXTargetDependency */,
 			);
 			name = ADALiOS;
 			productName = ADALiOS;
@@ -807,11 +799,6 @@
 			isa = PBXTargetDependency;
 			target = 8B0965A917F25770002BDFB8 /* ADALiOS */;
 			targetProxy = 8B0965C017F25770002BDFB8 /* PBXContainerItemProxy */;
-		};
-		D6FB3E3F1B3101150032F883 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8B0965B917F25770002BDFB8 /* ADALiOSTests */;
-			targetProxy = D6FB3E3E1B3101150032F883 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/ADALiOS/ADALiOS/ADAL.h
+++ b/ADALiOS/ADALiOS/ADAL.h
@@ -29,3 +29,4 @@
 #import "ADAuthenticationBroker.h"
 #import "ADErrorCodes.h"
 #import "ADAuthenticationParameters.h"
+#import "ADUserIdentifier.h"

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireAssertion.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireAssertion.h
@@ -29,6 +29,17 @@
                            correlationId:(NSUUID*)correlationId
                          completionBlock:(ADAuthenticationCallback)completionBlock;
 
+- (void)internalAcquireTokenForAssertion:(NSString*)samlAssertion
+                                clientId:(NSString*)clientId
+                             redirectUri:(NSString*)redirectUri
+                                resource:(NSString*)resource
+                           assertionType:(ADAssertionType)assertionType
+                          userIdentifier:(ADUserIdentifier*)userId
+                                   scope:(NSString*)scope
+                       validateAuthority:(BOOL)validateAuthority
+                           correlationId:(NSUUID*)correlationId
+                         completionBlock:(ADAuthenticationCallback)completionBlock;
+
 // Generic OAuth2 Authorization Request, obtains a token from a SAML assertion.
 - (void)requestTokenByAssertion:(NSString *)samlAssertion
                   assertionType:(ADAssertionType)assertionType

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireAssertion.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireAssertion.m
@@ -18,6 +18,7 @@
 
 #import "ADAuthenticationContext+Internal.h"
 #import "ADInstanceDiscovery.h"
+#import "ADUserIdentifier.h"
 
 @implementation ADAuthenticationContext (AcquireAssertion)
 
@@ -27,6 +28,30 @@
                                 resource:(NSString*)resource
                            assertionType:(ADAssertionType)assertionType
                                   userId:(NSString*)userId
+                                   scope:(NSString*)scope
+                       validateAuthority:(BOOL)validateAuthority
+                           correlationId:(NSUUID*)correlationId
+                         completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    ADUserIdentifier* identifier = [ADUserIdentifier identifierWithId:userId];
+    
+    [self internalAcquireTokenForAssertion:samlAssertion
+                                  clientId:clientId
+                               redirectUri:redirectUri
+                                  resource:resource
+                             assertionType:assertionType
+                            userIdentifier:identifier
+                                     scope:scope
+                         validateAuthority:validateAuthority
+                             correlationId:correlationId
+                           completionBlock:completionBlock];
+}
+- (void)internalAcquireTokenForAssertion:(NSString*)samlAssertion
+                                clientId:(NSString*)clientId
+                             redirectUri:(NSString*)redirectUri
+                                resource:(NSString*)resource
+                           assertionType:(ADAssertionType)assertionType
+                          userIdentifier:(ADUserIdentifier*)userId
                                    scope:(NSString*)scope
                        validateAuthority:(BOOL)validateAuthority
                            correlationId:(NSUUID*)correlationId
@@ -81,7 +106,7 @@
                                redirectUri: (NSString*) redirectUri
                                   resource: (NSString*) resource
                              assertionType: (ADAssertionType) assertionType
-                                    userId: (NSString*) userId
+                                    userId: (ADUserIdentifier*)userId
                                      scope: (NSString*) scope
                              correlationId: (NSUUID*) correlationId
                            completionBlock: (ADAuthenticationCallback)completionBlock

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.h
@@ -32,13 +32,25 @@
                            correlationId:(NSUUID*)correlationId
                          completionBlock:(ADAuthenticationCallback)completionBlock;
 
+- (void)internalAcquireTokenWithResource:(NSString*)resource
+                                clientId:(NSString*)clientId
+                             redirectUri:(NSURL*)redirectUri
+                          promptBehavior:(ADPromptBehavior)promptBehavior
+                                  silent:(BOOL)silent /* Do not show web UI for authorization. */
+                          userIdentifier:(ADUserIdentifier*)userId
+                                   scope:(NSString*)scope
+                    extraQueryParameters:(NSString*)queryParams
+                       validateAuthority:(BOOL)validateAuthority
+                           correlationId:(NSUUID*)correlationId
+                         completionBlock:(ADAuthenticationCallback)completionBlock;
+
 // For use after the authority has been validated
 - (void)validatedAcquireTokenWithResource:(NSString*)resource
                                  clientId:(NSString*)clientId
                               redirectUri:(NSURL*)redirectUri
                            promptBehavior:(ADPromptBehavior)promptBehavior
                                    silent:(BOOL)silent /* Do not show web UI for authorization. */
-                                   userId:(NSString*)userId
+                                   userId:(ADUserIdentifier*)userId
                                     scope:(NSString*)scope
                      extraQueryParameters:(NSString*)queryParams
                             correlationId:(NSUUID*)correlationId
@@ -51,7 +63,7 @@
                       redirectUri: (NSURL*) redirectUri
                    promptBehavior: (ADPromptBehavior) promptBehavior
                            silent: (BOOL) silent /* Do not show web UI for authorization. */
-                           userId: (NSString*) userId
+                           userId: (ADUserIdentifier*)userId
                             scope: (NSString*) scope
              extraQueryParameters: (NSString*) queryParams
                     correlationId: (NSUUID*) correlationId
@@ -64,7 +76,7 @@
                       redirectUri: (NSURL*) redirectUri
                    promptBehavior: (ADPromptBehavior) promptBehavior
                       allowSilent: (BOOL) allowSilent
-                           userId: (NSString*) userId
+                           userId: (ADUserIdentifier*)userId
                             scope: (NSString*) scope
              extraQueryParameters: (NSString*) queryParams
                     correlationId: (NSUUID*) correlationId
@@ -84,7 +96,7 @@
                                   clientId:(NSString*)clientId
                                redirectUri:(NSString*)redirectUri
                                   resource:(NSString*)resource
-                                    userId:(NSString*)userId
+                                    userId:(ADUserIdentifier*)userId
                                  cacheItem:(ADTokenCacheStoreItem*)cacheItem
                          validateAuthority:(BOOL)validateAuthority
                              correlationId:(NSUUID*)correlationId

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+AcquireToken.m
@@ -19,22 +19,51 @@
 #import "ADAuthenticationContext+Internal.h"
 #import "ADInstanceDiscovery.h"
 #import "ADHelpers.h"
+#import "ADUserIdentifier.h"
 
 @implementation ADAuthenticationContext (AcquireToken)
 
 #pragma mark -
 #pragma mark AcquireToken
-- (void)internalAcquireTokenWithResource: (NSString*) resource
-                                clientId: (NSString*) clientId
-                             redirectUri: (NSURL*) redirectUri
-                          promptBehavior: (ADPromptBehavior) promptBehavior
-                                  silent: (BOOL) silent /* Do not show web UI for authorization. */
-                                  userId: (NSString*) userId
-                                   scope: (NSString*) scope
-                    extraQueryParameters: (NSString*) queryParams
-                       validateAuthority: (BOOL) validateAuthority
-                           correlationId: (NSUUID*) correlationId
-                         completionBlock: (ADAuthenticationCallback)completionBlock
+- (void)internalAcquireTokenWithResource:(NSString*)resource
+                                clientId:(NSString*)clientId
+                             redirectUri:(NSURL*)redirectUri
+                          promptBehavior:(ADPromptBehavior)promptBehavior
+                                  silent:(BOOL)silent /* Do not show web UI for authorization. */
+                                  userId:(NSString*)userId
+                                   scope:(NSString*)scope
+                    extraQueryParameters:(NSString*)queryParams
+                       validateAuthority:(BOOL)validateAuthority
+                           correlationId:(NSUUID*)correlationId
+                         completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    ADUserIdentifier* identifier = [ADUserIdentifier identifierWithId:userId
+                                                                 type:RequiredDisplayableId];
+    [self internalAcquireTokenWithResource:resource
+                                  clientId:clientId
+                               redirectUri:redirectUri
+                            promptBehavior:promptBehavior
+                                    silent:silent
+                            userIdentifier:identifier
+                                     scope:scope
+                      extraQueryParameters:queryParams
+                         validateAuthority:validateAuthority
+                             correlationId:correlationId
+                           completionBlock:completionBlock];
+    
+}
+
+- (void)internalAcquireTokenWithResource:(NSString*)resource
+                                clientId:(NSString*)clientId
+                             redirectUri:(NSURL*)redirectUri
+                          promptBehavior:(ADPromptBehavior)promptBehavior
+                                  silent:(BOOL)silent /* Do not show web UI for authorization. */
+                          userIdentifier:(ADUserIdentifier*)userId
+                                   scope:(NSString*)scope
+                    extraQueryParameters:(NSString*)queryParams
+                       validateAuthority:(BOOL)validateAuthority
+                           correlationId:(NSUUID*)correlationId
+                         completionBlock:(ADAuthenticationCallback)completionBlock
 {
     THROW_ON_NIL_ARGUMENT(completionBlock);
     HANDLE_ARGUMENT(resource);
@@ -84,7 +113,7 @@
                               redirectUri:(NSURL*)redirectUri
                            promptBehavior:(ADPromptBehavior)promptBehavior
                                    silent:(BOOL)silent /* Do not show web UI for authorization. */
-                                   userId:(NSString*)userId
+                                   userId:(ADUserIdentifier*)userId
                                     scope:(NSString*)scope
                      extraQueryParameters:(NSString*)queryParams
                             correlationId:(NSUUID*)correlationId
@@ -145,16 +174,16 @@
                    completionBlock:completionBlock];
 }
 
-- (void) requestTokenWithResource: (NSString*) resource
-                         clientId: (NSString*) clientId
-                      redirectUri: (NSURL*) redirectUri
-                   promptBehavior: (ADPromptBehavior) promptBehavior
-                           silent: (BOOL) silent /* Do not show web UI for authorization. */
-                           userId: (NSString*) userId
-                            scope: (NSString*) scope
-             extraQueryParameters: (NSString*) queryParams
-                    correlationId: (NSUUID*) correlationId
-                  completionBlock: (ADAuthenticationCallback)completionBlock
+- (void) requestTokenWithResource:(NSString*)resource
+                         clientId:(NSString*)clientId
+                      redirectUri:(NSURL*)redirectUri
+                   promptBehavior:(ADPromptBehavior)promptBehavior
+                           silent:(BOOL)silent /* Do not show web UI for authorization. */
+                           userId:(ADUserIdentifier*)userId
+                            scope:(NSString*)scope
+             extraQueryParameters:(NSString*)queryParams
+                    correlationId:(NSUUID*)correlationId
+                  completionBlock:(ADAuthenticationCallback)completionBlock
 {
 #if !AD_BROKER
     if (silent)
@@ -184,16 +213,16 @@
                    completionBlock:completionBlock];
 }
 
-- (void) requestTokenWithResource: (NSString*) resource
-                         clientId: (NSString*) clientId
-                      redirectUri: (NSURL*) redirectUri
-                   promptBehavior: (ADPromptBehavior) promptBehavior
-                      allowSilent: (BOOL) allowSilent
-                           userId: (NSString*) userId
-                            scope: (NSString*) scope
-             extraQueryParameters: (NSString*) queryParams
-                    correlationId: (NSUUID*) correlationId
-                  completionBlock: (ADAuthenticationCallback)completionBlock
+- (void) requestTokenWithResource:(NSString*) resource
+                         clientId:(NSString*) clientId
+                      redirectUri:(NSURL*) redirectUri
+                   promptBehavior:(ADPromptBehavior) promptBehavior
+                      allowSilent:(BOOL) allowSilent
+                           userId:(ADUserIdentifier*)userId
+                            scope:(NSString*) scope
+             extraQueryParameters:(NSString*) queryParams
+                    correlationId:(NSUUID*) correlationId
+                  completionBlock:(ADAuthenticationCallback)completionBlock
 {
 #if !AD_BROKER
     //call the broker.
@@ -274,7 +303,7 @@
                                   clientId:(NSString*)clientId
                                redirectUri:(NSString*)redirectUri
                                   resource:(NSString*)resource
-                                    userId:(NSString*)userId
+                                    userId:(ADUserIdentifier*)userId
                                  cacheItem:(ADTokenCacheStoreItem*)cacheItem
                          validateAuthority:(BOOL)validateAuthority
                              correlationId:(NSUUID*)correlationId
@@ -320,14 +349,14 @@
                               completionBlock:completionBlock];
 }
 
-- (void) validatedAcquireTokenByRefreshToken: (NSString*) refreshToken
-                                    clientId: (NSString*) clientId
-                                 redirectUri: (NSString*) redirectUri
-                                    resource: (NSString*) resource
-                                      userId: (NSString*) userId
-                                   cacheItem: (ADTokenCacheStoreItem*) cacheItem
-                               correlationId: correlationId
-                             completionBlock: (ADAuthenticationCallback)completionBlock
+- (void) validatedAcquireTokenByRefreshToken:(NSString*) refreshToken
+                                    clientId:(NSString*) clientId
+                                 redirectUri:(NSString*) redirectUri
+                                    resource:(NSString*) resource
+                                      userId:(ADUserIdentifier*)userId
+                                   cacheItem:(ADTokenCacheStoreItem*) cacheItem
+                               correlationId:(NSUUID*)correlationId
+                             completionBlock:(ADAuthenticationCallback)completionBlock
 {
     [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:nil];
     //Fill the data for the token refreshing:

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Broker.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Broker.h
@@ -26,7 +26,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                       resource:(NSString*)resource
                       clientId:(NSString*)clientId
                    redirectUri:(NSURL*)redirectUri
-                        userId:(NSString*)userId
+                        userId:(ADUserIdentifier*)userId
           extraQueryParameters:(NSString*)queryParams
                  correlationId:(NSString*)correlationId
                completionBlock:(ADAuthenticationCallback)completionBlock;
@@ -35,7 +35,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                               resource:(NSString*)resource
                               clientId:(NSString*)clientId
                            redirectUri:(NSURL*)redirectUri
-                                userId:(NSString*)userId
+                                userId:(ADUserIdentifier*)userId
                   extraQueryParameters:(NSString*)queryParams
                          correlationId:(NSUUID*)correlationId
                        completionBlock:(ADAuthenticationCallback)completionBlock;

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Broker.m
@@ -24,6 +24,7 @@
 #import "NSString+ADHelperMethods.h"
 #import "ADPkeyAuthHelper.h"
 #import "ADHelpers.h"
+#import "ADUserIdentifier.h"
 
 @implementation ADAuthenticationContext (Broker)
 
@@ -151,27 +152,13 @@
                                         authenticationContextWithAuthority:result.tokenCacheStoreItem.authority
                                         error:nil];
         
-        SEL selector = @selector(updateCacheToResult:cacheItem:withRefreshToken:);
-        NSInvocation *inv = [NSInvocation invocationWithMethodSignature:[ctx methodSignatureForSelector:selector]];
-        [inv setSelector:selector];
-        [inv setTarget:ctx];
-        [inv setArgument:&result atIndex:2];
-        [inv invoke];
+        [ctx updateCacheToResult:result
+                       cacheItem:nil
+                withRefreshToken:nil];
         
         NSString* userId = [queryParamsMap valueForKey:@"user_id"];
-        selector = nil;
-        selector = @selector(updateResult:toUser:);
-        inv = nil;
-        inv = [NSInvocation invocationWithMethodSignature:[ctx methodSignatureForSelector:selector]];
-        [inv setSelector:selector];
-        [inv setTarget:ctx];
-        [inv setArgument:&result atIndex:2];
-        if(userId)
-        {
-            [inv setArgument:&userId atIndex:3];
-        }
-        
-        [inv invoke];
+        [ctx updateResult:result
+                   toUser:[ADUserIdentifier identifierWithId:userId]];
     }
     
     completionBlock(result);
@@ -182,7 +169,7 @@
                       resource:(NSString*)resource
                       clientId:(NSString*)clientId
                    redirectUri:(NSURL*)redirectUri
-                        userId:(NSString*)userId
+                        userId:(ADUserIdentifier*)userId
           extraQueryParameters:(NSString*)queryParams
                  correlationId:(NSString*)correlationId
                completionBlock:(ADAuthenticationCallback)completionBlock
@@ -220,7 +207,8 @@
                                       @"resource" : resource,
                                       @"client_id": clientId,
                                       @"redirect_uri": redirectUriStr,
-                                      @"username": userId ? userId : @"",
+                                      @"username_type": userId ? [userId typeAsString] : @"",
+                                      @"username": userId.userId ? userId.userId : @"",
                                       @"correlation_id": correlationId,
                                       @"broker_key": base64UrlKey,
                                       @"client_version": adalVersion,
@@ -251,7 +239,7 @@
                               resource:(NSString*)resource
                               clientId:(NSString*)clientId
                            redirectUri:(NSURL*)redirectUri
-                                userId:(NSString*)userId
+                                userId:(ADUserIdentifier*)userId
                   extraQueryParameters:(NSString*)queryParams
                          correlationId:(NSUUID*)correlationId
                        completionBlock:(ADAuthenticationCallback)completionBlock
@@ -289,7 +277,8 @@
                                       @"resource" : resource,
                                       @"client_id": clientId,
                                       @"redirect_uri": redirectUriStr,
-                                      @"username": userId ? userId : @"",
+                                      @"username_type": userId ? [userId typeAsString] : @"",
+                                      @"username": userId.userId ? userId.userId : @"",
                                       @"correlation_id": correlationIdStr,
                                       @"broker_key": base64UrlKey,
                                       @"client_version": adalVersion,

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.h
@@ -30,6 +30,8 @@
 
 #import "ADALiOS.h"
 
+@class ADUserIdentifier;
+
 #import "ADAuthenticationContext.h"
 #import "ADAuthenticationContext+AcquireToken.h"
 #import "ADAuthenticationContext+AcquireAssertion.h"
@@ -41,7 +43,6 @@
 #import "ADOAuth2Constants.h"
 
 typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
-
 
 extern NSString* const ADUnknownError;
 extern NSString* const ADCredentialsNeeded;
@@ -71,7 +72,7 @@ extern NSString* const ADRedirectUriInvalidError;
 + (BOOL)isForcedAuthorization:(ADPromptBehavior)prompt;
 
 - (ADAuthenticationResult*)updateResult:(ADAuthenticationResult*)result
-                                 toUser:(NSString*) userId;
+                                 toUser:(ADUserIdentifier*)userId;
 
 - (NSUUID*)getCorrelationId;
 - (void)setCorrelationId:(NSUUID*)correlationId;

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
@@ -133,6 +133,12 @@ static BOOL isCorrelationIdUserProvided = NO;
     
     ADUserInformation* userInfo = [[result tokenCacheStoreItem] userInformation];
     
+    if (!userInfo || ![userId userIdMatchString:userInfo])
+    {
+        // TODO: This behavior is questionable. Look into removing.
+        return result;
+    }
+    
     if (![ADUserIdentifier identifier:userId matchesInfo:userInfo])
     {
         NSString* errorText = [NSString stringWithFormat:@"Different user was authenticated. Expected: '%@'; Actual: '%@'. Either the user entered credentials for different user, or cookie for different logged user is present. Consider calling acquireToken with AD_PROMPT_ALWAYS to ignore the cookie.",

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
@@ -17,6 +17,7 @@
 // governing permissions and limitations under the License.
 
 #import "ADAuthenticationContext+Internal.h"
+#import "ADUserIdentifier.h"
 
 NSString* const ADUnknownError = @"Uknown error.";
 NSString* const ADCredentialsNeeded = @"The user credentials are need to obtain access token. Please call the non-silent acquireTokenWithResource methods.";
@@ -113,7 +114,7 @@ static BOOL isCorrelationIdUserProvided = NO;
 //the user for the obtained tokens (if provided by the server). If the user is different,
 //an error result is returned. Returns the same result, if no issues are found.
 - (ADAuthenticationResult*)updateResult:(ADAuthenticationResult*)result
-                                 toUser:(NSString*) userId
+                                 toUser:(ADUserIdentifier*)userId
 {
     if (!result)
     {
@@ -124,16 +125,35 @@ static BOOL isCorrelationIdUserProvided = NO;
         return [ADAuthenticationResult resultFromError:error];
     }
     
-    userId = [ADUserInformation normalizeUserId:userId];
-    NSString* actualUser = result.tokenCacheStoreItem.userInformation.userId;
-    if (!userId || AD_SUCCEEDED != result.status || !actualUser)
+    if (AD_SUCCEEDED != result.status || !userId || [NSString adIsStringNilOrBlank:userId.userId] || userId.type == OptionalDisplayableId)
     {
         //No user to compare - either no specific user id requested, or no specific userId obtained:
         return result;
     }
     
+    NSString* normalizedUserId = [ADUserInformation normalizeUserId:userId.userId];
+    NSString* actualUser = nil;
     
-    if (![userId isEqualToString:actualUser])
+    ADUserInformation* userInfo = [[result tokenCacheStoreItem] userInformation];
+    
+    switch (userId.type) {
+        // This case should already be handled above, but I don't want the compiler to complain
+        case OptionalDisplayableId:
+            break;
+        case RequiredDisplayableId:
+            actualUser = [userInfo userId];
+            break;
+        case UniqueId:
+            actualUser = [userInfo uniqueId];
+            break;
+    }
+    if (!actualUser)
+    {
+        return result;
+    }
+    actualUser = [ADUserInformation normalizeUserId:actualUser];
+    
+    if (![normalizedUserId isEqualToString:actualUser])
     {
         NSString* errorText = [NSString stringWithFormat:@"Different user was authenticated. Expected: '%@'; Actual: '%@'. Either the user entered credentials for different user, or cookie for different logged user is present. Consider calling acquireToken with AD_PROMPT_ALWAYS to ignore the cookie.",
                                userId, actualUser];

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m
@@ -131,32 +131,12 @@ static BOOL isCorrelationIdUserProvided = NO;
         return result;
     }
     
-    NSString* normalizedUserId = [ADUserInformation normalizeUserId:userId.userId];
-    NSString* actualUser = nil;
-    
     ADUserInformation* userInfo = [[result tokenCacheStoreItem] userInformation];
     
-    switch (userId.type) {
-        // This case should already be handled above, but I don't want the compiler to complain
-        case OptionalDisplayableId:
-            break;
-        case RequiredDisplayableId:
-            actualUser = [userInfo userId];
-            break;
-        case UniqueId:
-            actualUser = [userInfo uniqueId];
-            break;
-    }
-    if (!actualUser)
-    {
-        return result;
-    }
-    actualUser = [ADUserInformation normalizeUserId:actualUser];
-    
-    if (![normalizedUserId isEqualToString:actualUser])
+    if (![ADUserIdentifier identifier:userId matchesInfo:userInfo])
     {
         NSString* errorText = [NSString stringWithFormat:@"Different user was authenticated. Expected: '%@'; Actual: '%@'. Either the user entered credentials for different user, or cookie for different logged user is present. Consider calling acquireToken with AD_PROMPT_ALWAYS to ignore the cookie.",
-                               userId, actualUser];
+                               userId.userId, [userId userIdMatchString:userInfo]];
         
         ADAuthenticationError* error =
         [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_WRONG_USER

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.h
@@ -27,7 +27,7 @@
                      resource:(NSString*)resource
                      clientId:(NSString*)clientId
                   redirectUri:(NSString*)redirectUri
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                 correlationId:(NSUUID*)correlationId
               completionBlock:(ADAuthenticationCallback)completionBlock;
 
@@ -40,7 +40,7 @@
                   redirectUri:(NSURL*)redirectUri
                promptBehavior:(ADPromptBehavior)promptBehavior
                        silent:(BOOL)silent
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
          extraQueryParameters:(NSString*)queryParams
                 correlationId:(NSUUID*)correlationId
               completionBlock:(ADAuthenticationCallback)completionBlock;
@@ -54,7 +54,7 @@
 //Checks the cache for item that can be used to get directly or indirectly an access token.
 //Checks the multi-resource refresh tokens too.
 - (ADTokenCacheStoreItem*)findCacheItemWithKey:(ADTokenCacheStoreKey*) key
-                                        userId:(NSString*) userId
+                                        userId:(ADUserIdentifier*)userId
                                 useAccessToken:(BOOL*) useAccessToken
                                          error:(ADAuthenticationError* __autoreleasing*) error;
 
@@ -67,5 +67,9 @@
               cacheInstance:(id<ADTokenCacheStoring>)tokenCacheStoreInstance
                   cacheItem:(ADTokenCacheStoreItem*)cacheItem
            withRefreshToken:(NSString*)refreshToken;
+
+- (ADTokenCacheStoreItem*)extractCacheItemWithKey:(ADTokenCacheStoreKey*)key
+                                           userId:(ADUserIdentifier*)userId
+                                            error:(ADAuthenticationError* __autoreleasing*)error;
 
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.h
@@ -47,7 +47,7 @@
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
                 correlationId:(NSUUID*)correlationId
@@ -58,7 +58,7 @@
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
        refreshTokenCredential:(NSString*)refreshTokenCredential
@@ -69,7 +69,7 @@
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
        refreshTokenCredential:(NSString*)refreshTokenCredential

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
@@ -296,7 +296,7 @@ static volatile int sDialogInProgress = 0;
     
     [startUrl appendFormat:@"&%@", [[ADLogger adalId] adURLFormEncode]];
     
-    if (![NSString adIsStringNilOrBlank:userId.userId])
+    if (userId && [userId isDisplayable] && ![NSString adIsStringNilOrBlank:userId.userId])
     {
         [startUrl appendFormat:@"&%@=%@", OAUTH2_LOGIN_HINT, [userId.userId adUrlFormEncode]];
     }

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
@@ -27,6 +27,7 @@
 #import "ADAuthenticationBroker.h"
 #import "ADHelpers.h"
 #import "NSURL+ADExtensions.h"
+#import "ADUserIdentifier.h"
 
 #import <libkern/OSAtomic.h>
 
@@ -278,7 +279,7 @@ static volatile int sDialogInProgress = 0;
                             clientId:(NSString*)clientId
                          redirectUri:(NSURL*)redirectUri
                                scope:(NSString*)scope /* for future use */
-                              userId:(NSString*)userId
+                              userId:(ADUserIdentifier*)userId
                          requestType:(NSString*)requestType
                       promptBehavior:(ADPromptBehavior)promptBehavior
                 extraQueryParameters:(NSString*)queryParams
@@ -295,9 +296,9 @@ static volatile int sDialogInProgress = 0;
     
     [startUrl appendFormat:@"&%@", [[ADLogger adalId] adURLFormEncode]];
     
-    if (![NSString adIsStringNilOrBlank:userId])
+    if (![NSString adIsStringNilOrBlank:userId.userId])
     {
-        [startUrl appendFormat:@"&%@=%@", OAUTH2_LOGIN_HINT, [userId adUrlFormEncode]];
+        [startUrl appendFormat:@"&%@=%@", OAUTH2_LOGIN_HINT, [userId.userId adUrlFormEncode]];
     }
     NSString* promptParam = [ADAuthenticationContext getPromptParameter:promptBehavior];
     if (promptParam)
@@ -328,7 +329,7 @@ static volatile int sDialogInProgress = 0;
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
                 correlationId:(NSUUID*)correlationId
@@ -353,7 +354,7 @@ static volatile int sDialogInProgress = 0;
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
        refreshTokenCredential:(NSString*)refreshTokenCredential
@@ -378,7 +379,7 @@ static volatile int sDialogInProgress = 0;
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                         scope:(NSString*)scope /*for future use */
-                       userId:(NSString*)userId
+                       userId:(ADUserIdentifier*)userId
                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
        refreshTokenCredential:(NSString*)refreshTokenCredential

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -276,14 +276,13 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
 
 /*! Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize the
  resource usage (through webview credentials UI) or attempt to use the cached tokens first.
- @param resource: the resource for whom token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol
- @param userId: An ADUserIdentifier object describing the user being authenticated
- @param extraQueryParameters: will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
- @param credentialsType: controls the way of obtaining client credentials if such are needed.
- @param promptBehavior: controls if any credentials UI will be shownt.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param resource the resource for whom token is needed.
+ @param clientId the client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param promptBehavior controls if any credentials UI will be shown.
+ @param userId An ADUserIdentifier object describing the user being authenticated
+ @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param completionBlock the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 -(void)  acquireTokenWithResource: (NSString*) resource
                          clientId: (NSString*) clientId

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -36,6 +36,7 @@ typedef UIWebView WebViewType;
 typedef WebView   WebViewType;
 #endif
 
+@class ADUserIdentifier;
 @class UIViewController;
 
 typedef enum
@@ -270,6 +271,25 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                       redirectUri: (NSURL*) redirectUri
                    promptBehavior: (ADPromptBehavior) promptBehavior
                            userId: (NSString*) userId
+             extraQueryParameters: (NSString*) queryParams
+                  completionBlock: (ADAuthenticationCallback) completionBlock;
+
+/*! Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize the
+ resource usage (through webview credentials UI) or attempt to use the cached tokens first.
+ @param resource: the resource for whom token is needed.
+ @param clientId: the client identifier
+ @param redirectUri: The redirect URI according to OAuth2 protocol
+ @param userId: An ADUserIdentifier object describing the user being authenticated
+ @param extraQueryParameters: will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param credentialsType: controls the way of obtaining client credentials if such are needed.
+ @param promptBehavior: controls if any credentials UI will be shownt.
+ @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+-(void)  acquireTokenWithResource: (NSString*) resource
+                         clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
+                   promptBehavior: (ADPromptBehavior) promptBehavior
+                   userIdentifier: (ADUserIdentifier*) userId
              extraQueryParameters: (NSString*) queryParams
                   completionBlock: (ADAuthenticationCallback) completionBlock;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -379,5 +379,27 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                              completionBlock:completionBlock];
 }
 
+-(void)  acquireTokenWithResource: (NSString*) resource
+                         clientId: (NSString*) clientId
+                      redirectUri: (NSURL*) redirectUri
+                   promptBehavior: (ADPromptBehavior) promptBehavior
+                   userIdentifier: (ADUserIdentifier*) userId
+             extraQueryParameters: (NSString*) queryParams
+                  completionBlock: (ADAuthenticationCallback) completionBlock
+{
+    API_ENTRY;
+    [self internalAcquireTokenWithResource:resource
+                                  clientId:clientId
+                               redirectUri:redirectUri
+                            promptBehavior:promptBehavior
+                                    silent:NO
+                            userIdentifier:userId
+                                     scope:nil
+                      extraQueryParameters:queryParams
+                         validateAuthority:self.validateAuthority
+                             correlationId:[self getCorrelationId]
+                           completionBlock:completionBlock];
+}
+
 @end
 

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
@@ -128,4 +128,37 @@
     return self;
 }
 
+- (BOOL)isEqual:(id)object
+{
+    if (!object)
+        return NO;
+    
+    if (![object isKindOfClass:[ADTokenCacheStoreItem class]])
+        return NO;
+    
+    ADTokenCacheStoreItem* item = (ADTokenCacheStoreItem*)object;
+    
+    if (self.resource && (!item.resource || ![self.resource isEqualToString:item.resource]))
+    {
+        return NO;
+    }
+    
+    if (![self.authority isEqualToString:item.authority])
+    {
+        return NO;
+    }
+    
+    if (![self.clientId isEqualToString:item.clientId])
+    {
+        return NO;
+    }
+    
+    if (![self isSameUser:item])
+    {
+        return NO;
+    }
+    
+    return YES;
+}
+
 @end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.h
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.h
@@ -44,6 +44,8 @@ typedef enum ADUserIdentifierType
     RequiredDisplayableId,
 } ADUserIdentifierType;
 
+@class ADUserInformation;
+
 @interface ADUserIdentifier : NSObject
 
 @property (readonly, retain) NSString* userId;
@@ -65,6 +67,11 @@ typedef enum ADUserIdentifierType
 
 + (ADUserIdentifier*)identifierWithId:(NSString *)userId
                        typeFromString:(NSString*)type;
+
++ (BOOL)identifier:(ADUserIdentifier*)identifier
+       matchesInfo:(ADUserInformation*)info;
+
+- (NSString*)userIdMatchString:(ADUserInformation*)info;
 
 - (NSString*)typeAsString;
 

--- a/ADALiOS/ADALiOS/ADUserIdentifier.h
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.h
@@ -75,4 +75,6 @@ typedef enum ADUserIdentifierType
 
 - (NSString*)typeAsString;
 
+- (BOOL)isDisplayable;
+
 @end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.h
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.h
@@ -1,0 +1,68 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+
+#import <Foundation/Foundation.h>
+
+typedef enum ADUserIdentifierType
+{
+    /*!
+     When a ADUserIdentifier of this type is passed in a token acquisition operation the operation
+     is gauranteed to return a token issued for a user with the corresponding UserIdentifier or
+     fail.
+     */
+    UniqueId,
+    
+    /*!
+     When a ADUserIdentifier of this type is passed in a token acquisition operation, the operation
+     restricts cache matches to the value provided and injects it as a hint in the authentication
+     experience. However the end user could overwrite that value, resulting in a token issued to
+     a different account than the one specified in the ADUserIdentifier in input.
+     */
+    OptionalDisplayableId,
+    
+    /*!
+     When a ADUserIdentifier of this type is passed in a token acquisition operation, the operation
+     is guaranteed to return a token issued for the user with corresponding DisplayableId (UPN or
+     email) or fail
+     */
+    RequiredDisplayableId,
+} ADUserIdentifierType;
+
+@interface ADUserIdentifier : NSObject
+
+@property (readonly, retain) NSString* userId;
+@property (readonly) ADUserIdentifierType type;
+
+/*!
+    Creates a ADUserIdentifier with the provided userId and RequiredDisplayableId type.
+    @param  userId  The userid
+ */
++ (ADUserIdentifier*)identifierWithId:(NSString*)userId;
+
+/*!
+    Creates a ADUserIdentifier with the provided userId and type.
+    @param  userId  The userid
+    @param  type    The type that describes how ADAL should validate this User ID.
+ */
++ (ADUserIdentifier*)identifierWithId:(NSString*)userId
+                                 type:(ADUserIdentifierType)type;
+
+- (NSString*)typeAsString;
+
+@end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.h
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.h
@@ -63,6 +63,9 @@ typedef enum ADUserIdentifierType
 + (ADUserIdentifier*)identifierWithId:(NSString*)userId
                                  type:(ADUserIdentifierType)type;
 
++ (ADUserIdentifier*)identifierWithId:(NSString *)userId
+                       typeFromString:(NSString*)type;
+
 - (NSString*)typeAsString;
 
 @end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -96,10 +96,12 @@
         return NO;
     }
     
+    NSString* matchString = [identifier userIdMatchString:info];
+    if (!matchString || [matchString isEqualToString:identifier.userId])
+    {
+        return YES;
+    }
     
-    
-    NSString* log = [NSString stringWithFormat:@"Unrecognized type on identifier match: %d", type];
-    AD_LOG_ERROR(log, AD_ERROR_UNEXPECTED, nil);
     return NO;
 }
 
@@ -111,6 +113,9 @@
         case OptionalDisplayableId: return nil;
         case RequiredDisplayableId: return info.userId;
     }
+    
+    NSString* log = [NSString stringWithFormat:@"Unrecognized type on identifier match: %d", _type];
+    AD_LOG_ERROR(log, AD_ERROR_UNEXPECTED, nil);
     
     return nil;
 }

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -18,6 +18,10 @@
 
 
 #import "ADUserIdentifier.h"
+#import "ADLogger.h"
+#import "ADErrorCodes.h"
+
+#define DEFAULT_USER_TYPE RequiredDisplayableId
 
 @implementation ADUserIdentifier
 {
@@ -37,7 +41,7 @@
     }
     
     identifier->_userId = userId;
-    identifier->_type = RequiredDisplayableId;
+    identifier->_type = DEFAULT_USER_TYPE;
     
     return identifier;
 }
@@ -57,16 +61,50 @@
     return identifier;
 }
 
-#define ENUM_CASE(_val) case _val: return @#_val;
++ (ADUserIdentifier*)identifierWithId:(NSString *)userId
+                       typeFromString:(NSString*)type
+{
+    ADUserIdentifier* identifier = [[ADUserIdentifier alloc] init];
+    if (!identifier)
+    {
+        return nil;
+    }
+    
+    identifier->_userId = userId;
+    identifier->_type = [ADUserIdentifier typeFromString:type];
+    
+    return identifier;
+}
+
+#define ENUM_TO_STRING_CASE(_val) case _val: return @#_val;
 
 - (NSString*)typeAsString
 {
     switch (_type)
     {
-        ENUM_CASE(UniqueId);
-        ENUM_CASE(OptionalDisplayableId);
-        ENUM_CASE(RequiredDisplayableId);
+        ENUM_TO_STRING_CASE(UniqueId);
+        ENUM_TO_STRING_CASE(OptionalDisplayableId);
+        ENUM_TO_STRING_CASE(RequiredDisplayableId);
     }
+}
+
+#define CHECK_TYPE(_type) if( [@#_type isEqualToString:type] ) { return _type; }
++ (ADUserIdentifierType)typeFromString:(NSString*)type
+{
+    if (!type)
+    {
+        // If we don't get a type string then just return default
+        return DEFAULT_USER_TYPE;
+    }
+    
+    CHECK_TYPE(UniqueId);
+    CHECK_TYPE(OptionalDisplayableId);
+    CHECK_TYPE(RequiredDisplayableId);
+    
+    // If it didn't match against a known type return default, but log an error
+    NSString* log = [NSString stringWithFormat:@"Did not recognize type \"%@\"", type];
+    AD_LOG_ERROR(log, AD_ERROR_UNEXPECTED, nil);
+    return DEFAULT_USER_TYPE;
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -1,0 +1,72 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+
+#import "ADUserIdentifier.h"
+
+@implementation ADUserIdentifier
+{
+    NSString* _userId;
+    ADUserIdentifierType _type;
+}
+
+@synthesize userId = _userId;
+@synthesize type = _type;
+
++ (ADUserIdentifier*)identifierWithId:(NSString*)userId
+{
+    ADUserIdentifier* identifier = [[ADUserIdentifier alloc] init];
+    if (!identifier)
+    {
+        return nil;
+    }
+    
+    identifier->_userId = userId;
+    identifier->_type = RequiredDisplayableId;
+    
+    return identifier;
+}
+
++ (ADUserIdentifier*)identifierWithId:(NSString*)userId
+                                 type:(ADUserIdentifierType)type
+{
+    ADUserIdentifier* identifier = [[ADUserIdentifier alloc] init];
+    if (!identifier)
+    {
+        return nil;
+    }
+    
+    identifier->_userId = userId;
+    identifier->_type = type;
+    
+    return identifier;
+}
+
+#define ENUM_CASE(_val) case _val: return @#_val;
+
+- (NSString*)typeAsString
+{
+    switch (_type)
+    {
+        ENUM_CASE(UniqueId);
+        ENUM_CASE(OptionalDisplayableId);
+        ENUM_CASE(RequiredDisplayableId);
+    }
+}
+
+@end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -20,6 +20,7 @@
 #import "ADUserIdentifier.h"
 #import "ADLogger.h"
 #import "ADErrorCodes.h"
+#import "ADUserInformation.h"
 
 #define DEFAULT_USER_TYPE RequiredDisplayableId
 
@@ -40,7 +41,7 @@
         return nil;
     }
     
-    identifier->_userId = userId;
+    identifier->_userId = [ADUserInformation normalizeUserId:userId];
     identifier->_type = DEFAULT_USER_TYPE;
     
     return identifier;
@@ -55,7 +56,7 @@
         return nil;
     }
     
-    identifier->_userId = userId;
+    identifier->_userId = [ADUserInformation normalizeUserId:userId];
     identifier->_type = type;
     
     return identifier;
@@ -70,10 +71,48 @@
         return nil;
     }
     
-    identifier->_userId = userId;
+    identifier->_userId = [ADUserInformation normalizeUserId:userId];
     identifier->_type = [ADUserIdentifier typeFromString:type];
     
     return identifier;
+}
+
++ (BOOL)identifier:(ADUserIdentifier*)identifier
+       matchesInfo:(ADUserInformation*)info
+{
+    if (!identifier)
+    {
+        return YES;
+    }
+    
+    ADUserIdentifierType type = [identifier type];
+    if (type == OptionalDisplayableId)
+    {
+        return YES;
+    }
+    
+    if (!info)
+    {
+        return NO;
+    }
+    
+    
+    
+    NSString* log = [NSString stringWithFormat:@"Unrecognized type on identifier match: %d", type];
+    AD_LOG_ERROR(log, AD_ERROR_UNEXPECTED, nil);
+    return NO;
+}
+
+- (NSString*)userIdMatchString:(ADUserInformation*)info
+{
+    switch(_type)
+    {
+        case UniqueId: return info.uniqueId;
+        case OptionalDisplayableId: return nil;
+        case RequiredDisplayableId: return info.userId;
+    }
+    
+    return nil;
 }
 
 #define ENUM_TO_STRING_CASE(_val) case _val: return @#_val;

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -132,6 +132,11 @@
     }
 }
 
+- (BOOL)isDisplayable
+{
+    return (_type == RequiredDisplayableId || _type == OptionalDisplayableId);
+}
+
 #define CHECK_TYPE(_type) if( [@#_type isEqualToString:type] ) { return _type; }
 + (ADUserIdentifierType)typeFromString:(NSString*)type
 {

--- a/ADALiOS/ADALiOS/ADUserInformation.h
+++ b/ADALiOS/ADALiOS/ADUserInformation.h
@@ -32,12 +32,15 @@
                                            error: (ADAuthenticationError* __autoreleasing*) error;
 
 /* This is the only unique property, as it is used in the key generation for the cache.
- Two ADUserInformation objects are considered the same if this property is the same. */
+ Two ADUserInformation objects are considered the same if this property is the same. Using RequiredDisplayableId
+ will validate against this property. */
 @property (readonly) NSString* userId;
 
 /*! Determines whether userId is displayable */
 @property (readonly) BOOL userIdDisplayable;
 
+/*! This property will be the userObjectId if it exists, or the subject if it does not. It is typically a GUID
+    and not displayable. Using UniqueId as the ADUserIdentifierType will validate against this property. */
 @property (readonly) NSString* uniqueId;
 
 /*! May be null */

--- a/ADALiOS/ADALiOS/ADUserInformation.h
+++ b/ADALiOS/ADALiOS/ADUserInformation.h
@@ -38,6 +38,8 @@
 /*! Determines whether userId is displayable */
 @property (readonly) BOOL userIdDisplayable;
 
+@property (readonly) NSString* uniqueId;
+
 /*! May be null */
 @property (readonly, getter = getGivenName) NSString* givenName;
 

--- a/ADALiOS/ADALiOS/ADUserInformation.m
+++ b/ADALiOS/ADALiOS/ADUserInformation.m
@@ -203,6 +203,8 @@ NSString* const ID_TOKEN_GUEST_ID = @"altsecid";
         _uniqueId = self.subject;
     }
     
+    _uniqueId = [ADUserInformation normalizeUserId:_uniqueId];
+    
     return self;
 }
 

--- a/ADALiOS/ADALiOS/ADUserInformation.m
+++ b/ADALiOS/ADALiOS/ADUserInformation.m
@@ -194,6 +194,15 @@ NSString* const ID_TOKEN_GUEST_ID = @"altsecid";
     }
     _userId = [self.class normalizeUserId:_userId];
     
+    if (![NSString adIsStringNilOrBlank:self.userObjectId])
+    {
+        _uniqueId = self.userObjectId;
+    }
+    else if (![NSString adIsStringNilOrBlank:self.subject])
+    {
+        _uniqueId = self.subject;
+    }
+    
     return self;
 }
 

--- a/ADALiOS/ADALiOSTests/ADTestAuthenticationContext.h
+++ b/ADALiOS/ADALiOSTests/ADTestAuthenticationContext.h
@@ -51,12 +51,12 @@
                                             error: (ADAuthenticationError* __autoreleasing *) error;
 
 //Override of the parent's request to allow testing of the class behavior.
-- (void)request:(NSString *)authorizationServer
-    requestData:(NSDictionary *)request_data
-requestCorrelationId: (NSUUID*) requestCorrelationId
-isHandlingPKeyAuthChallenge: (BOOL) isHandlingPKeyAuthChallenge
-additionalHeaders:(NSDictionary *)additionalHeaders
-     completion:( void (^)(NSDictionary *) )completionBlock;
+- (void)requestWithServer:(NSString *)authorizationServer
+              requestData:(NSDictionary *)request_data
+     requestCorrelationId:(NSUUID*)requestCorrelationId
+          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
+        additionalHeaders:(NSDictionary *)additionalHeaders
+               completion:( void (^)(NSDictionary *) )completionBlock;
 
 
 @end

--- a/ADALiOS/ADALiOSTests/ADTestTokenCacheStore.m
+++ b/ADALiOS/ADALiOSTests/ADTestTokenCacheStore.m
@@ -20,7 +20,8 @@
 
 @implementation ADTestTokenCacheStore
 
--(ADTokenCacheStoreItem*) getItemWithKey:(ADTokenCacheStoreKey*)key error: (ADAuthenticationError* __autoreleasing*) error
+-(ADTokenCacheStoreItem*) getItemWithKey:(ADTokenCacheStoreKey*)key
+                                   error: (ADAuthenticationError* __autoreleasing*) error
 {
     return nil;
 }
@@ -30,7 +31,9 @@
 {
 }
 
--(void) removeItemWithKey: (ADTokenCacheStoreKey*) key userId:(NSString *)userId error:(ADAuthenticationError *__autoreleasing *)error
+-(void) removeItemWithKey: (ADTokenCacheStoreKey*) key
+                   userId:(NSString *)userId
+                    error:(ADAuthenticationError *__autoreleasing *)error
 {
     return;
 }
@@ -56,8 +59,8 @@
     //Nothing to store.
 }
 
--(ADTokenCacheStoreItem*) getItemWithKey: (ADTokenCacheStoreKey*) key
-                                   userId: (NSString *)userId
+-(ADTokenCacheStoreItem*) getItemWithKey:(ADTokenCacheStoreKey*)key
+                                  userId:(NSString *)userId
                                    error:(ADAuthenticationError *__autoreleasing *)error
 {
     return nil;

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
@@ -90,17 +90,9 @@ typedef enum
 //Creates a sample user information object
 -(ADUserInformation*) adCreateUserInformation;
 
-//Ensures that two cache items are the same:
--(void) adVerifySameWithItem: (ADTokenCacheStoreItem*) item1
-                     item2: (ADTokenCacheStoreItem*) item2;
 //Ensures that all properties return non-default values. Useful to ensure that
 //the tests cover all properties of the tested objects:
 -(void) adVerifyPropertiesAreSet: (NSObject*) object;
-
-//Ensures that all properties of the first object are the same as the ones in the
-//second. Useful to ensure that copying/unpersisting operates on all object data:
--(void) adVerifyPropertiesAreSame: (NSObject*) object1
-                           second: (NSObject*) object2;
 
 -(NSString*) adLogLevelLogs;
 -(NSString*) adMessagesLogs;

--- a/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
+++ b/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
@@ -246,7 +246,7 @@
 				ORGANIZATIONNAME = MS;
 				TargetAttributes = {
 					8BA42AF517E3C150002D206E = {
-						DevelopmentTeam = 4XAC8VP2M2;
+						DevelopmentTeam = UBF8T346G9;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;

--- a/Samples/MyTestiOSApp/MyTestiOSApp/BVTestMainViewController.h
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/BVTestMainViewController.h
@@ -24,6 +24,10 @@
 
 @interface BVTestMainViewController : UIViewController <BVTestFlipsideViewControllerDelegate, UIPopoverControllerDelegate>
 {
+    IBOutlet UITextView*            _resultView;
+    IBOutlet UITextField*           _tfUserId;
+    IBOutlet UISegmentedControl*    _scUserType;
+    IBOutlet UISegmentedControl*    _scPromptBehavior;
     @protected
     BVSettings* mTestData;
     BVTestInstance* mAADInstance;

--- a/Samples/MyTestiOSApp/MyTestiOSApp/Base.lproj/Main_iPad.storyboard
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/Base.lproj/Main_iPad.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="aVO-UE-KGo">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" initialViewController="aVO-UE-KGo">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--Test Main View Controller-->
@@ -29,49 +29,112 @@
                                     </navigationItem>
                                 </items>
                             </navigationBar>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="QBA-Jf-dIr">
+                                <rect key="frame" x="412" y="77" width="266" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="userId:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOj-Kw-dLc">
+                                <rect key="frame" x="344" y="77" width="53" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" name="controlLightHighlightColor" catalog="System" colorSpace="catalog"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="userType:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Tqx-tf-XKh">
+                                <rect key="frame" x="323" y="115" width="74" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="2" translatesAutoresizingMaskIntoConstraints="NO" id="28s-Ay-hJH">
+                                <rect key="frame" x="412" y="115" width="266" height="29"/>
+                                <segments>
+                                    <segment title="unique"/>
+                                    <segment title="optional"/>
+                                    <segment title="required"/>
+                                </segments>
+                            </segmentedControl>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="prompt:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7pX-2t-vQz">
+                                <rect key="frame" x="339" y="156" width="61" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="BuY-Ru-0Wn">
+                                <rect key="frame" x="412" y="151" width="266" height="29"/>
+                                <segments>
+                                    <segment title="Auto"/>
+                                    <segment title="Always"/>
+                                    <segment title="Refresh"/>
+                                </segments>
+                            </segmentedControl>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="rs5-sx-tir">
-                                <rect key="frame" x="175" y="72" width="76" height="30"/>
+                                <rect key="frame" x="90" y="77" width="76" height="30"/>
                                 <state key="normal" title="End to End">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="pressMeAction:" destination="aVO-UE-KGo" eventType="touchUpInside" id="2pv-st-Yhh"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yyp-w6-IDf">
-                                <rect key="frame" x="175" y="250" width="140" height="30"/>
+                                <rect key="frame" x="90" y="255" width="140" height="30"/>
                                 <state key="normal" title="Acquire Token Silent">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="acquireTokenSilentAction:" destination="aVO-UE-KGo" eventType="touchUpInside" id="ZzC-gS-OkP"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hh2-Lg-JjF">
-                                <rect key="frame" x="175" y="110" width="85" height="30"/>
+                                <rect key="frame" x="90" y="115" width="85" height="30"/>
                                 <state key="normal" title="Clear Cache">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="clearCachePressed:" destination="aVO-UE-KGo" eventType="touchUpInside" id="gvX-mR-Ilc"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="vR7-U5-PHm">
-                                <rect key="frame" x="175" y="142" width="118" height="30"/>
+                                <rect key="frame" x="90" y="147" width="118" height="30"/>
                                 <state key="normal" title="Get logged users">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="getUsersPressed:" destination="aVO-UE-KGo" eventType="touchUpInside" id="VaK-ZP-m74"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eja-p2-Vem">
-                                <rect key="frame" x="175" y="180" width="64" height="30"/>
+                                <rect key="frame" x="90" y="185" width="64" height="30"/>
                                 <state key="normal" title="Expire All">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="expireAllPressed:" destination="aVO-UE-KGo" eventType="touchUpInside" id="t8l-Rz-cNf"/>
+                                </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WvT-Ws-WRP" userLabel="Button - Promp Always">
-                                <rect key="frame" x="175" y="218" width="118" height="30"/>
+                                <rect key="frame" x="90" y="223" width="118" height="30"/>
                                 <state key="normal" title="Prompt Always">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
+                                <connections>
+                                    <action selector="promptAlways:" destination="aVO-UE-KGo" eventType="touchUpInside" id="9ah-BR-r0x"/>
+                                </connections>
                             </button>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Label" lineBreakMode="characterWrap" numberOfLines="6" baselineAdjustment="alignBaselines" minimumFontSize="9" preferredMaxLayoutWidth="588" translatesAutoresizingMaskIntoConstraints="NO" id="riI-9j-1cj">
-                                <rect key="frame" x="90" y="347" width="588" height="493"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uyB-vR-SeS">
+                                <rect key="frame" x="16" y="309" width="736" height="695"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                                <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
-                                <nil key="highlightedColor"/>
-                            </label>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="1" translatesAutoresizingMaskIntoConstraints="NO" id="aEk-sC-PfV">
+                                <rect key="frame" x="465" y="245" width="161" height="29"/>
+                                <segments>
+                                    <segment title="Embedded"/>
+                                    <segment title="Broker"/>
+                                </segments>
+                            </segmentedControl>
                         </subviews>
                         <color key="backgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
@@ -81,7 +144,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="resultLabel" destination="riI-9j-1cj" id="fRe-C2-UX0"/>
+                        <outlet property="_resultView" destination="uyB-vR-SeS" id="61t-df-gjy"/>
+                        <outlet property="_scPromptBehavior" destination="BuY-Ru-0Wn" id="F2h-Mb-gpJ"/>
+                        <outlet property="_scUserType" destination="28s-Ay-hJH" id="8xO-HI-c3b"/>
+                        <outlet property="_tfUserId" destination="QBA-Jf-dIr" id="dN1-Nk-0f9"/>
                         <segue destination="FTa-do-hRx" kind="modal" identifier="showAlternate" modalTransitionStyle="flipHorizontal" id="pXF-iP-W5x"/>
                     </connections>
                 </viewController>

--- a/Samples/MyTestiOSApp/MyTestiOSApp/Base.lproj/Main_iPhone.storyboard
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/Base.lproj/Main_iPhone.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7531" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="rQl-PL-IFJ">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="7706" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="rQl-PL-IFJ">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7520"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
     </dependencies>
     <scenes>
         <!--Test Main View Controller-->
@@ -32,7 +32,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="hp0-J2-wnv">
-                                <rect key="frame" x="52" y="81" width="76" height="30"/>
+                                <rect key="frame" x="20" y="63" width="76" height="30"/>
                                 <state key="normal" title="End to End">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -41,7 +41,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Kmh-k3-Gc8">
-                                <rect key="frame" x="52" y="119" width="85" height="30"/>
+                                <rect key="frame" x="20" y="101" width="85" height="30"/>
                                 <state key="normal" title="Clear Cache">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -50,8 +50,8 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xkk-Hs-VRK">
-                                <rect key="frame" x="52" y="151" width="118" height="30"/>
-                                <state key="normal" title="Get logged users">
+                                <rect key="frame" x="20" y="133" width="68" height="30"/>
+                                <state key="normal" title=" get users">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
                                 <connections>
@@ -65,7 +65,7 @@
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eED-F4-K6i">
-                                <rect key="frame" x="52" y="259" width="140" height="30"/>
+                                <rect key="frame" x="20" y="241" width="140" height="30"/>
                                 <state key="normal" title="Acquire Token Silent">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -75,7 +75,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cvg-hR-arT">
-                                <rect key="frame" x="52" y="189" width="64" height="30"/>
+                                <rect key="frame" x="20" y="171" width="64" height="30"/>
                                 <state key="normal" title="Expire All">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -84,7 +84,7 @@
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="lDc-ZK-ov7" userLabel="Button - Promp Always">
-                                <rect key="frame" x="52" y="227" width="118" height="30"/>
+                                <rect key="frame" x="20" y="209" width="118" height="30"/>
                                 <state key="normal" title="Prompt Always">
                                     <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
                                 </state>
@@ -92,6 +92,33 @@
                                     <action selector="promptAlways:" destination="rQl-PL-IFJ" eventType="touchUpInside" id="zeu-t5-AFy"/>
                                 </connections>
                             </button>
+                            <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="2Uz-WV-uIs">
+                                <rect key="frame" x="138" y="78" width="166" height="30"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits"/>
+                            </textField>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="6Hi-cK-CSj">
+                                <rect key="frame" x="138" y="117" width="166" height="29"/>
+                                <segments>
+                                    <segment title="unq"/>
+                                    <segment title="opt"/>
+                                    <segment title="req"/>
+                                </segments>
+                            </segmentedControl>
+                            <segmentedControl opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="left" contentVerticalAlignment="top" segmentControlStyle="plain" selectedSegmentIndex="0" translatesAutoresizingMaskIntoConstraints="NO" id="bwY-ER-l8D">
+                                <rect key="frame" x="138" y="153" width="166" height="29"/>
+                                <segments>
+                                    <segment title="auto"/>
+                                    <segment title="alwys"/>
+                                    <segment title="rfrsh"/>
+                                </segments>
+                            </segmentedControl>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="user id:" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="UKM-c9-hpF">
+                                <rect key="frame" x="145" y="49" width="57" height="21"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <nil key="highlightedColor"/>
+                            </label>
                         </subviews>
                         <color key="backgroundColor" white="0.25" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                         <constraints>
@@ -100,7 +127,10 @@
                         </constraints>
                     </view>
                     <connections>
-                        <outlet property="resultLabel" destination="wT8-Bz-vLQ" id="Ai6-LW-Ilf"/>
+                        <outlet property="_resultView" destination="wT8-Bz-vLQ" id="iue-DJ-Rkg"/>
+                        <outlet property="_scPromptBehavior" destination="bwY-ER-l8D" id="V82-F3-6gU"/>
+                        <outlet property="_scUserType" destination="6Hi-cK-CSj" id="N8B-s5-fED"/>
+                        <outlet property="_tfUserId" destination="2Uz-WV-uIs" id="r7Z-NL-zv4"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="h4L-l5-tyG" sceneMemberID="firstResponder"/>

--- a/Samples/MyTestiOSApp/MyTestiOSAppTests/MyTestiOSAppTests.m
+++ b/Samples/MyTestiOSApp/MyTestiOSAppTests/MyTestiOSAppTests.m
@@ -203,7 +203,7 @@ const int sTokenWorkflowTimeout     = 20;
                                             interactive: (BOOL) interactive
                                            keepSignedIn: (BOOL) keepSignedIn
                                           expectSuccess: (BOOL) expectSuccess
-                                                 userId: (NSString*) userId /*requested userid, may be different from entered*/
+                                                 userId: (ADUserIdentifier*)userId /*requested userid, may be different from entered*/
                                                    line: (int) sourceLine
 {
     XCTAssertNotNil(instance, "Internal test failure.");


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23issuecomment-112941500%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23issuecomment-113035257%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676282%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676388%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676960%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32677190%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32677274%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32679399%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693472%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693525%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693649%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693712%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693915%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693918%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693964%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32693996%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32694008%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32694080%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32694123%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32694196%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32698472%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23issuecomment-112941500%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40RPangrle-MS__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3EYou%27ve%20already%20signed%20the%20contribution%20license%20agreement.%20Thanks%21%3C/span%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%3Cp%3EThe%20agreement%20was%20validated%20by%20Microsoft%20Open%20Technologies%2C%20Inc.%20and%20real%20humans%20are%20currently%20evaluating%20your%20PR.%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-06-17T20%3A35%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-18T04%3A37%3A39Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADAuthenticationContext%252BInternal.m%2030%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676282%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22ADUserIdentifier%20should%20have%20%27id%27%20field%20not%20%27userid%27.%20It%20will%20look%20better%20if%20we%20have%20here%3A%5Cr%5Cn%5Cr%5Cn%60%60%60%5Cr%5Cn%5BADUserInformation%20normalizeUserId%3Auser.Id%5D%3B%5Cr%5Cn%60%60%60%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A20%3A10Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22id%20is%20a%20reserved%20word%20in%20Objective%20C.%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A01%3A21Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A-1%3A%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A01%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext%2BInternal.m%3AL125-160%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADUserInformation.h%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32679399%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Add%20comment%20here.%20This%20is%20passed%20to%20ADUserIdentifier%20as%20ID%20when%20type%20if%20UniqueId.%20This%20is%20not%20displayable%20so%20not%20used%20as%20login_hint.%20Adal.Net%20stores%20items%20in%20the%20cache%20for%20uniqueID%20and%20displayableid.%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A53%3A47Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20didn%27t%20want%20to%20diverge%20too%20much%20from%20established%20ADALiOS%20behavior%2C%20at%20least%20in%20the%20default%20case.%20That%20means%20having%20RequiredDisplayableId%20mean%20the%20previous%20behavior.%20This%20is%20something%20we%20can%20fix%20in%20the%20redesign.%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A06%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A09%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADUserInformation.h%3AL38-46%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADAuthenticationContext%252BWebRequest.m%2025%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32677190%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22UniqueId%20can%20be%20GUID%20since%20it%20is%20assigned%20from%20subjectid/objectid.%20You%20can%20use%20userid%20as%20a%20loginhint%20if%20type%20is%20not%20UniqueId.%20%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A30%3A15Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20they%20gave%20us%20a%20UniqueId%20as%20the%20UserIdentifier%20we%20don%27t%20have%20anything%20else%20to%20go%20by%2C%20we%20don%27t%20have%20the%20full%20UserInformation%20struct%20here.%22%2C%20%22created_at%22%3A%20%222015-06-18T01%3A51%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22If%20you%20look%20at%20the%20UserIdentifier%20class%20in%20.NET%20%28https%3A//github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/src/ADAL.Common/UserIdentifier.cs%29%20the%20only%20fields%20are%20%27id%27%20and%20%27type.%27%20I%20can%27t%20call%20a%20field%20in%20ObjC%20%27id%27%20because%20that%27s%20a%20reserved%20word%20in%20the%20language%20so%20I%20used%20%27userId%27%20instead.%20It%20doesn%27t%20map%20to%20%27userId%27%20concept%20in%20ADUserInformation%2C%20however%20that%20userId%20concept%20isn%27t%20in%20the%20.NET%20client%20either.%22%2C%20%22created_at%22%3A%20%222015-06-18T01%3A54%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22In%20.NET%20it%20appears%20no%20login%20hint%20is%20passed%20in%20at%20all%20if%20it%27s%20not%20a%20displayableId.%20I%20will%20copy%20that%20behavior.%22%2C%20%22created_at%22%3A%20%222015-06-18T01%3A55%3A33Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A03%3A11Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext%2BWebRequest.m%3AL296-305%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADAuthenticationContext.h%2016%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32677274%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Param%20order%20in%20document%20does%20not%20match%20to%20method.%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A31%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%20A%20number%20of%20the%20other%20document%20blocks%20have%20this%20problem%2C%20and%20also%20reference%20now-gone%20parameters.%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A05%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext.h%3AL274-299%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADAuthenticationContext%252BInternal.m%2053%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676388%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22We%20should%20log%20this%20error%20as%20well.%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A21%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A02%3A12Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext%2BInternal.m%3AL125-160%22%7D%2C%20%22Pull%2054aa3a27e6b8eaa3708e8faea2c771dba875e20b%20ADALiOS/ADALiOS/ADAuthenticationContext%252BTokenCaching.m%2039%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335%23discussion_r32676960%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Does%20it%20create%20multiple%20entries%20in%20cache%20if%20first%20request%20has%20UserIdentifier%27s%20type%20UniqueId%20and%20second%20request%20has%20RequiredDisplayableId%3F%20Both%20of%20them%20should%20refer%20to%20same%20cache%20entry%20since%20it%20is%20same%20user.%22%2C%20%22created_at%22%3A%20%222015-06-17T21%3A27%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20would%20require%20a%20significant%20rearchitecture%20of%20our%20caching%20code.%20Right%20now%20we%20stash%20the%20username%20in%20the%20appropriate%20field%20in%20keychain%2C%20we%20would%20need%20more%20keychain%20properties.%22%2C%20%22created_at%22%3A%20%222015-06-18T01%3A50%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22Unless%20you%20feel%20really%20strongly%20on%20this%2C%20I%20recommend%20punting%20to%20redesign.%20This%20would%20require%20days%20of%20work%20and%20would%20be%20a%20breaking%20change.%22%2C%20%22created_at%22%3A%20%222015-06-18T02%3A02%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle-MS%22%7D%7D%2C%20%7B%22body%22%3A%20%22It%20is%20fine%20for%20this%2C%20but%20for%20convergence%20we%20need%20to%20match%20adal.net%20cache%20model.%22%2C%20%22created_at%22%3A%20%222015-06-18T04%3A32%3A48Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationContext%2BTokenCaching.m%3AL94-101%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/omercs%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/omercs'><img src='https://avatars.githubusercontent.com/u/466805?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADAuthenticationContext%2BInternal.m 30'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32676282'>File: ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m:L125-160</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> ADUserIdentifier should have 'id' field not 'userid'. It will look better if we have here:
```
[ADUserInformation normalizeUserId:user.Id];
```
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> id is a reserved word in Objective C.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> :-1:
- [ ] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADAuthenticationContext%2BTokenCaching.m 39'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32676960'>File: ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.m:L94-101</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> Does it create multiple entries in cache if first request has UserIdentifier's type UniqueId and second request has RequiredDisplayableId? Both of them should refer to same cache entry since it is same user.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> That would require a significant rearchitecture of our caching code. Right now we stash the username in the appropriate field in keychain, we would need more keychain properties.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Unless you feel really strongly on this, I recommend punting to redesign. This would require days of work and would be a breaking change.
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It is fine for this, but for convergence we need to match adal.net cache model.
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#issuecomment-112941500'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@RPangrle-MS__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>You've already signed the contribution license agreement. Thanks!</span>
<p>The agreement was validated by Microsoft Open Technologies, Inc. and real humans are currently evaluating your PR.</p>
TTYL, MSOTBOT;
- [x] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADAuthenticationContext%2BInternal.m 53'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32676388'>File: ADALiOS/ADALiOS/ADAuthenticationContext+Internal.m:L125-160</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> We should log this error as well.
- [x] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADAuthenticationContext%2BWebRequest.m 25'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32677190'>File: ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m:L296-305</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> UniqueId can be GUID since it is assigned from subjectid/objectid. You can use userid as a loginhint if type is not UniqueId.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> If they gave us a UniqueId as the UserIdentifier we don't have anything else to go by, we don't have the full UserInformation struct here.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> If you look at the UserIdentifier class in .NET (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/src/ADAL.Common/UserIdentifier.cs) the only fields are 'id' and 'type.' I can't call a field in ObjC 'id' because that's a reserved word in the language so I used 'userId' instead. It doesn't map to 'userId' concept in ADUserInformation, however that userId concept isn't in the .NET client either.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> In .NET it appears no login hint is passed in at all if it's not a displayableId. I will copy that behavior.
- [x] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADAuthenticationContext.h 16'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32677274'>File: ADALiOS/ADALiOS/ADAuthenticationContext.h:L274-299</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> Param order in document does not match to method.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> :+1: A number of the other document blocks have this problem, and also reference now-gone parameters.
- [x] <a href='#crh-comment-Pull 54aa3a27e6b8eaa3708e8faea2c771dba875e20b ADALiOS/ADALiOS/ADUserInformation.h 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335#discussion_r32679399'>File: ADALiOS/ADALiOS/ADUserInformation.h:L38-46</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> Add comment here. This is passed to ADUserIdentifier as ID when type if UniqueId. This is not displayable so not used as login_hint. Adal.Net stores items in the cache for uniqueID and displayableid.
- <a href='https://github.com/RPangrle-MS'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I didn't want to diverge too much from established ADALiOS behavior, at least in the default case. That means having RequiredDisplayableId mean the previous behavior. This is something we can fix in the redesign.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/335?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/335?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/335?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/335'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>