### PR TITLE
Remove duplicative code between handleBrokerResponse and resultFromBr…

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		97A522501A1A8999001D77CE /* ADClientMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */; };
 		97DFE4671AE38903008109E1 /* ADAL.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 97DFE4661AE37B42008109E1 /* ADAL.h */; };
 		97EEE7BB1A4C97A400D003F8 /* UIAlertView+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 97EEE7BA1A4C97A400D003F8 /* UIAlertView+Additions.m */; };
+		D6BD014A1B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BD01491B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.m */; };
 		D6E43A5E1B02D955000F5BE2 /* ADBrokerKeyHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 97D685AF1A107F0000EE816C /* ADBrokerKeyHelper.m */; };
 		D6E43A671B04015A000F5BE2 /* ADAuthenticationRequest+AcquireToken.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A661B04015A000F5BE2 /* ADAuthenticationRequest+AcquireToken.m */; };
 		D6E43A6A1B04026D000F5BE2 /* ADAuthenticationContext+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */; };
@@ -269,6 +270,8 @@
 		97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		97EEE7B91A4C97A400D003F8 /* UIAlertView+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIAlertView+Additions.h"; sourceTree = "<group>"; };
 		97EEE7BA1A4C97A400D003F8 /* UIAlertView+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIAlertView+Additions.m"; sourceTree = "<group>"; };
+		D6BD01481B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADTokenCacheStoreItem+Internal.h"; sourceTree = "<group>"; };
+		D6BD01491B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADTokenCacheStoreItem+Internal.m"; sourceTree = "<group>"; };
 		D6E43A651B04015A000F5BE2 /* ADAuthenticationRequest+AcquireToken.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationRequest+AcquireToken.h"; sourceTree = "<group>"; };
 		D6E43A661B04015A000F5BE2 /* ADAuthenticationRequest+AcquireToken.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationRequest+AcquireToken.m"; sourceTree = "<group>"; };
 		D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+Internal.h"; sourceTree = "<group>"; };
@@ -401,6 +404,8 @@
 				8B7E6FC71856A1E8000DC3C8 /* ADOAuth2Constants.m */,
 				8B59894C1810BEAC00744AEE /* ADTokenCacheStoreItem.h */,
 				8B59894D1810BEAC00744AEE /* ADTokenCacheStoreItem.m */,
+				D6BD01481B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.h */,
+				D6BD01491B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.m */,
 				8B5989531811B89800744AEE /* ADTokenCacheStoreKey.h */,
 				8B5989541811B89800744AEE /* ADTokenCacheStoreKey.m */,
 				8B5989561811BEC500744AEE /* ADTokenCacheStoring.h */,
@@ -725,6 +730,7 @@
 			files = (
 				971C56BE1AF2278C0034820F /* ADBrokerNotificationManager.m in Sources */,
 				D6E43A701B040A9C000F5BE2 /* ADAuthenticationRequest+AcquireAssertion.m in Sources */,
+				D6BD014A1B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.m in Sources */,
 				8B343450183305A6002DE1DC /* ADAuthenticationWebViewController.m in Sources */,
 				8B7E6FC81856A1E8000DC3C8 /* ADOAuth2Constants.m in Sources */,
 				8B343444183304FE002DE1DC /* ADWebResponse.m in Sources */,

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.m
@@ -165,9 +165,8 @@
     if (![NSString adIsStringNilOrBlank:accessToken])
     {
         [item setAuthority:self.authority];
-        [item fillItemWithResponse:response error:&error];
-        [item logWithCorrelationId:responseUUID];
-        return [ADAuthenticationResult resultFromTokenCacheStoreItem:item multiResourceRefreshToken:item.multiResourceRefreshToken];
+        BOOL isMrrt = [item fillItemWithResponse:response];
+        return [ADAuthenticationResult resultFromTokenCacheStoreItem:item multiResourceRefreshToken:isMrrt];
     }
     
     //No access token and no error, we assume that there was another kind of error (connection, server down, etc.).

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -119,36 +119,6 @@
     
     if (AD_SUCCEEDED == result.status)
     {
-        result.tokenCacheStoreItem.accessTokenType = @"Bearer";
-        // Token response
-        id expires_on = [queryParamsMap objectForKey:@"expires_on"];
-        NSDate *expires    = nil;
-        if ( expires_on != nil )
-        {
-            if ( [expires_on isKindOfClass:[NSString class]] )
-            {
-                NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-                
-                expires = [NSDate dateWithTimeIntervalSince1970:[formatter numberFromString:expires_on].longValue];
-            }
-            else if ( [expires_on isKindOfClass:[NSNumber class]] )
-            {
-                expires = [NSDate dateWithTimeIntervalSince1970:((NSNumber *)expires_on).longValue];
-            }
-            else
-            {
-                AD_LOG_WARN_F(@"Unparsable time", @"The response value for the access token expiration cannot be parsed: %@", expires);
-                // Unparseable, use default value
-                expires = [NSDate dateWithTimeIntervalSinceNow:3600.0];//1 hour
-            }
-        }
-        else
-        {
-            AD_LOG_WARN(@"Missing expiration time.", @"The server did not return the expiration time for the access token.");
-            expires = [NSDate dateWithTimeIntervalSinceNow:3600.0];//Assume 1hr expiration
-        }
-        
-        result.tokenCacheStoreItem.expiresOn = expires;
         ADAuthenticationContext* ctx = [ADAuthenticationContext
                                         authenticationContextWithAuthority:result.tokenCacheStoreItem.authority
                                         error:nil];

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -136,20 +136,10 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
         return [ADAuthenticationResult resultFromError:error];
     }
     
-    ADAuthenticationError* error = nil;
     item = [ADTokenCacheStoreItem new];
     [item setAccessTokenType:@"Bearer"];
-    [item fillItemWithResponse:response
-                         error:&error];
-    if (error)
-    {
-        return [ADAuthenticationResult resultFromError:error];
-    }
-    NSString* responseIdString = [response objectForKey:OAUTH2_CORRELATION_ID_RESPONSE];
-    NSUUID* responseId = [[NSUUID alloc] initWithUUIDString:responseIdString];
-    [item logWithCorrelationId:responseId];
-    
-    return [[ADAuthenticationResult alloc] initWithItem:item multiResourceRefreshToken:item.multiResourceRefreshToken];
+    BOOL isMRRT = [item fillItemWithResponse:response];
+    return [[ADAuthenticationResult alloc] initWithItem:item multiResourceRefreshToken:isMRRT];
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.h
@@ -1,0 +1,30 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import <Foundation/Foundation.h>
+#import "ADTokenCacheStoreItem.h"
+
+@class ADAuthenticationError;
+
+@interface ADTokenCacheStoreItem (Internal)
+
+- (void)fillItemWithResponse:(NSDictionary*)responseDictionary
+                       error:(ADAuthenticationError* __autoreleasing *)error;
+- (void)logWithCorrelationId:(NSUUID*)correlationId;
+
+@end

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.h
@@ -23,8 +23,11 @@
 
 @interface ADTokenCacheStoreItem (Internal)
 
-- (void)fillItemWithResponse:(NSDictionary*)responseDictionary
-                       error:(ADAuthenticationError* __autoreleasing *)error;
-- (void)logWithCorrelationId:(NSUUID*)correlationId;
+/*!
+    Fills out the cache item with the given response dictionary
+ 
+    @return Whether the resulting item is a Multi Resource Refresh Token
+ */
+- (BOOL)fillItemWithResponse:(NSDictionary*)responseDictionary;
 
 @end

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
@@ -1,0 +1,127 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import "ADAL.h"
+#import "ADTokenCacheStoreItem+Internal.h"
+#import "ADAuthenticationError.h"
+#import "ADOAuth2Constants.h"
+#import "ADUserInformation.h"
+#import "ADLogger.h"
+
+@implementation ADTokenCacheStoreItem (Internal)
+
+#define CHECK_ERROR(_CHECK, _ERR) { if (_CHECK) { if (error) {*error = _ERR;} return; } }
+
+- (void)fillUserInformation:(NSString*)idToken
+                      error:(ADAuthenticationError* __autoreleasing *)error
+{
+    if (!idToken)
+    {
+        return;
+    }
+    
+    ADUserInformation* info = nil;
+    ADAuthenticationError* adError = nil;
+    info = [ADUserInformation userInformationWithIdToken:idToken
+                                                   error:&adError];
+    
+    CHECK_ERROR(adError, adError);
+    
+    self.userInformation = info;
+}
+
+#define FILL_FIELD(_FIELD, _KEY) { id _val = [responseDictionary valueForKey:_KEY]; if (_val) { self._FIELD = _val; } }
+
+- (void)fillItemWithResponse:(NSDictionary*)responseDictionary
+                       error:(ADAuthenticationError* __autoreleasing *)error
+{
+    ADAuthenticationError* adError = nil;
+    CHECK_ERROR(!responseDictionary, [ADAuthenticationError errorFromArgument:responseDictionary
+                                                                 argumentName:@"responseDictionary"]);
+    
+    if (self.userInformation == nil)
+    {
+        [self fillUserInformation:[responseDictionary valueForKey:OAUTH2_ID_TOKEN]
+                            error:&adError];
+        
+        if (error)
+        {
+            *error = adError;
+        }
+    }
+    
+    FILL_FIELD(authority, OAUTH2_AUTHORITY);
+    FILL_FIELD(resource, OAUTH2_RESOURCE);
+    FILL_FIELD(clientId, OAUTH2_CLIENT_ID);
+    FILL_FIELD(accessToken, OAUTH2_ACCESS_TOKEN);
+    FILL_FIELD(refreshToken, OAUTH2_REFRESH_TOKEN);
+    FILL_FIELD(accessTokenType, OAUTH2_TOKEN_TYPE);
+    
+    // Token response
+    id expires_in = [responseDictionary objectForKey:@"expires_on"];
+    NSDate *expires    = nil;
+    
+    if ( expires_in != nil )
+    {
+        if ( [expires_in isKindOfClass:[NSString class]] )
+        {
+            NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
+            
+            expires = [NSDate dateWithTimeIntervalSinceNow:[formatter numberFromString:expires_in].longValue];
+        }
+        else if ( [expires_in isKindOfClass:[NSNumber class]] )
+        {
+            expires = [NSDate dateWithTimeIntervalSinceNow:((NSNumber *)expires_in).longValue];
+        }
+        else
+        {
+            AD_LOG_WARN_F(@"Unparsable time", @"The response value for the access token expiration cannot be parsed: %@", expires);
+            // Unparseable, use default value
+            expires = [NSDate dateWithTimeIntervalSinceNow:3600.0];//1 hour
+        }
+    }
+    else
+    {
+        AD_LOG_WARN(@"Missing expiration time.", @"The server did not return the expiration time for the access token.");
+        expires = [NSDate dateWithTimeIntervalSinceNow:3600.0];//Assume 1hr expiration
+    }
+    
+    self.expiresOn = expires;
+}
+
+- (void)logWithCorrelationId:(NSUUID*)correlationId
+{
+    if (self.accessToken)
+    {
+        [ADLogger logToken:self.accessToken
+                 tokenType:self.accessTokenType
+                 expiresOn:self.expiresOn
+             correlationId:correlationId];
+    }
+    
+    if (self.refreshToken)
+    {
+        [ADLogger logToken:self.refreshToken
+                 tokenType:self.multiResourceRefreshToken ? @"multi-resource refresh token" : @"refresh token"
+                 expiresOn:nil
+             correlationId:correlationId];
+    }
+}
+
+
+@end


### PR DESCRIPTION
…okerResponse.

Clear up some of the error handling codepaths.

This mirrors some of the changes in OSXUniversal
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23issuecomment-117822143%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23issuecomment-119012419%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23issuecomment-119406855%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r33737714%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r33737864%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r34112636%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r34219002%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23issuecomment-117822143%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40RPangrle__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla2.msopentech.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-01T20%3A59%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40RPangrle__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSOTBOT%3B%22%2C%20%22created_at%22%3A%20%222015-07-06T22%3A15%3A53Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-08T03%3A03%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20f2e45e015b4e6c29529de1c7198ab169443c4364%20ADALiOS/ADALiOS/ADAuthenticationResult%252BInternal.m%2055%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r33737864%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22If%20you%20log%20that%20response%20exists%2C%20but%20idtoken%20is%20failed%20to%20decode.%22%2C%20%22created_at%22%3A%20%222015-07-02T00%3A14%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20ended%20up%20copying%20over%20the%20existing%20behavior%20on%20the%20non-broker%20code%20path%20where%20if%20idtoken%20fails%20to%20decode%20it%27ll%20just%20continue%20onwards.%20Whether%20or%20not%20that%27s%20the%20right%20behavior%20for%20either%20case%20is%20up%20for%20discussion.%20%3A%2B1%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-09T02%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationResult%2BInternal.m%3AL109-163%22%7D%2C%20%22Pull%20f2e45e015b4e6c29529de1c7198ab169443c4364%20ADALiOS/ADALiOS/ADAuthenticationResult%252BInternal.m%2061%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348%23discussion_r33737714%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22It%20will%20be%20better%20if%20you%20create%20a%20factory%20method%20that%20creates%20ADTokenCacheStoreItem%20%20from%20%20%28NSDictionary%2A%29%20response.%22%2C%20%22created_at%22%3A%20%222015-07-02T00%3A11%3A13Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-07-08T03%3A03%3A49Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationResult%2BInternal.m%3AL109-163%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348#issuecomment-117822143'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@RPangrle__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla2.msopentech.com.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> __@RPangrle__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSOTBOT;
- [x] <a href='#crh-comment-Pull f2e45e015b4e6c29529de1c7198ab169443c4364 ADALiOS/ADALiOS/ADAuthenticationResult%2BInternal.m 61'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348#discussion_r33737714'>File: ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m:L109-163</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> It will be better if you create a factory method that creates ADTokenCacheStoreItem  from  (NSDictionary*) response.
- [x] <a href='#crh-comment-Pull f2e45e015b4e6c29529de1c7198ab169443c4364 ADALiOS/ADALiOS/ADAuthenticationResult%2BInternal.m 55'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348#discussion_r33737864'>File: ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m:L109-163</a></b>
- <a href='https://github.com/omercs'><img border=0 src='https://avatars.githubusercontent.com/u/466805?v=3' height=16 width=16'></a> If you log that response exists, but idtoken is failed to decode.
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I ended up copying over the existing behavior on the non-broker code path where if idtoken fails to decode it'll just continue onwards. Whether or not that's the right behavior for either case is up for discussion. :+1:


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/348?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/348?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/348'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>