### PR TITLE
Fix double encoding issue

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+WebRequest.m
@@ -114,24 +114,12 @@
         endPoint = [authorizationServer stringByAppendingString:OAUTH2_TOKEN_SUFFIX];
     }
     
-    NSURL *endpointUrl = [NSURL URLWithString:endPoint];
-    
     if(isGetRequest)
     {
-        NSURLComponents *components = [[NSURLComponents alloc] initWithString:endPoint];
-        NSString* query = [components query];
-        
-        if (query)
-        {
-            [components setQuery:[query stringByAppendingString:[request_data adURLFormEncode]]];
-        }
-        else
-        {
-            [components setQuery:[request_data adURLFormEncode]];
-        }
-        
-        endpointUrl = [components URL];
+        endPoint = [NSString stringWithFormat:@"%@?%@", endPoint, [request_data adURLFormEncode]];
     }
+    
+    NSURL *endpointUrl = [NSURL URLWithString:endPoint];
     
     ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:endpointUrl
                                                    correlationId:requestCorrelationId];


### PR DESCRIPTION
NSURLComponents percent encodes strings set into it, causing double encoding of query params in this GET case.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/355%23issuecomment-126787856%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/355%23issuecomment-126806507%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/355%23issuecomment-126787856%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40RPangrle__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Open%20Technologies%2C%20Inc.%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSOTBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3EYou%27ve%20already%20signed%20the%20contribution%20license%20agreement.%20Thanks%21%3C/span%3E%5Cr%5Cn%20%20%20%20%20%20%20%20%3Cp%3EThe%20agreement%20was%20validated%20by%20Microsoft%20Open%20Technologies%2C%20Inc.%20and%20real%20humans%20are%20currently%20evaluating%20your%20PR.%3C/p%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSOTBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-07-31T19%3A11%3A54Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9519461%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msotclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%20%22%2C%20%22created_at%22%3A%20%222015-07-31T20%3A35%3A01Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/omercs%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/omercs%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/466805%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/omercs'><img src='https://avatars.githubusercontent.com/u/466805?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/355#issuecomment-126787856'>General Comment</a></b>
- <a href='https://github.com/msotclas'><img border=0 src='https://avatars.githubusercontent.com/u/9519461?v=3' height=16 width=16'></a> Hi __@RPangrle__, I'm your friendly neighborhood Microsoft Open Technologies, Inc. Pull Request Bot (You can call me MSOTBOT). Thanks for your contribution!
<span>You've already signed the contribution license agreement. Thanks!</span>
<p>The agreement was validated by Microsoft Open Technologies, Inc. and real humans are currently evaluating your PR.</p>
TTYL, MSOTBOT;


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/355?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/355?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/355?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/355'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>