### PR TITLE
Real b2c -> convergence-dev

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 		D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
 		D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */ = {isa = PBXBuildFile; fileRef = D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */; };
 		FB4C7C1E1BA0DF5F003B93C5 /* ADPolicyItem.m in Sources */ = {isa = PBXBuildFile; fileRef = FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */; settings = {ASSET_TAGS = (); }; };
+		FB538EF01BA32BEE003ABD9A /* NSString+ADExtentions.m in Sources */ = {isa = PBXBuildFile; fileRef = FB538EEF1BA32BEE003ABD9A /* NSString+ADExtentions.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -301,6 +302,8 @@
 		D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADUserIdentifier.m; sourceTree = "<group>"; };
 		FB4C7C1C1BA0DF5F003B93C5 /* ADPolicyItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADPolicyItem.h; sourceTree = "<group>"; };
 		FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADPolicyItem.m; sourceTree = "<group>"; };
+		FB538EEE1BA32BEE003ABD9A /* NSString+ADExtentions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+ADExtentions.h"; sourceTree = "<group>"; };
+		FB538EEF1BA32BEE003ABD9A /* NSString+ADExtentions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+ADExtentions.m"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -456,6 +459,8 @@
 				9453EF081B581C73007EF5E8 /* NSArray+ADExtensions.m */,
 				FB4C7C1C1BA0DF5F003B93C5 /* ADPolicyItem.h */,
 				FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */,
+				FB538EEE1BA32BEE003ABD9A /* NSString+ADExtentions.h */,
+				FB538EEF1BA32BEE003ABD9A /* NSString+ADExtentions.m */,
 			);
 			path = ADALiOS;
 			sourceTree = "<group>";
@@ -788,6 +793,7 @@
 				8B5989551811B89800744AEE /* ADTokenCacheStoreKey.m in Sources */,
 				8B0DA7DE182AD01100CF5E1E /* ADAuthenticationResult+Internal.m in Sources */,
 				972A58A81A4AB5580054BE11 /* ADNTLMHandler.m in Sources */,
+				FB538EF01BA32BEE003ABD9A /* NSString+ADExtentions.m in Sources */,
 				FB4C7C1E1BA0DF5F003B93C5 /* ADPolicyItem.m in Sources */,
 				8B5989511811A3DB00744AEE /* ADAuthenticationError.m in Sources */,
 				D6E43A6A1B04026D000F5BE2 /* ADAuthenticationContext+Internal.m in Sources */,

--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -105,6 +105,62 @@
 		D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */ = {isa = PBXBuildFile; fileRef = D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */; };
 		FB4C7C1E1BA0DF5F003B93C5 /* ADPolicyItem.m in Sources */ = {isa = PBXBuildFile; fileRef = FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */; settings = {ASSET_TAGS = (); }; };
 		FB538EF01BA32BEE003ABD9A /* NSString+ADExtentions.m in Sources */ = {isa = PBXBuildFile; fileRef = FB538EEF1BA32BEE003ABD9A /* NSString+ADExtentions.m */; settings = {ASSET_TAGS = (); }; };
+		FB538EF21BA34299003ABD9A /* ADAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 97DFE4661AE37B42008109E1 /* ADAL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF31BA34299003ABD9A /* ADPkeyAuthHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 97345B90199160BD0044B1A6 /* ADPkeyAuthHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF41BA34299003ABD9A /* ADRegistrationInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9722232719A2C9F900092E85 /* ADRegistrationInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF51BA34299003ABD9A /* ADWorkPlaceJoin.h in Headers */ = {isa = PBXBuildFile; fileRef = 9722232919A2C9F900092E85 /* ADWorkPlaceJoin.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF61BA34299003ABD9A /* ADWorkPlaceJoinConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = 9722232B19A2C9F900092E85 /* ADWorkPlaceJoinConstants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF71BA34299003ABD9A /* ADWorkPlaceJoinUtil.h in Headers */ = {isa = PBXBuildFile; fileRef = 9722232C19A2C9F900092E85 /* ADWorkPlaceJoinUtil.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF81BA34299003ABD9A /* ADAuthenticationContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8345A18074A58007F9F0D /* ADAuthenticationContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EF91BA34299003ABD9A /* ADAuthenticationContext+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFA1BA34299003ABD9A /* ADAuthenticationContext+TokenCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A6B1B040603000F5BE2 /* ADAuthenticationContext+TokenCaching.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFB1BA34299003ABD9A /* ADAuthenticationError.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B59894F1811A3DB00744AEE /* ADAuthenticationError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFC1BA34299003ABD9A /* ADAuthenticationOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B598938180DE00300744AEE /* ADAuthenticationOperation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFD1BA34299003ABD9A /* ADAuthenticationParameters+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BD14617182189C800796E79 /* ADAuthenticationParameters+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFE1BA34299003ABD9A /* ADAuthenticationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8346018074CFA007F9F0D /* ADAuthenticationParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538EFF1BA34299003ABD9A /* ADAuthenticationRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 949B3A9A1B3DEAAD00381438 /* ADAuthenticationRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F001BA34299003ABD9A /* ADAuthenticationRequest+AcquireAssertion.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A6E1B040A9C000F5BE2 /* ADAuthenticationRequest+AcquireAssertion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F011BA34299003ABD9A /* ADAuthenticationRequest+AcquireToken.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A651B04015A000F5BE2 /* ADAuthenticationRequest+AcquireToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F021BA34299003ABD9A /* ADAuthenticationRequest+Broker.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A741B04142C000F5BE2 /* ADAuthenticationRequest+Broker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F031BA34299003ABD9A /* ADAuthenticationRequest+WebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = D6E43A711B040ED5000F5BE2 /* ADAuthenticationRequest+WebRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F041BA34299003ABD9A /* ADAuthenticationResult+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B0DA7DC182AD01100CF5E1E /* ADAuthenticationResult+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F051BA34299003ABD9A /* ADAuthenticationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB8345D18074B74007F9F0D /* ADAuthenticationResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F061BA34299003ABD9A /* ADAuthenticationSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 8BB83463180764B6007F9F0D /* ADAuthenticationSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F071BA3429A003ABD9A /* ADErrorCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B598946180DF6F000744AEE /* ADErrorCodes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F081BA3429A003ABD9A /* ADInstanceDiscovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B6113FF186E517D007759C2 /* ADInstanceDiscovery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F091BA3429A003ABD9A /* ADKeychainQuery.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453EF041B53070C007EF5E8 /* ADKeychainQuery.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0A1BA3429A003ABD9A /* ADLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B92DB6E181B2335004AAB0E /* ADLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0B1BA3429A003ABD9A /* ADOAuth2Constants.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B7E6FC61856A1E8000DC3C8 /* ADOAuth2Constants.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0C1BA3429A003ABD9A /* ADTokenCacheStoreItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B59894C1810BEAC00744AEE /* ADTokenCacheStoreItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0D1BA3429A003ABD9A /* ADTokenCacheStoreItem+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = D6BD01481B4C7D7F008AB2B0 /* ADTokenCacheStoreItem+Internal.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0E1BA3429A003ABD9A /* ADTokenCacheStoreKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5989531811B89800744AEE /* ADTokenCacheStoreKey.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F0F1BA3429A003ABD9A /* ADTokenCacheStoring.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B5989561811BEC500744AEE /* ADTokenCacheStoring.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F101BA3429A003ABD9A /* ADKeychainItem.h in Headers */ = {isa = PBXBuildFile; fileRef = D68D582A1B83B3A6000C15A3 /* ADKeychainItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F111BA3429A003ABD9A /* ADKeychainTokenCacheStore.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B8FD799188223770070B1BE /* ADKeychainTokenCacheStore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F121BA3429A003ABD9A /* ADProfileInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B59893C180DE8A100744AEE /* ADProfileInfo.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F131BA3429A003ABD9A /* ADNTLMHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 972A58A61A4AB5580054BE11 /* ADNTLMHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F141BA3429A003ABD9A /* UIApplication+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B3434451833057F002DE1DC /* UIApplication+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F151BA3429A003ABD9A /* ADAuthenticationBroker.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34344818330591002DE1DC /* ADAuthenticationBroker.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F161BA3429A003ABD9A /* ADAuthenticationViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34344B183305A6002DE1DC /* ADAuthenticationViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F171BA3429A003ABD9A /* ADAuthenticationWebViewController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34344D183305A6002DE1DC /* ADAuthenticationWebViewController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F181BA3429A003ABD9A /* NSDictionary+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34343518330474002DE1DC /* NSDictionary+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F191BA3429A003ABD9A /* NSURL+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34343B183304B1002DE1DC /* NSURL+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1A1BA3429A003ABD9A /* ADAuthenticationDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34343E183304C9002DE1DC /* ADAuthenticationDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1B1BA3429B003ABD9A /* ADWebRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B34343F183304FE002DE1DC /* ADWebRequest.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1C1BA3429B003ABD9A /* ADWebResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B343441183304FE002DE1DC /* ADWebResponse.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1D1BA3429B003ABD9A /* UIAlertView+Additions.h in Headers */ = {isa = PBXBuildFile; fileRef = 97EEE7B91A4C97A400D003F8 /* UIAlertView+Additions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1E1BA3429B003ABD9A /* ADCustomHeaderHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 971C57C71AFFFE010034820F /* ADCustomHeaderHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F1F1BA3429B003ABD9A /* NSString+ADHelperMethods.h in Headers */ = {isa = PBXBuildFile; fileRef = 8B92DB6A181ADE44004AAB0E /* NSString+ADHelperMethods.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F201BA3429B003ABD9A /* ADBrokerKeyHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 97D685B11A107F1E00EE816C /* ADBrokerKeyHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F211BA3429B003ABD9A /* ADHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A5224A1A1A7583001D77CE /* ADHelpers.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F221BA3429B003ABD9A /* ADJwtHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = 9727D4D11A8753C300774236 /* ADJwtHelper.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F231BA3429B003ABD9A /* ADBrokerNotificationManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 971C56BC1AF2278C0034820F /* ADBrokerNotificationManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F241BA3429B003ABD9A /* ADUserIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F251BA3429B003ABD9A /* NSUUID+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 94351A9E1B3F67FB00CD5F5E /* NSUUID+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F261BA3429B003ABD9A /* NSSet+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = D6BD014E1B50A194008AB2B0 /* NSSet+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F271BA3429B003ABD9A /* NSArray+ADExtensions.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453EF071B581C73007EF5E8 /* NSArray+ADExtensions.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F281BA3429B003ABD9A /* ADPolicyItem.h in Headers */ = {isa = PBXBuildFile; fileRef = FB4C7C1C1BA0DF5F003B93C5 /* ADPolicyItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		FB538F291BA3429C003ABD9A /* NSString+ADExtentions.h in Headers */ = {isa = PBXBuildFile; fileRef = FB538EEE1BA32BEE003ABD9A /* NSString+ADExtentions.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -631,6 +687,72 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		FB538EF11BA34215003ABD9A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				FB538EF21BA34299003ABD9A /* ADAL.h in Headers */,
+				FB538EF31BA34299003ABD9A /* ADPkeyAuthHelper.h in Headers */,
+				FB538EF41BA34299003ABD9A /* ADRegistrationInformation.h in Headers */,
+				FB538EF51BA34299003ABD9A /* ADWorkPlaceJoin.h in Headers */,
+				FB538EF61BA34299003ABD9A /* ADWorkPlaceJoinConstants.h in Headers */,
+				FB538EF71BA34299003ABD9A /* ADWorkPlaceJoinUtil.h in Headers */,
+				FB538EF81BA34299003ABD9A /* ADAuthenticationContext.h in Headers */,
+				FB538EF91BA34299003ABD9A /* ADAuthenticationContext+Internal.h in Headers */,
+				FB538EFA1BA34299003ABD9A /* ADAuthenticationContext+TokenCaching.h in Headers */,
+				FB538EFB1BA34299003ABD9A /* ADAuthenticationError.h in Headers */,
+				FB538EFC1BA34299003ABD9A /* ADAuthenticationOperation.h in Headers */,
+				FB538EFD1BA34299003ABD9A /* ADAuthenticationParameters+Internal.h in Headers */,
+				FB538EFE1BA34299003ABD9A /* ADAuthenticationParameters.h in Headers */,
+				FB538EFF1BA34299003ABD9A /* ADAuthenticationRequest.h in Headers */,
+				FB538F001BA34299003ABD9A /* ADAuthenticationRequest+AcquireAssertion.h in Headers */,
+				FB538F011BA34299003ABD9A /* ADAuthenticationRequest+AcquireToken.h in Headers */,
+				FB538F021BA34299003ABD9A /* ADAuthenticationRequest+Broker.h in Headers */,
+				FB538F031BA34299003ABD9A /* ADAuthenticationRequest+WebRequest.h in Headers */,
+				FB538F041BA34299003ABD9A /* ADAuthenticationResult+Internal.h in Headers */,
+				FB538F051BA34299003ABD9A /* ADAuthenticationResult.h in Headers */,
+				FB538F061BA34299003ABD9A /* ADAuthenticationSettings.h in Headers */,
+				FB538F071BA3429A003ABD9A /* ADErrorCodes.h in Headers */,
+				FB538F081BA3429A003ABD9A /* ADInstanceDiscovery.h in Headers */,
+				FB538F091BA3429A003ABD9A /* ADKeychainQuery.h in Headers */,
+				FB538F0A1BA3429A003ABD9A /* ADLogger.h in Headers */,
+				FB538F0B1BA3429A003ABD9A /* ADOAuth2Constants.h in Headers */,
+				FB538F0C1BA3429A003ABD9A /* ADTokenCacheStoreItem.h in Headers */,
+				FB538F0D1BA3429A003ABD9A /* ADTokenCacheStoreItem+Internal.h in Headers */,
+				FB538F0E1BA3429A003ABD9A /* ADTokenCacheStoreKey.h in Headers */,
+				FB538F0F1BA3429A003ABD9A /* ADTokenCacheStoring.h in Headers */,
+				FB538F101BA3429A003ABD9A /* ADKeychainItem.h in Headers */,
+				FB538F111BA3429A003ABD9A /* ADKeychainTokenCacheStore.h in Headers */,
+				FB538F121BA3429A003ABD9A /* ADProfileInfo.h in Headers */,
+				FB538F131BA3429A003ABD9A /* ADNTLMHandler.h in Headers */,
+				FB538F141BA3429A003ABD9A /* UIApplication+ADExtensions.h in Headers */,
+				FB538F151BA3429A003ABD9A /* ADAuthenticationBroker.h in Headers */,
+				FB538F161BA3429A003ABD9A /* ADAuthenticationViewController.h in Headers */,
+				FB538F171BA3429A003ABD9A /* ADAuthenticationWebViewController.h in Headers */,
+				FB538F181BA3429A003ABD9A /* NSDictionary+ADExtensions.h in Headers */,
+				FB538F191BA3429A003ABD9A /* NSURL+ADExtensions.h in Headers */,
+				FB538F1A1BA3429A003ABD9A /* ADAuthenticationDelegate.h in Headers */,
+				FB538F1B1BA3429B003ABD9A /* ADWebRequest.h in Headers */,
+				FB538F1C1BA3429B003ABD9A /* ADWebResponse.h in Headers */,
+				FB538F1D1BA3429B003ABD9A /* UIAlertView+Additions.h in Headers */,
+				FB538F1E1BA3429B003ABD9A /* ADCustomHeaderHandler.h in Headers */,
+				FB538F1F1BA3429B003ABD9A /* NSString+ADHelperMethods.h in Headers */,
+				FB538F201BA3429B003ABD9A /* ADBrokerKeyHelper.h in Headers */,
+				FB538F211BA3429B003ABD9A /* ADHelpers.h in Headers */,
+				FB538F221BA3429B003ABD9A /* ADJwtHelper.h in Headers */,
+				FB538F231BA3429B003ABD9A /* ADBrokerNotificationManager.h in Headers */,
+				FB538F241BA3429B003ABD9A /* ADUserIdentifier.h in Headers */,
+				FB538F251BA3429B003ABD9A /* NSUUID+ADExtensions.h in Headers */,
+				FB538F261BA3429B003ABD9A /* NSSet+ADExtensions.h in Headers */,
+				FB538F271BA3429B003ABD9A /* NSArray+ADExtensions.h in Headers */,
+				FB538F281BA3429B003ABD9A /* ADPolicyItem.h in Headers */,
+				FB538F291BA3429C003ABD9A /* NSString+ADExtentions.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		8B0965A917F25770002BDFB8 /* ADALiOS */ = {
 			isa = PBXNativeTarget;
@@ -640,6 +762,7 @@
 				8B0965A617F25770002BDFB8 /* Sources */,
 				8B0965A717F25770002BDFB8 /* Frameworks */,
 				8B19339718BAEDE4008FD93A /* ShellScript */,
+				FB538EF11BA34215003ABD9A /* Headers */,
 			);
 			buildRules = (
 			);

--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		D6E43A761B04142C000F5BE2 /* ADAuthenticationRequest+Broker.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A751B04142C000F5BE2 /* ADAuthenticationRequest+Broker.m */; };
 		D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
 		D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */ = {isa = PBXBuildFile; fileRef = D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */; };
+		FB4C7C1E1BA0DF5F003B93C5 /* ADPolicyItem.m in Sources */ = {isa = PBXBuildFile; fileRef = FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */; settings = {ASSET_TAGS = (); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -298,6 +299,8 @@
 		D6E43A751B04142C000F5BE2 /* ADAuthenticationRequest+Broker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationRequest+Broker.m"; sourceTree = "<group>"; };
 		D6FB3E3A1B30D3630032F883 /* ADUserIdentifier.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADUserIdentifier.h; sourceTree = "<group>"; };
 		D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADUserIdentifier.m; sourceTree = "<group>"; };
+		FB4C7C1C1BA0DF5F003B93C5 /* ADPolicyItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADPolicyItem.h; sourceTree = "<group>"; };
+		FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADPolicyItem.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -451,6 +454,8 @@
 				D6BD014F1B50A194008AB2B0 /* NSSet+ADExtensions.m */,
 				9453EF071B581C73007EF5E8 /* NSArray+ADExtensions.h */,
 				9453EF081B581C73007EF5E8 /* NSArray+ADExtensions.m */,
+				FB4C7C1C1BA0DF5F003B93C5 /* ADPolicyItem.h */,
+				FB4C7C1D1BA0DF5F003B93C5 /* ADPolicyItem.m */,
 			);
 			path = ADALiOS;
 			sourceTree = "<group>";
@@ -783,6 +788,7 @@
 				8B5989551811B89800744AEE /* ADTokenCacheStoreKey.m in Sources */,
 				8B0DA7DE182AD01100CF5E1E /* ADAuthenticationResult+Internal.m in Sources */,
 				972A58A81A4AB5580054BE11 /* ADNTLMHandler.m in Sources */,
+				FB4C7C1E1BA0DF5F003B93C5 /* ADPolicyItem.m in Sources */,
 				8B5989511811A3DB00744AEE /* ADAuthenticationError.m in Sources */,
 				D6E43A6A1B04026D000F5BE2 /* ADAuthenticationContext+Internal.m in Sources */,
 				D6BD01501B50A194008AB2B0 /* NSSet+ADExtensions.m in Sources */,

--- a/ADALiOS/ADALiOS.xcodeproj/xcshareddata/xcschemes/ADALiOS.xcscheme
+++ b/ADALiOS/ADALiOS.xcodeproj/xcshareddata/xcschemes/ADALiOS.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,24 +39,36 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8B0965A917F25770002BDFB8"
+            BuildableName = "libADALiOS.a"
+            BlueprintName = "ADALiOS"
+            ReferencedContainer = "container:ADALiOS.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.m
@@ -165,7 +165,8 @@
     }
     
     NSString* accessToken = [response objectForKey:OAUTH2_ACCESS_TOKEN];
-    if (![NSString adIsStringNilOrBlank:accessToken])
+    NSString* idToken = [response objectForKey:OAUTH2_ID_TOKEN];
+    if (![NSString adIsStringNilOrBlank:accessToken] || ![NSString adIsStringNilOrBlank:idToken])
     {
         [item setAuthority:self.authority];
         [item fillItemWithResponse:response];

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -229,7 +229,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param redirectUri: The redirect URI according to OAuth2 protocol.
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -251,7 +251,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -275,7 +275,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
                                 "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -299,7 +299,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                                 "^(ADAuthenticationResult res){ <your logic here> }"
  */
 
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -320,7 +320,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                     completionBlock:(ADAuthenticationCallback)completionBlock;
@@ -337,7 +337,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param identifier       An ADUserIdentifier object specifying the semantics
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier
@@ -356,7 +356,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param policy           ?????
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -213,6 +213,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                 additionalScopes:(NSArray*)additionalScopes
                         clientId:(NSString*)clientId
                       identifier:(ADUserIdentifier*)identifier
+                  promptBehavior:(ADPromptBehavior*)promptBehavior
                  completionBlock:(ADAuthenticationCallback)completionBlock;
 
 
@@ -227,12 +228,14 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param resource: the resource whose token is needed.
     @param clientId: the client identifier
     @param redirectUri: The redirect URI according to OAuth2 protocol.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
+                promptBehavior:(ADPromptBehavior*)promptBehavior
               completionBlock:(ADAuthenticationCallback)completionBlock;
 
 /*!
@@ -248,6 +251,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param clientId         the client identifier
     @param redirectUri      The redirect URI according to OAuth2 protocol
     @param identifier       A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
@@ -256,6 +260,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+                promptBehavior:(ADPromptBehavior*)promptBehavior
               completionBlock:(ADAuthenticationCallback)completionBlock;
 
 /*!
@@ -271,6 +276,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param clientId             The client identifier
     @param redirectUri          The redirect URI according to OAuth2 protocol
     @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
                                 "^(ADAuthenticationResult res){ <your logic here> }"
@@ -280,6 +286,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+                promptBehavior:(ADPromptBehavior*)promptBehavior
          extraQueryParameters:(NSString*)queryParams
               completionBlock:(ADAuthenticationCallback)completionBlock;
 
@@ -293,6 +300,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param redirectUri          The redirect URI according to OAuth2 protocol
     @param promptBehavior       controls if any credentials UI will be shown
     @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
     @param policy               ??????
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
@@ -304,6 +312,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+                promptBehavior:(ADPromptBehavior*)promptBehavior
          extraQueryParameters:(NSString*)queryParams
                        policy:(NSString*)policy
               completionBlock:(ADAuthenticationCallback)completionBlock;
@@ -317,12 +326,14 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param scopes           An array of NSString* specifying the scopes required for the request
     @param clientId         the client identifier
     @param redirectUri      The redirect URI according to OAuth2 protocol.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
+                        promptBehavior:(ADPromptBehavior*)promptBehavior
                     completionBlock:(ADAuthenticationCallback)completionBlock;
 
 /*!
@@ -335,12 +346,14 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param clientId         the client identifier
     @param redirectUri      The redirect URI according to OAuth2 protocol
     @param identifier       An ADUserIdentifier object specifying the semantics
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier
+                        promptBehavior:(ADPromptBehavior*)promptBehavior
                     completionBlock:(ADAuthenticationCallback)completionBlock;
 
 /*!
@@ -353,6 +366,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param clientId         the client identifier
     @param redirectUri      The redirect URI according to OAuth2 protocol
     @param identifier       An ADUserIdentifier object specifying the semantics
+    @param promptBehavior       controls if any credentials UI will be shown
     @param policy           ?????
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
@@ -360,6 +374,7 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier
+                        promptBehavior:(ADPromptBehavior*)promptBehavior
                              policy:(NSString*)policy
                     completionBlock:(ADAuthenticationCallback)completionBlock;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -294,29 +294,6 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
     @param promptBehavior       controls if any credentials UI will be shown
     @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
     @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
-    @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
-                                "^(ADAuthenticationResult res){ <your logic here> }"
- */
-- (void)acquireTokenForScopes:(NSArray*)scopes
-             additionalScopes:(NSArray*)additionalScopes
-                     clientId:(NSString*)clientId
-                  redirectUri:(NSURL*)redirectUri
-               promptBehavior:(ADPromptBehavior)promptBehavior
-                   identifier:(ADUserIdentifier*)identifier
-         extraQueryParameters:(NSString*)queryParams
-              completionBlock:(ADAuthenticationCallback)completionBlock;
-
-/*!
-    Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize
-    the resource usage (through webview credentials UI) or attempt to use the cached tokens first.
- 
-    @param scopes               An array of NSStrings specifying the scopes required for the request
-    @param additionalScopes     An array of NSStrings of any additional scopes to ask the user consent for
-    @param clientId             the client identifier
-    @param redirectUri          The redirect URI according to OAuth2 protocol
-    @param promptBehavior       controls if any credentials UI will be shown
-    @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
-    @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
     @param policy               ??????
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
                                 "^(ADAuthenticationResult res){ <your logic here> }"

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -293,7 +293,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param redirectUri: The redirect URI according to OAuth2 protocol.
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -325,7 +325,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -361,7 +361,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
                                 "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -397,7 +397,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                                 "^(ADAuthenticationResult res){ <your logic here> }"
  */
 
-- (void)acquireTokenForScopes:(NSArray*)scopes
+- (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
@@ -432,7 +432,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                     completionBlock:(ADAuthenticationCallback)completionBlock
@@ -457,7 +457,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param identifier       An ADUserIdentifier object specifying the semantics
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier
@@ -488,7 +488,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param policy           ?????
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
-- (void)acquireTokenSilentForScopes:(NSArray*)scopes
+- (void)acquireTokenSilentWithScopes:(NSArray*)scopes
                            clientId:(NSString*)clientId
                         redirectUri:(NSURL*)redirectUri
                          identifier:(ADUserIdentifier*)identifier

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -377,44 +377,6 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     [request setUserIdentifier:identifier];
     [request setExtraQueryParameters:queryParams];
-
-    [request acquireToken:completionBlock];
-}
-
-
-/*!
-    Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize
-    the resource usage (through webview credentials UI) or attempt to use the cached tokens first.
- 
-    @param scopes               An array of NSStrings specifying the scopes required for the request
-    @param additionalScopes     An array of NSStrings of any additional scopes to ask the user consent for
-    @param clientId             the client identifier
-    @param redirectUri          The redirect URI according to OAuth2 protocol
-    @param promptBehavior       controls if any credentials UI will be shown
-    @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
-    @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
-    @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
-                                "^(ADAuthenticationResult res){ <your logic here> }"
- */
-- (void)acquireTokenForScopes:(NSArray*)scopes
-             additionalScopes:(NSArray*)additionalScopes
-                     clientId:(NSString*)clientId
-                  redirectUri:(NSURL*)redirectUri
-               promptBehavior:(ADPromptBehavior)promptBehavior
-                   identifier:(ADUserIdentifier*)identifier
-         extraQueryParameters:(NSString*)queryParams
-              completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    API_ENTRY_F(@"scopes:%@ additionalScopes:%@ clientId:%@ redirectUri:%@ identifier:%@ queryParams:%@",
-                scopes, additionalScopes, clientId, redirectUri, identifier, queryParams);
-    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId);
-    
-    CALLBACK_ON_ERROR([request setScopes:scopes]);
-    CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
-    [request setPromptBehavior:promptBehavior];
-    [request setUserIdentifier:identifier];
-    [request setExtraQueryParameters:queryParams];
-    
     [request acquireToken:completionBlock];
 }
 
@@ -453,7 +415,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     [request setUserIdentifier:identifier];
     [request setExtraQueryParameters:queryParams];
     [request setPolicy:policy];
-    
+    [ADAuthenticationSettings sharedInstance].policy = policy;
     [request acquireToken:completionBlock];
 }
 

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -255,6 +255,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param additionalScopes An array of NSStrings of any additional scopes to ask the user consent for
     @param clientId         the client identifier
     @param identifier       A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
@@ -264,6 +265,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                 additionalScopes:(NSArray*)additionalScopes
                         clientId:(NSString*)clientId
                       identifier:(ADUserIdentifier*)identifier
+                  promptBehavior:(ADPromptBehavior)promptBehavior
                  completionBlock:(ADAuthenticationCallback)completionBlock
 {
     API_ENTRY_F(@"assertion:%lu assertiontype:%@ scopes:%@ additionalscopes:%@ clientId:%@ identifier:%@",
@@ -273,6 +275,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setScopes:scopes]);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     [request setUserIdentifier:identifier];
+    [request setPromptBehavior:promptBehavior];
     
     [request acquireTokenForAssertion:assertion
                         assertionType:assertionType
@@ -290,12 +293,14 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
     @param resource: the resource whose token is needed.
     @param clientId: the client identifier
+    @param promptBehavior       controls if any credentials UI will be shown
     @param redirectUri: The redirect URI according to OAuth2 protocol.
     @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithScopes:(NSArray*)scopes
              additionalScopes:(NSArray*)additionalScopes
                      clientId:(NSString*)clientId
+                promptBehavior:(ADPromptBehavior)promptBehavior
                   redirectUri:(NSURL*)redirectUri
               completionBlock:(ADAuthenticationCallback)completionBlock
 {
@@ -305,6 +310,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setScopes:scopes]);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     
+    [request setPromptBehavior:promptBehavior];
     [request acquireToken:completionBlock];
 }
 
@@ -322,6 +328,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param clientId         the client identifier
     @param redirectUri      The redirect URI according to OAuth2 protocol
     @param identifier       A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param completionBlock  the block to execute upon completion. You can use embedded block, e.g.
                             "^(ADAuthenticationResult res){ <your logic here> }"
  */
@@ -330,6 +337,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+                promptBehavior:(ADPromptBehavior)promptBehavior
               completionBlock:(ADAuthenticationCallback)completionBlock
 {
     API_ENTRY_F(@"scopes:%@ additionalScopes:%@ clientId:%@ redirectUri:%@ identifier:%@",
@@ -339,6 +347,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setScopes:scopes]);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     [request setUserIdentifier:identifier];
+    [request setPromptBehavior:promptBehavior];
     
     [request acquireToken:completionBlock];
 }
@@ -357,6 +366,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param clientId             The client identifier
     @param redirectUri          The redirect URI according to OAuth2 protocol
     @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
                                 "^(ADAuthenticationResult res){ <your logic here> }"
@@ -366,6 +376,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+            promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
               completionBlock:(ADAuthenticationCallback)completionBlock
 {
@@ -376,6 +387,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setScopes:scopes]);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     [request setUserIdentifier:identifier];
+    [request setPromptBehavior:promptBehavior];
     [request setExtraQueryParameters:queryParams];
     [request acquireToken:completionBlock];
 }
@@ -389,8 +401,8 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     @param additionalScopes     An array of NSStrings of any additional scopes to ask the user consent for
     @param clientId             the client identifier
     @param redirectUri          The redirect URI according to OAuth2 protocol
-    @param promptBehavior       controls if any credentials UI will be shown
     @param identifier           A ADUserIdentifier object describing the user being authenticated. This parameter can be nil.
+    @param promptBehavior       controls if any credentials UI will be shown
     @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
     @param policy               ??????
     @param completionBlock      the block to execute upon completion. You can use embedded block, e.g.
@@ -402,6 +414,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
                      clientId:(NSString*)clientId
                   redirectUri:(NSURL*)redirectUri
                    identifier:(ADUserIdentifier*)identifier
+                promptBehavior:(ADPromptBehavior)promptBehavior
          extraQueryParameters:(NSString*)queryParams
                        policy:(NSString*)policy
               completionBlock:(ADAuthenticationCallback)completionBlock
@@ -413,6 +426,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     CALLBACK_ON_ERROR([request setScopes:scopes]);
     CALLBACK_ON_ERROR([request setAdditionalScopes:additionalScopes]);
     [request setUserIdentifier:identifier];
+    [request setPromptBehavior:promptBehavior];
     [request setExtraQueryParameters:queryParams];
     [request setPolicy:policy];
     [ADAuthenticationSettings sharedInstance].policy = policy;

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
@@ -20,6 +20,7 @@
 #import "ADInstanceDiscovery.h"
 #import "ADUserIdentifier.h"
 #import "ADAuthenticationRequest.h"
+#import "NSSet+ADExtensions.h"
 
 @implementation ADAuthenticationRequest (AcquireAssertion)
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -21,7 +21,7 @@
 #import "ADInstanceDiscovery.h"
 #import "ADHelpers.h"
 #import "ADUserIdentifier.h"
-#import "../ADALiOS/NSSet+ADExtensions.h"
+#import "NSSet+ADExtensions.h"
 
 @implementation ADAuthenticationRequest (AcquireToken)
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -21,6 +21,7 @@
 #import "ADInstanceDiscovery.h"
 #import "ADHelpers.h"
 #import "ADUserIdentifier.h"
+#import "../ADALiOS/NSSet+ADExtensions.h"
 
 @implementation ADAuthenticationRequest (AcquireToken)
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
@@ -30,6 +30,7 @@
 #import "ADUserIdentifier.h"
 #import "ADAuthenticationRequest.h"
 #import "ADPolicyItem.h"
+#import "NSSet+ADExtensions.h"
 
 #import <libkern/OSAtomic.h>
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.h
@@ -90,6 +90,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 #endif
 
 - (BOOL)validateProperties:(ADAuthenticationCallback)completionBlock;
+//- (BOOL)isClientID:(NSString*)scope;
 
 - (NSSet*)combinedScopes;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -27,7 +27,7 @@
 #import "NSURL+ADExtensions.h"
 #import "ADBrokerKeyHelper.h"
 #import "ADAuthenticationRequest+WebRequest.h"
-#import "NSString+ADExtentions.h"
+#import "NSSet+ADExtensions.h"
 
 #include <libkern/OSAtomic.h>
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -27,6 +27,7 @@
 #import "NSURL+ADExtensions.h"
 #import "ADBrokerKeyHelper.h"
 #import "ADAuthenticationRequest+WebRequest.h"
+#import "NSString+ADExtentions.h"
 
 #include <libkern/OSAtomic.h>
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -129,12 +129,35 @@ static ADAuthenticationError* _validateScopes(NSArray* scopes)
     return nil;
 }
 
+//static BOOL isClientID(NSString* scope)
+//{
+    
+  //  NSError *error;
+    
+ //   NSRegularExpression *regex =
+ //   [NSRegularExpression regularExpressionWithPattern:@"\\A\\{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}\\}\\Z"
+                                 //             options:NSRegularExpressionAnchorsMatchLines
+                                 //               error:&error];
+ //   NSPredicate *testGUID = [NSPredicate predicateWithFormat:@"SELF MATCHES %@", regex];
+    
+    
+    
+ //   if ([testGUID evaluateWithObject: scope]) {
+        
+   //     return YES;
+        
+  //  } else {
+        
+  //      return NO;
+  //  }
+//}
+
 - (ADAuthenticationError*)setScopes:(NSArray *)scopes
 {
     CHECK_REQUEST_STARTED_R(nil);
     
     ADAuthenticationError* error = nil;
-    NSArray* lowercaseScopes = _arrayOfLowercaseStrings(scopes, @"scopes", &error);
+    NSMutableArray* lowercaseScopes = _arrayOfLowercaseStrings(scopes, @"scopes", &error);
     if (!lowercaseScopes)
     {
         return error;
@@ -142,7 +165,24 @@ static ADAuthenticationError* _validateScopes(NSArray* scopes)
     
     RETURN_IF_NOT_NIL(_validateScopes(lowercaseScopes));
     
-    _scopes = [NSSet setWithArray:scopes];
+    for (NSString* scope in lowercaseScopes) {
+        
+        if ([scope isEqualToString:_clientId]) {
+            
+            // first, remove the Client ID from scopes. It has served it's holy purpose.
+            
+            [lowercaseScopes removeObject:scope];
+            
+            // next, let's add the scopes that we need to get an id_token
+            
+            [lowercaseScopes addObject:@"openid"];
+            [lowercaseScopes addObject:@"offline_access"];
+            
+        }
+        
+    }
+    
+    _scopes = [NSSet setWithArray:lowercaseScopes];
     
     return nil;
 }
@@ -284,5 +324,6 @@ static ADAuthenticationError* _validateScopes(NSArray* scopes)
     
     return YES;
 }
+
 
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -74,13 +74,13 @@
         //Bad item, return error:
         return [ADAuthenticationResult resultFromError:error];
     }
-    if ([NSString adIsStringNilOrBlank:item.accessToken])
-    {
-        //Bad item, the access token should be accurate, else an error should be
-        //reported instead of this creator:
-        ADAuthenticationError* error = [ADAuthenticationError unexpectedInternalError:@"ADAuthenticationResult created from item with no access token."];
-        return [ADAuthenticationResult resultFromError:error];
-    }
+//    if ([NSString adIsStringNilOrBlank:item.idToken])
+//    {
+//        //Bad item, the access token should be accurate, else an error should be
+//        //reported instead of this creator:
+//        ADAuthenticationError* error = [ADAuthenticationError unexpectedInternalError:@"ADAuthenticationResult created from item with no id token."];
+//        return [ADAuthenticationResult resultFromError:error];
+//    }
     //The item can be used, just use it:
     return [[ADAuthenticationResult alloc] initWithItem:item];
 }

--- a/ADALiOS/ADALiOS/ADAuthenticationResult.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult.h
@@ -54,6 +54,11 @@ typedef enum
  case of error.*/
 @property (readonly) NSString* accessToken;
 
+/*! A valid access token, if the results indicates success. The property is
+ calculated from the tokenCacheStoreItem one. The property is nil, in
+ case of error.*/
+@property (readonly) NSString* idToken;
+
 @property (readonly) ADTokenCacheStoreItem* tokenCacheStoreItem;
 
 /*! The error that occurred or nil, if the operation was successful */

--- a/ADALiOS/ADALiOS/ADAuthenticationSettings.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationSettings.h
@@ -62,6 +62,9 @@ typedef enum
 /*! Used for the webView. Default is YES.*/
 @property BOOL enableFullScreen;
 
+/*! Used for determining if we change the flows for B2C. Default is NO.*/
+@property NSString* policy;
+
 /*! The dispatch queue to be used for the asynchronous calls. */
 @property dispatch_queue_t dispatchQueue;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationSettings.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationSettings.m
@@ -40,6 +40,7 @@
         //exists. Hence for now, we create the connection on the main thread by default:
         self.dispatchQueue = dispatch_get_main_queue();
         self.defaultTokenCacheStore = [ADKeychainTokenCacheStore new];
+        self.policy = nil;
     }
     return self;
 }

--- a/ADALiOS/ADALiOS/ADKeychainItem.m
+++ b/ADALiOS/ADALiOS/ADKeychainItem.m
@@ -139,7 +139,7 @@
     return YES;
 }
 
-- (ADKeychainToken*)tokenForScopes:(NSSet*)scopes
+- (ADKeychainToken*)tokenWithScopes:(NSSet*)scopes
 {
     for (ADKeychainToken* token in _accessTokens)
     {
@@ -163,7 +163,7 @@
 {
     item.refreshToken = _refreshToken;
     
-    ADKeychainToken* token = [self tokenForScopes:scopes];
+    ADKeychainToken* token = [self tokenWithScopes:scopes];
     [token addToTokenItem:item];
 }
 

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.m
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.m
@@ -18,7 +18,7 @@
 
 #import "ADOAuth2Constants.h"
 
-NSString *const OAUTH2_ACCESS_TOKEN       = @"access_token";
+NSString *const OAUTH2_ACCESS_TOKEN       = @"id_token";
 NSString *const OAUTH2_AUTHORIZATION      = @"authorization";
 NSString *const OAUTH2_AUTHORIZE_V1_SUFFIX = @"/oauth2/authorize";
 NSString *const OAUTH2_AUTHORIZE_SUFFIX   = @"/oauth2/v2.0/authorize";

--- a/ADALiOS/ADALiOS/ADPolicyItem.h
+++ b/ADALiOS/ADALiOS/ADPolicyItem.h
@@ -1,0 +1,18 @@
+//
+//  ADPolicyItem.h
+//  ADALiOS
+//
+//  Created by Brandon Werner on 9/9/15.
+//  Copyright © 2015 MS Open Tech. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ADPolicyItem : NSObject
+
+@property (strong) NSString* policyName;
+@property (strong) NSString* policyID;
+
++(id) getInstance;
+
+@end

--- a/ADALiOS/ADALiOS/ADPolicyItem.m
+++ b/ADALiOS/ADALiOS/ADPolicyItem.m
@@ -1,0 +1,30 @@
+//
+//  ADPolicyItem.m
+//  ADALiOS
+//
+//  Created by Brandon Werner on 9/9/15.
+//  Copyright © 2015 MS Open Tech. All rights reserved.
+//
+
+#import "ADPolicyItem.h"
+
+@implementation ADPolicyItem
+
++(id) getInstance
+{
+    static ADPolicyItem *instance = nil;
+    static dispatch_once_t onceToken;
+    
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+        NSDictionary *dictionary = [NSDictionary dictionaryWithContentsOfFile:[[NSBundle mainBundle] pathForResource:@"settings" ofType:@"plist"]];
+        instance.policyName = [dictionary objectForKey:@"policyName"];
+        instance.policyID = [dictionary objectForKey:@"policyID"];
+        
+        
+    });
+    
+    return instance;
+}
+
+@end

--- a/ADALiOS/ADALiOS/ADProfileInfo.m
+++ b/ADALiOS/ADALiOS/ADProfileInfo.m
@@ -156,7 +156,7 @@ static ADAuthenticationError* _errorFromInfo(const char* cond, NSString* profile
         AD_LOG_WARN(@"The id_token type is missing.", @"Assuming JWT type.");
     }
     
-    if (![allClaims objectForKey:PROFILE_INFO_PREFERRED_USERNAME])
+    if (![allClaims objectForKey:PROFILE_INFO_TENANTID])
     {
         RETURN_NIL_ERROR(error, AD_ERROR_AUTHENTICATION, @"Profile info is missing the 'preferred_username' claim");
     }
@@ -177,7 +177,7 @@ static ADAuthenticationError* _errorFromInfo(const char* cond, NSString* profile
 PROFILE_INFO_PROPERTY_GETTER(subject, PROFILE_INFO_SUBJECT);
 PROFILE_INFO_PROPERTY_GETTER(tenantId, PROFILE_INFO_TENANTID);
 PROFILE_INFO_PROPERTY_GETTER(friendlyName, PROFILE_INFO_FRIENDLY_NAME);
-PROFILE_INFO_PROPERTY_GETTER(username, PROFILE_INFO_PREFERRED_USERNAME);
+PROFILE_INFO_PROPERTY_GETTER(username, PROFILE_INFO_TENANTID);
 
 + (ADProfileInfo*)profileInfoWithUsername:(NSString*)username
                                     error:(ADAuthenticationError* __autoreleasing*)error

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
@@ -97,7 +97,7 @@
         return NO;
     }
     
-    self.profileInfo = [ADProfileInfo profileInfoWithEncodedString:[responseDictionary objectForKey:OAUTH2_PROFILE_INFO]
+    self.profileInfo = [ADProfileInfo profileInfoWithEncodedString:[responseDictionary objectForKey:OAUTH2_ID_TOKEN]
                                                              error:nil];
     NSArray* scopes = [[responseDictionary objectForKey:OAUTH2_SCOPE] componentsSeparatedByString:@" "];
     self.scopes = [NSSet setWithArray:scopes];

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
@@ -44,6 +44,8 @@
 
 @property NSString* refreshToken;
 
+@property NSString* idToken;
+
 @property NSString* policy;
 
 @property NSData* sessionKey;

--- a/ADALiOS/ADALiOS/NSArray+ADExtensions.m
+++ b/ADALiOS/ADALiOS/NSArray+ADExtensions.m
@@ -17,6 +17,7 @@
 // governing permissions and limitations under the License.
 
 #import "NSArray+ADExtensions.h"
+#import "NSString+ADExtentions.h"
 
 @implementation NSArray (ADExtensions)
 

--- a/ADALiOS/ADALiOS/NSSet+ADExtensions.m
+++ b/ADALiOS/ADALiOS/NSSet+ADExtensions.m
@@ -17,6 +17,7 @@
 // governing permissions and limitations under the License.
 
 #import "NSSet+ADExtensions.h"
+#import "NSString+ADExtentions.h"
 
 @implementation NSSet (ADExtensions)
 

--- a/ADALiOS/ADALiOS/NSString+ADExtentions.h
+++ b/ADALiOS/ADALiOS/NSString+ADExtentions.h
@@ -1,10 +1,20 @@
+// Copyright © Microsoft Open Technologies, Inc.
 //
-//  NSString+ADExtentions.h
-//  ADALiOS
+// All Rights Reserved
 //
-//  Created by Brandon Werner on 9/11/15.
-//  Copyright © 2015 MS Open Tech. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
 

--- a/ADALiOS/ADALiOS/NSString+ADExtentions.h
+++ b/ADALiOS/ADALiOS/NSString+ADExtentions.h
@@ -1,0 +1,17 @@
+//
+//  NSString+ADExtentions.h
+//  ADALiOS
+//
+//  Created by Brandon Werner on 9/11/15.
+//  Copyright © 2015 MS Open Tech. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface NSString (ADExtensions)
+
+- (NSString*)adSpaceDeliminatedString;
+- (NSString*)adUrlFormEncode;
+
+@end
+

--- a/ADALiOS/ADALiOS/NSString+ADExtentions.m
+++ b/ADALiOS/ADALiOS/NSString+ADExtentions.m
@@ -1,10 +1,20 @@
+// Copyright © Microsoft Open Technologies, Inc.
 //
-//  NSString+ADExtentions.m
-//  ADALiOS
+// All Rights Reserved
 //
-//  Created by Brandon Werner on 9/11/15.
-//  Copyright © 2015 MS Open Tech. All rights reserved.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
 
 #import "NSString+ADExtentions.h"
 

--- a/ADALiOS/ADALiOS/NSString+ADExtentions.m
+++ b/ADALiOS/ADALiOS/NSString+ADExtentions.m
@@ -1,0 +1,45 @@
+//
+//  NSString+ADExtentions.m
+//  ADALiOS
+//
+//  Created by Brandon Werner on 9/11/15.
+//  Copyright © 2015 MS Open Tech. All rights reserved.
+//
+
+#import "NSString+ADExtentions.h"
+
+@implementation NSString (ADExtensions)
+
+- (NSString*)adSpaceDeliminatedString
+{
+    NSMutableString* string = [NSMutableString new];
+    
+    __block BOOL first = YES;
+    
+    [self enumerateLinesUsingBlock:^(id obj, BOOL *stop) {
+        if (![obj isKindOfClass:[NSString class]])
+        {
+            return;
+        }
+        
+        if (!first)
+        {
+            [string appendString:@" "];
+        }
+        else
+        {
+            first = NO;
+        }
+        
+        [string appendString:obj];
+    }];
+    
+    return string;
+}
+
+- (NSString*)adUrlFormEncode
+{
+    return [[self adSpaceDeliminatedString] adUrlFormEncode];
+}
+
+@end

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -410,7 +410,6 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
                             additionalScopes:nil
                                        clientId:_clientId
                                     redirectUri:_redirectURL
-                                 promptBehavior:_promptBehavior
                                   identifier:[ADUserIdentifier identifierWithId:_userId type:RequiredDisplayableId]
                            extraQueryParameters:nil
                                 completionBlock:callback];

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -29,6 +29,7 @@
 #import "../ADALiOS/ADAuthenticationSettings.h"
 #import "../ADALiOS/ADKeychainTokenCacheStore.h"
 #import "../ADALiOS/NSArray+ADExtensions.h"
+#import "../ADALiOS/NSSet+ADExtensions.h"
 
 const int sAsyncContextTimeout = 10;
 @interface ADAuthenticationContextTests : XCTestCase

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -112,7 +112,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
     [super tearDown];
 }
 
-- (NSString*)encodedStringForScopes
+- (NSString*)encodedStringWithScopes
 {
     return [_scopes adUrlFormEncode];
 }
@@ -398,7 +398,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
          };
          if (_silent)
          {
-             [_context acquireTokenSilentForScopes:_scopes
+             [_context acquireTokenSilentWithScopes:_scopes
                                           clientId:_clientId
                                        redirectUri:_redirectURL
                                        identifier:[ADUserIdentifier identifierWithId:_userId type:RequiredDisplayableId]
@@ -406,7 +406,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
          }
          else
          {
-             [_context acquireTokenForScopes:_scopes
+             [_context acquireTokenWithScopes:_scopes
                             additionalScopes:nil
                                        clientId:_clientId
                                     redirectUri:_redirectURL
@@ -434,7 +434,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
 
 - (void)testAcquireTokenBadCompletionBlock
 {
-    ADAssertThrowsArgument([_context acquireTokenForScopes:_scopes additionalScopes:nil clientId:_clientId redirectUri:_redirectURL completionBlock:nil]);
+    ADAssertThrowsArgument([_context acquireTokenWithScopes:_scopes additionalScopes:nil clientId:_clientId redirectUri:_redirectURL completionBlock:nil]);
 }
 
 - (void)testAcquireTokenBadScopes
@@ -1006,7 +1006,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
 
     [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ semaphore:sem block:^
      {
-         [_context acquireTokenForScopes:_scopes
+         [_context acquireTokenWithScopes:_scopes
                         additionalScopes:nil
                                    clientId:_clientId
                                 redirectUri:_redirectURL
@@ -1017,7 +1017,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
     
     [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ semaphore:sem block:^
      {
-         [_context acquireTokenForScopes:_scopes
+         [_context acquireTokenWithScopes:_scopes
                         additionalScopes:nil
                                 clientId:_clientId
                              redirectUri:_redirectURL
@@ -1029,7 +1029,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
 
     [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ semaphore:sem block:^
      {
-         [_context acquireTokenForScopes:_scopes
+         [_context acquireTokenWithScopes:_scopes
                         additionalScopes:nil
                                 clientId:_clientId
                              redirectUri:_redirectURL

--- a/ADALiOS/ADALiOSTests/ADKeychainCacheStoreTests.m
+++ b/ADALiOS/ADALiOSTests/ADKeychainCacheStoreTests.m
@@ -104,7 +104,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     if (_newUser) \
     { \
         ADAuthenticationError* error; \
-        _newItem.profileInfo = [ADUserInformation profileInfoWithUserId:_newUser error:&error]; \
+        _newItem.profileInfo = [ADProfileInfo profileInfoWithUserId:_newUser error:&error]; \
         ADAssertNoError; \
     } \
     else \

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
@@ -39,7 +39,7 @@
  static volatile int comletion  = 0;
  [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ completionSignal: &completion block:^
  {
-    [mAuthenticationContext acquireTokenForScopes:mScopes
+    [mAuthenticationContext acquireTokenWithScopes:mScopes
                                      completionBlock:^(ADAuthenticationResult* result)
     {
         //Inner block:


### PR DESCRIPTION
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310473%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310503%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310545%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310606%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39311222%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39315668%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39319556%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39319557%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39319558%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39319559%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39319817%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39320475%22%5D%2C%20%22comments%22%3A%20%7B%22Pull%200517d65511b2e8a399700630c8e37beca28d8ec4%20ADALiOS/ADALiOS/NSString%252BADExtentions.m%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310473%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Replace%20with%20standard%20file%20header%22%2C%20%22created_at%22%3A%20%222015-09-11T19%3A57%3A02Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/NSString%2BADExtentions.m%3AL1-46%22%7D%2C%20%22Pull%200517d65511b2e8a399700630c8e37beca28d8ec4%20ADALiOS/ADALiOS/ADAuthenticationRequest%252BAcquireToken.m%204%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310545%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22the%20%5C%22.../ADALiOS%5C%22%20shouldn%27t%20be%20necessary%22%2C%20%22created_at%22%3A%20%222015-09-11T19%3A57%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADAuthenticationRequest%2BAcquireToken.m%3AL21-28%22%7D%2C%20%22Pull%200517d65511b2e8a399700630c8e37beca28d8ec4%20ADALiOS/ADALiOS/NSString%252BADExtentions.m%2013%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39311222%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Is%20this%20equivalent%20to%20%5BmyString%20stringByReplacingOcurrencesOfString%3A%40%5C%22%5C%5Cn%5C%22%20withString%3A%40%5C%22%20%5C%22%5D%3F%22%2C%20%22created_at%22%3A%20%222015-09-11T20%3A04%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20but%20you%20need%20this%20in%20various%20places%20in%20the%20code%20and%20it%20wasn%27t%20there.%20Makes%20sense%20to%20follow%20the%20pattern%20and%20add%20a%20category.%20It%27s%20up%20to%20you%20-%20but%20I%20think%20for%20the%20OSS%20developer%20seeing%20NSString%20equally%20amongst%20NSSet%20and%20NSArray%20categories%20for%20ADExtensions%20implementing%20%60adSpaceDelimitedString%60%20will%20help%20them%20understand%20what%20the%20code%20is%20doing%20even%20if%20we%20can%20actually%20make%20it%20fancy.%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A30%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%20was%20pointing%20you%20you%20could%20replace%20that%20whole%20implementation%20with%20one%20line%20%3A%29.%20I%27m%20fine%20with%20keeping%20the%20category%20method%20around%2C%20especially%20cause%20it%20might%20allow%20us%20to%20be%20lazier%20in%20other%20contexts...%20sorry%20I%20mean%20%5C%22more%20dynamic.%5C%22%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A36%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/NSString%2BADExtentions.m%3AL1-46%22%7D%2C%20%22Pull%200517d65511b2e8a399700630c8e37beca28d8ec4%20ADALiOS/ADALiOS/ADProfileInfo.m%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310606%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%2Ashudder%2A%22%2C%20%22created_at%22%3A%20%222015-09-11T19%3A58%3A29Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22Will%20update%20this%20to%20accept%20oid%20or%20fail.%20The%20old%20will%20need%20to%20be%20past%20by%20the%20B2C%20admin%20for%20any%20mobile%20scenarios%20to%20work.%20Discussed%20with%20%40skwan%20and%20%40dstrockis%20%22%2C%20%22created_at%22%3A%20%222015-09-11T20%3A48%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-none%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADProfileInfo.m%3AL156-163%22%7D%2C%20%22Pull%200517d65511b2e8a399700630c8e37beca28d8ec4%20ADALiOS/ADALiOS/NSString%252BADExtentions.h%207%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377%23discussion_r39310503%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Replace%20with%20standard%20file%20header%22%2C%20%22created_at%22%3A%20%222015-09-11T19%3A57%3A14Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%3Ca%20href%3D%27%23crh-update-complete%27%3E%3C/a%3E%22%2C%20%22created_at%22%3A%20%222015-09-11T21%3A28%3A27Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/1471883%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/brandwe%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/NSString%2BADExtentions.h%3AL1-18%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
- [ ] <a href='#crh-comment-Pull 0517d65511b2e8a399700630c8e37beca28d8ec4 ADALiOS/ADALiOS/NSString%2BADExtentions.m 13'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377#discussion_r39311222'>File: ADALiOS/ADALiOS/NSString+ADExtentions.m:L1-46</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Is this equivalent to [myString stringByReplacingOcurrencesOfString:@"\n" withString:@" "]?
- <a href='https://github.com/brandwe'><img border=0 src='https://avatars.githubusercontent.com/u/1471883?v=3' height=16 width=16'></a> Yes, but you need this in various places in the code and it wasn't there. Makes sense to follow the pattern and add a category. It's up to you - but I think for the OSS developer seeing NSString equally amongst NSSet and NSArray categories for ADExtensions implementing `adSpaceDelimitedString` will help them understand what the code is doing even if we can actually make it fancy.
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I was pointing you you could replace that whole implementation with one line :). I'm fine with keeping the category method around, especially cause it might allow us to be lazier in other contexts... sorry I mean "more dynamic."
- [x] <a href='#crh-comment-Pull 0517d65511b2e8a399700630c8e37beca28d8ec4 ADALiOS/ADALiOS/NSString%2BADExtentions.m 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377#discussion_r39310473'>File: ADALiOS/ADALiOS/NSString+ADExtentions.m:L1-46</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Replace with standard file header
- [x] <a href='#crh-comment-Pull 0517d65511b2e8a399700630c8e37beca28d8ec4 ADALiOS/ADALiOS/NSString%2BADExtentions.h 7'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377#discussion_r39310503'>File: ADALiOS/ADALiOS/NSString+ADExtentions.h:L1-18</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Replace with standard file header
- [x] <a href='#crh-comment-Pull 0517d65511b2e8a399700630c8e37beca28d8ec4 ADALiOS/ADALiOS/ADAuthenticationRequest%2BAcquireToken.m 4'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377#discussion_r39310545'>File: ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m:L21-28</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> the ".../ADALiOS" shouldn't be necessary
- [x] <a href='#crh-comment-Pull 0517d65511b2e8a399700630c8e37beca28d8ec4 ADALiOS/ADALiOS/ADProfileInfo.m 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377#discussion_r39310606'>File: ADALiOS/ADALiOS/ADProfileInfo.m:L156-163</a></b>
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> *shudder*
- <a href='https://github.com/brandwe'><img border=0 src='https://avatars.githubusercontent.com/u/1471883?v=3' height=16 width=16'></a> Will update this to accept oid or fail. The old will need to be past by the B2C admin for any mobile scenarios to work. Discussed with @skwan and @dstrockis


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/377?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/377?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/377'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>