### PR TITLE
Pluggable Auth Handlers

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -44,7 +44,6 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
     ADAuthenticationViewController*     _authenticationViewController;
     ADAuthenticationWebViewController*  _authenticationWebViewController;
     
-    BOOL                               _ntlmSession;
     NSLock                             *_completionLock;
     
     void (^_completionBlock)( ADAuthenticationError *, NSURL *);
@@ -106,7 +105,6 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
     if ( self )
     {
         _completionLock = [[NSLock alloc] init];
-        _ntlmSession = NO;
     }
     
     return self;
@@ -229,11 +227,7 @@ correlationId:(NSUUID *)correlationId
     _completionBlock = [completionBlock copy];
     ADAuthenticationError* error = nil;
     
-    _ntlmSession = [ADNTLMHandler startWebViewNTLMHandlerWithError:nil];
-    if (_ntlmSession)
-    {
-        AD_LOG_INFO(@"Authorization UI", @"NTLM support enabled.");
-    }
+    [ADURLProtocol registerProtocol];
     
 	if(![NSString adIsStringNilOrBlank:refreshTokenCredential])
     {
@@ -343,10 +337,8 @@ correlationId:(NSUUID *)correlationId
     //       be resilient to this condition and should not generate
     //       two callbacks.
     [_completionLock lock];
-    if (_ntlmSession)
-    {
-        [ADNTLMHandler endWebViewNTLMHandler];
-    }
+    
+    [ADURLProtocol unregisterProtocol];
     
     if ( _completionBlock )
     {

--- a/ADALiOS/ADALiOS/ADNTLMHandler.h
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.h
@@ -27,7 +27,7 @@
  if the challenge has been handled. */
 + (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
                 request:(NSURLRequest*)request
-               protocol:(NSURLProtocol*)protocol;
+               protocol:(ADURLProtocol*)protocol;
 
 + (BOOL)isChallengeCancelled;
 

--- a/ADALiOS/ADALiOS/ADNTLMHandler.h
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.h
@@ -17,26 +17,19 @@
 // governing permissions and limitations under the License.
 
 #import <Foundation/Foundation.h>
+#import "ADURLProtocol.h"
 
 @class ADAuthenticationError;
 
-@interface ADNTLMHandler : NSObject
-
-/* Starts intercepting HTTPS connections to enable NTLM authentication over webview. 
- If this method succeeds, it should be paired with endWebViewNTLMHandler. The method attempts
- to retrieve the workplace join identity and certificate. The interception should be as 
- short as possible, as this is a very specific fix to overcome the webview limitations. */
-+(BOOL) startWebViewNTLMHandlerWithError: (ADAuthenticationError* __autoreleasing*) error;
-/* Stops the HTTPS interception. */
-+(void) endWebViewNTLMHandler;
+@interface ADNTLMHandler : NSObject <ADAuthMethodHandler>
 
 /* Handles a client authentication NTLM challenge by collecting user credentials. Returns YES,
  if the challenge has been handled. */
-+(BOOL) handleNTLMChallenge:(NSURLAuthenticationChallenge *)challenge
-                 urlRequest:(NSURLRequest*) request
-             customProtocol:(NSURLProtocol*) protocol;
++ (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
+                request:(NSURLRequest*)request
+               protocol:(NSURLProtocol*)protocol;
 
-+(BOOL) isChallengeCancelled;
++ (BOOL)isChallengeCancelled;
 
-+(void) setCancellationUrl:(NSString*) url;
++ (void)setCancellationUrl:(NSString*) url;
 @end

--- a/ADALiOS/ADALiOS/ADNTLMHandler.m
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.m
@@ -68,7 +68,7 @@ static NSURLConnection *_conn = nil;
 
 + (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
                 request:(NSURLRequest*)request
-               protocol:(NSURLProtocol*)protocol
+               protocol:(ADURLProtocol*)protocol
 {
     BOOL __block succeeded = NO;
     @synchronized(self)

--- a/ADALiOS/ADALiOS/ADURLProtocol.h
+++ b/ADALiOS/ADALiOS/ADURLProtocol.h
@@ -19,12 +19,13 @@
 #pragma once
 
 @class ADAuthenticationError;
+@class ADURLProtocol;
 
 @protocol ADAuthMethodHandler
 
 + (BOOL)handleChallenge:(NSURLAuthenticationChallenge*)challenge
                 request:(NSURLRequest*)request
-               protocol:(NSURLProtocol*)protocol;
+               protocol:(ADURLProtocol*)protocol;
 + (void)resetHandler;
 
 @end
@@ -38,5 +39,7 @@
 
 + (BOOL)registerProtocol;
 + (void)unregisterProtocol;
+
+- (void)startLoading:(NSURL*)url;
 
 @end

--- a/ADALiOS/ADALiOS/ADURLProtocol.h
+++ b/ADALiOS/ADALiOS/ADURLProtocol.h
@@ -18,8 +18,25 @@
 
 #pragma once
 
+@class ADAuthenticationError;
+
+@protocol ADAuthMethodHandler
+
++ (BOOL)handleChallenge:(NSURLAuthenticationChallenge*)challenge
+                request:(NSURLRequest*)request
+               protocol:(NSURLProtocol*)protocol;
++ (void)resetHandler;
+
+@end
+
 //Intercepts HTTPS protocol for the application in order to allow
 //NTLM with client-authentication. The class is not thread-safe.
 @interface ADURLProtocol : NSURLProtocol <NSURLConnectionDelegate, NSURLConnectionDataDelegate>
+
++ (void)registerHandler:(Class<ADAuthMethodHandler>)handler
+             authMethod:(NSString*)authMethod;
+
++ (BOOL)registerProtocol;
++ (void)unregisterProtocol;
 
 @end

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -108,8 +108,14 @@ static NSMutableDictionary* s_handlers = nil;
         return;
     }
     
-    AD_LOG_VERBOSE_F(sLog, @"startLoading host: %@", [self.request.URL host] );
+    [self startLoading:self.request.URL];
+}
+
+- (void)startLoading:(NSURL*)url
+{
+    AD_LOG_VERBOSE_F(sLog, @"startLoading host: %@", [url host] );
     NSMutableURLRequest *mutableRequest = [self.request mutableCopy];
+    [mutableRequest setURL:url];
     [NSURLProtocol setProperty:@"YES" forKey:@"ADURLProtocol" inRequest:mutableRequest];
     _connection = [[NSURLConnection alloc] initWithRequest:mutableRequest
                                                   delegate:self

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -22,11 +22,52 @@
 #import "ADNTLMHandler.h"
 #import "ADCustomHeaderHandler.h"
 
-NSString* const sLog = @"HTTP Protocol";
+static NSString* const sLog = @"HTTP Protocol";
+static NSMutableDictionary* s_handlers = nil;
+
 
 @implementation ADURLProtocol
 {
     NSURLConnection *_connection;
+}
+
++ (void)registerHandler:(id)handler
+             authMethod:(NSString*)authMethod
+{
+    if (!handler || !authMethod)
+    {
+        return;
+    }
+    
+    @synchronized(self)
+    {
+        static dispatch_once_t once;
+        dispatch_once(&once, ^{
+            s_handlers = [NSMutableDictionary new];
+        });
+        
+        [s_handlers setValue:handler forKey:authMethod];
+    }
+}
+
+
++ (BOOL)registerProtocol
+{
+    return [NSURLProtocol registerClass:self];
+}
+
++ (void)unregisterProtocol
+{
+    [NSURLProtocol unregisterClass:self];
+    
+    @synchronized(self)
+    {
+        for (NSString* key in s_handlers)
+        {
+            Class<ADAuthMethodHandler> handler = [s_handlers objectForKey:key];
+            [handler resetHandler];
+        }
+    }
 }
 
 + (BOOL)canInitWithRequest:(NSURLRequest *)request
@@ -93,9 +134,21 @@ NSString* const sLog = @"HTTP Protocol";
 -(void) connection:(NSURLConnection *)connection
 willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challenge
 {
-    AD_LOG_VERBOSE_F(sLog, @"connection:willSendRequestForAuthenticationChallenge: %@. Previous challenge failure count: %ld", challenge.protectionSpace.authenticationMethod, (long)challenge.previousFailureCount);
+    NSString* authMethod = [challenge.protectionSpace.authenticationMethod lowercaseString];
     
-    if (![ADNTLMHandler handleNTLMChallenge:challenge urlRequest:[connection currentRequest] customProtocol:self])
+    AD_LOG_VERBOSE_F(sLog, @"connection:willSendRequestForAuthenticationChallenge: %@. Previous challenge failure count: %ld", authMethod, (long)challenge.previousFailureCount);
+    
+    BOOL handled = NO;
+    @synchronized([self class])
+    {
+        Class<ADAuthMethodHandler> handler = [s_handlers objectForKey:authMethod];
+        handled = [handler handleChallenge:challenge
+                                   request:[connection currentRequest]
+                                  protocol:self];
+        
+    }
+    
+    if (!handled)
     {
         // Do default handling
         [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];


### PR DESCRIPTION
Architect NSURL auth handlers so we can plug in different classes for different auth types.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398%23issuecomment-150066913%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398%23issuecomment-150067794%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398%23issuecomment-150313242%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398%23issuecomment-150066913%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22Are%20you%20doing%20this%20to%20allow%20for%20client%20TLS%20via%20Safari%20/%20System%20Web%20View%3F%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A58%3A55Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes.%20This%20bit%20is%20so%20we%20can%20intercept%20cert%20auth%20requests%2C%20the%20meat%20of%20the%20implementation%20will%20be%20elsewhere.%22%2C%20%22created_at%22%3A%20%222015-10-22T01%3A01%3A30Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-22T18%3A23%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398#issuecomment-150066913'>General Comment</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Are you doing this to allow for client TLS via Safari / System Web View?
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Yes. This bit is so we can intercept cert auth requests, the meat of the implementation will be elsewhere.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/398?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/398?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/398?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/398'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>