### PR TITLE
Adding code to prevent error dialog from popping up

### DIFF
--- a/ADAL-OSX/ADAL-OSX.xcodeproj/project.pbxproj
+++ b/ADAL-OSX/ADAL-OSX.xcodeproj/project.pbxproj
@@ -110,7 +110,7 @@
 		97EEE7CE1A52110600D003F8 /* ADNTLMHandlerOSX.m in Sources */ = {isa = PBXBuildFile; fileRef = 97EEE7CD1A52110600D003F8 /* ADNTLMHandlerOSX.m */; };
 		97EEE7D31A52758A00D003F8 /* ADCredentialCollectionController.h in Headers */ = {isa = PBXBuildFile; fileRef = 97EEE7D11A52758A00D003F8 /* ADCredentialCollectionController.h */; };
 		97EEE7D41A52758A00D003F8 /* ADCredentialCollectionController.m in Sources */ = {isa = PBXBuildFile; fileRef = 97EEE7D21A52758A00D003F8 /* ADCredentialCollectionController.m */; };
-		D6E242941B0E9B6600CC2904 /* ADAuthenticationBroker+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E242921B0E9B6600CC2904 /* ADAuthenticationBroker+Test.m */; };
+		9858B5C01B5037E900A5F3BA /* ADAuthenticationBroker+Test.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E242921B0E9B6600CC2904 /* ADAuthenticationBroker+Test.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -639,7 +639,6 @@
 				4C60D60718C697E500F9EAAE /* ADOAuth2Constants.m in Sources */,
 				4C8AB1C518E2336B005F241A /* ADAuthenticationBrokerOSX.m in Sources */,
 				4C60D5F218C697E500F9EAAE /* ADAuthenticationResult.m in Sources */,
-				D6E242941B0E9B6600CC2904 /* ADAuthenticationBroker+Test.m in Sources */,
 				4C60D5EE18C697E500F9EAAE /* ADAuthenticationParameters.m in Sources */,
 				4C60D60518C697E500F9EAAE /* ADLogger.m in Sources */,
 			);
@@ -652,6 +651,7 @@
 				8BE8682618D7BA5100D95ABB /* ADAuthenticationParametersTests.m in Sources */,
 				8BE8681118D7B60C00D95ABB /* NSURLExtensionsTests.m in Sources */,
 				8BE8682A18D7BA5100D95ABB /* ADLoggerTests.m in Sources */,
+				9858B5C01B5037E900A5F3BA /* ADAuthenticationBroker+Test.m in Sources */,
 				8BE8682F18D7BA5100D95ABB /* ADTokenCacheStoreKeyTests.m in Sources */,
 				8BE8682918D7BA5100D95ABB /* ADInstanceDiscoveryTests.m in Sources */,
 				8BE8683018D7BA5100D95ABB /* ADUserInformationTests.m in Sources */,

--- a/ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m
+++ b/ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m
@@ -125,6 +125,14 @@
 #pragma unused(sender)
     if ([_parentDelegate respondsToSelector:@selector(webView:didFailProvisionalLoadWithError:forFrame:)])
         [_parentDelegate webView:sender didFailProvisionalLoadWithError:error forFrame:frame];
+    
+    if (NSURLErrorCancelled == error.code)
+    {
+        //This is a common error that webview generates and could be ignored.
+        //See this thread for details: https://discussions.apple.com/thread/1727260
+        return;
+    }
+    
     [self handleError:error toFrame:frame];
 }
 


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23issuecomment-119365021%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23discussion_r34214447%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23discussion_r34376140%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23issuecomment-120476892%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23issuecomment-119365021%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40cesarami__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20This%20seems%20like%20a%20small%20%28but%20important%29%20contribution%2C%20so%20no%20Contribution%20License%20Agreement%20is%20required%20at%20this%20point.%20Real%20humans%20will%20now%20evaluate%20your%20PR.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-07T22%3A42%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22Added%20one%20more%20commit.%20THere%20was%20a%20test%20class%20that%20was%20part%20of%20the%20library%20target%20instead%20of%20the%20test%20target.%22%2C%20%22created_at%22%3A%20%222015-07-10T17%3A49%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12160250%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cesarami%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%20a7a547e670dc6886fe8206eb03e6f1fada50cf4f%20ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m%2011%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350%23discussion_r34214447%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Any%20reason%20why%20this%20fix%20is%20OS%20X%20only%3F%22%2C%20%22created_at%22%3A%20%222015-07-09T00%3A44%3A34Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22This%20is%20already%20on%20iOS.%20You%20can%20find%20it%20in%20ADAuthenticationWebViewController%3A219%22%2C%20%22created_at%22%3A%20%222015-07-10T17%3A26%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/12160250%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/cesarami%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m%3AL125-139%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350#issuecomment-119365021'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@cesarami__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>
This seems like a small (but important) contribution, so no Contribution License Agreement is required at this point. Real humans will now evaluate your PR.
</span>
TTYL, MSOTBOT;
- <a href='https://github.com/cesarami'><img border=0 src='https://avatars.githubusercontent.com/u/12160250?v=3' height=16 width=16'></a> Added one more commit. THere was a test class that was part of the library target instead of the test target.
- [ ] <a href='#crh-comment-Pull a7a547e670dc6886fe8206eb03e6f1fada50cf4f ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m 11'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350#discussion_r34214447'>File: ADAL-OSX/ADAL-OSX/ADAuthenticationWebViewControllerOSX.m:L125-139</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Any reason why this fix is OS X only?
- <a href='https://github.com/cesarami'><img border=0 src='https://avatars.githubusercontent.com/u/12160250?v=3' height=16 width=16'></a> This is already on iOS. You can find it in ADAuthenticationWebViewController:219


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/350?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/350?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/350'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>