### PR TITLE
Preventing override of user set WebView

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.h
@@ -19,6 +19,7 @@
 @interface ADAuthenticationWebViewController : NSObject <UIWebViewDelegate, NSURLConnectionDelegate>
 
 @property (weak, nonatomic) id<ADAuthenticationDelegate> delegate;
+@property (weak, nonatomic) id<UIWebViewDelegate> customDelegate;
 
 - (id)initWithWebView:(UIWebView *)webView startAtURL:(NSURL *)startURL endAtURL:(NSURL *)endURL;
 - (void)start;

--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
@@ -57,6 +57,11 @@ NSTimer *timer;
         _complete  = NO;
         _timeout = [[ADAuthenticationSettings sharedInstance] requestTimeOut];
         _webView          = webView;
+        
+        //Storing the previous webview delegate since we are replacing it
+        if(webView.delegate)
+            _customDelegate = _webView.delegate;
+        
         _webView.delegate = self;
         [ADNTLMHandler setCancellationUrl:[_startURL absoluteString]];
     }
@@ -116,6 +121,10 @@ NSTimer *timer;
 #pragma unused(webView)
 #pragma unused(navigationType)
     
+    if(_customDelegate){
+        [_customDelegate webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];
+    }
+    
     if([ADNTLMHandler isChallengeCancelled]){
         _complete = YES;
         dispatch_async( dispatch_get_main_queue(), ^{[_delegate webAuthenticationDidCancel];});
@@ -166,6 +175,10 @@ NSTimer *timer;
     if (timer != nil){
         [timer invalidate];
     }
+    if(_customDelegate){
+        [_customDelegate webViewDidStartLoad:webView];
+    }
+
 #pragma unused(webView)
     timer = [NSTimer scheduledTimerWithTimeInterval:_timeout target:self selector:@selector(failWithTimeout) userInfo:nil repeats:NO];
 }
@@ -175,6 +188,10 @@ NSTimer *timer;
 #pragma unused(webView)
     [timer invalidate];
     timer = nil;
+    
+    if(_customDelegate){
+        [_customDelegate webViewDidFinishLoad:webView];
+    }
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error

--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
@@ -118,13 +118,16 @@ NSTimer *timer;
 
 - (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
 {
+    if(_customDelegate){
+        if ([_customDelegate respondsToSelector:@selector(webView: shouldStartLoadWithRequest: navigationType:)]) {
+            [_customDelegate webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];
+        }
+    }
+    
 #pragma unused(webView)
 #pragma unused(navigationType)
     
-    if(_customDelegate){
-        [_customDelegate webView:webView shouldStartLoadWithRequest:request navigationType:navigationType];
-    }
-    
+
     if([ADNTLMHandler isChallengeCancelled]){
         _complete = YES;
         dispatch_async( dispatch_get_main_queue(), ^{[_delegate webAuthenticationDidCancel];});
@@ -176,7 +179,9 @@ NSTimer *timer;
         [timer invalidate];
     }
     if(_customDelegate){
-        [_customDelegate webViewDidStartLoad:webView];
+        if ([_customDelegate respondsToSelector:@selector(webViewDidStartLoad:)]) {
+            [_customDelegate webViewDidStartLoad:webView];
+        }
     }
 
 #pragma unused(webView)
@@ -185,17 +190,25 @@ NSTimer *timer;
 
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
+    
+    if(_customDelegate){
+        if ([_customDelegate respondsToSelector:@selector(webViewDidFinishLoad:)]) {
+            [_customDelegate webViewDidFinishLoad:webView];
+        }
+    }
 #pragma unused(webView)
     [timer invalidate];
     timer = nil;
-    
-    if(_customDelegate){
-        [_customDelegate webViewDidFinishLoad:webView];
-    }
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
 {
+    if(_customDelegate){
+        if ([_customDelegate respondsToSelector:@selector(webView: didFailLoadWithError:)]) {
+            [_customDelegate webViewDidFinishLoad:webView];
+        }
+    }
+    
 #pragma unused(webView)
     if(timer && [timer isValid]){
         [timer invalidate];


### PR DESCRIPTION
Would be helpful to not override users webview delegate when passing a custom webview for login.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-127754468%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-127756250%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-131797994%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-131798013%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-131940014%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-131952781%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356%23issuecomment-127754468%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Hi%20__%40nhart12__%2C%20I%27m%20your%20friendly%20neighborhood%20Microsoft%20Pull%20Request%20Bot%20%28You%20can%20call%20me%20MSBOT%29.%20Thanks%20for%20your%20contribution%21%5Cr%5Cn%20%20%20%20%3Cspan%3E%5Cr%5Cn%20%20%20%20%20%20%20%20In%20order%20for%20us%20to%20evaluate%20and%20accept%20your%20PR%2C%20we%20ask%20that%20you%20sign%20a%20contribution%20license%20agreement.%20It%27s%20all%20electronic%20and%20will%20take%20just%20minutes.%20I%20promise%20there%27s%20no%20faxing.%20https%3A//cla.microsoft.com.%5Cr%5Cn%20%20%20%20%3C/span%3E%5Cr%5Cn%5Cr%5CnTTYL%2C%20MSBOT%3B%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-04T20%3A38%3A17Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22__%40nhart12__%2C%20Thanks%20for%20signing%20the%20contribution%20license%20agreement%20so%20quickly%21%20Actual%20humans%20will%20now%20validate%20the%20agreement%20and%20then%20evaluate%20the%20PR.%5Cr%5Cn%3Cbr%20/%3EThanks%2C%20MSBOT%3B%22%2C%20%22created_at%22%3A%20%222015-08-04T20%3A44%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/9287708%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/msftclas%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A19%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8458409%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nhart12%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-08-17T12%3A19%3A59Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8458409%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nhart12%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20hoping%20to%20have%20something%20soonish%20that%20will%20accomplish%20a%20similar%20goal%2C%20but%20I%20want%20to%20avoid%20using%20UIWebViewDelegate%20because%20it%20doesn%27t%20work%20on%20Mac%20and%20implies%20greater%20support/functionality%20then%20we%20want%20to%20provide.%20%28It%27ll%20probably%20be%20called%20ADWebDelegate%2C%20or%20something%20of%20the%20sort%29%20I%27d%20also%20prefer%20something%20a%20little%20more%20explicit%20from%20the%20API%20side%20then%20grabbing%20whatever%20delegate%20was%20previously%20on%20the%20webview.%22%2C%20%22created_at%22%3A%20%222015-08-17T19%3A43%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22That%20makes%20sense.%20I%27m%20glad%20you%20have%20something%20in%20the%20pipeline%20for%20this.%5Cr%5Cn%22%2C%20%22created_at%22%3A%20%222015-08-17T20%3A30%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8458409%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/nhart12%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/nhart12%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/8458409%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/nhart12'><img src='https://avatars.githubusercontent.com/u/8458409?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356#issuecomment-127754468'>General Comment</a></b>
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> Hi __@nhart12__, I'm your friendly neighborhood Microsoft Pull Request Bot (You can call me MSBOT). Thanks for your contribution!
<span>
In order for us to evaluate and accept your PR, we ask that you sign a contribution license agreement. It's all electronic and will take just minutes. I promise there's no faxing. https://cla.microsoft.com.
</span>
TTYL, MSBOT;
- <a href='https://github.com/msftclas'><img border=0 src='https://avatars.githubusercontent.com/u/9287708?v=3' height=16 width=16'></a> __@nhart12__, Thanks for signing the contribution license agreement so quickly! Actual humans will now validate the agreement and then evaluate the PR.
<br />Thanks, MSBOT;
- <a href='https://github.com/nhart12'><img border=0 src='https://avatars.githubusercontent.com/u/8458409?v=3' height=16 width=16'></a> :+1:
- <a href='https://github.com/nhart12'><img border=0 src='https://avatars.githubusercontent.com/u/8458409?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I'm hoping to have something soonish that will accomplish a similar goal, but I want to avoid using UIWebViewDelegate because it doesn't work on Mac and implies greater support/functionality then we want to provide. (It'll probably be called ADWebDelegate, or something of the sort) I'd also prefer something a little more explicit from the API side then grabbing whatever delegate was previously on the webview.
- <a href='https://github.com/nhart12'><img border=0 src='https://avatars.githubusercontent.com/u/8458409?v=3' height=16 width=16'></a> That makes sense. I'm glad you have something in the pipeline for this.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/356?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/356?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/356?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/356'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>