### PR TITLE
Change broker protocol keys

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -184,7 +184,7 @@
                                       @"correlation_id": _correlationId,
                                       @"broker_key": base64UrlKey,
                                       @"client_version": adalVersion,
-									  BROKER_MAX_VERSION : @"2",
+									  BROKER_MAX_PROTOCOL_VERSION : @"2",
                                       @"extra_qp": _queryParams ? _queryParams : @"",
                                       };
     

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -84,12 +84,12 @@
         
         NSString* hash = [queryParamsMap valueForKey:BROKER_HASH_KEY];
         NSString* encryptedBase64Response = [queryParamsMap valueForKey:BROKER_RESPONSE_KEY];
-        NSString* brokerProtocolVer = [queryParamsMap valueForKey:BROKER_PROTOCOL_VERSION];
+        NSString* msgVer = [queryParamsMap valueForKey:BROKER_MESSAGE_VERSION];
         NSInteger protocolVersion = 1;
         
-        if (brokerProtocolVer)
+        if (msgVer)
         {
-            protocolVersion = [brokerProtocolVer integerValue];
+            protocolVersion = [msgVer integerValue];
         }
         
         //decrypt response first
@@ -184,7 +184,7 @@
                                       @"correlation_id": _correlationId,
                                       @"broker_key": base64UrlKey,
                                       @"client_version": adalVersion,
-									  BROKER_PROTOCOL_VERSION : @"2",
+									  BROKER_MAX_VERSION : @"2",
                                       @"extra_qp": _queryParams ? _queryParams : @"",
                                       };
     

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.h
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.h
@@ -53,7 +53,7 @@ extern NSString *const OAUTH2_SAML11_BEARER_VALUE;
 extern NSString *const OAUTH2_SAML2_BEARER_VALUE;
 extern NSString *const OAUTH2_ASSERTION;
 
-extern NSString *const BROKER_MAX_VERSION;
+extern NSString *const BROKER_MAX_PROTOCOL_VERSION;
 extern NSString *const BROKER_MESSAGE_VERSION;
 extern NSString *const BROKER_RESPONSE_KEY;
 extern NSString *const BROKER_HASH_KEY;

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.h
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.h
@@ -53,7 +53,8 @@ extern NSString *const OAUTH2_SAML11_BEARER_VALUE;
 extern NSString *const OAUTH2_SAML2_BEARER_VALUE;
 extern NSString *const OAUTH2_ASSERTION;
 
-extern NSString *const BROKER_PROTOCOL_VERSION;
+extern NSString *const BROKER_MAX_VERSION;
+extern NSString *const BROKER_MESSAGE_VERSION;
 extern NSString *const BROKER_RESPONSE_KEY;
 extern NSString *const BROKER_HASH_KEY;
 

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.m
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.m
@@ -53,7 +53,7 @@ NSString *const OAUTH2_ASSERTION = @"assertion";
 NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml1_1-bearer";
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 
-NSString *const BROKER_MAX_VERSION              = @"max_protocol_ver";
+NSString *const BROKER_MAX_PROTOCOL_VERSION              = @"max_protocol_ver";
 
 NSString *const BROKER_MESSAGE_VERSION          = @"msg_protocol_ver";
 NSString *const BROKER_RESPONSE_KEY             = @"response";

--- a/ADALiOS/ADALiOS/ADOAuth2Constants.m
+++ b/ADALiOS/ADALiOS/ADOAuth2Constants.m
@@ -53,7 +53,9 @@ NSString *const OAUTH2_ASSERTION = @"assertion";
 NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml1_1-bearer";
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 
-NSString *const BROKER_PROTOCOL_VERSION         = @"broker_protocol_ver";
+NSString *const BROKER_MAX_VERSION              = @"max_protocol_ver";
+
+NSString *const BROKER_MESSAGE_VERSION          = @"msg_protocol_ver";
 NSString *const BROKER_RESPONSE_KEY             = @"response";
 NSString *const BROKER_HASH_KEY                 = @"hash";
 


### PR DESCRIPTION
Split the "BROKER_PROTOCOL_VERSION" macro into max_protocol_ver, which the client sends to the broker to indicate the maximum version it understands, and msg_protocol_ver, which the broker sends back to indicate the protocol version of the message.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399%23issuecomment-151321170%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-27T00%3A16%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%208e116c669bfef7612abaab22a9dcd1b59fd4665b%20ADALiOS/ADALiOS/ADOAuth2Constants.m%205%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399%23discussion_r42701367%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40RPangrle%20Could%20this%20be%20BROKER_MAX_PROTOCOL_VERSION%20or%20some%20such.%20%20Right%20now%20it%20seems%20as%20if%20it%20is%20referring%20to%20the%20version%20of%20the%20broker%20rather%20than%20a%20a%20flavor%20of%20protocol%20that%20the%20broker%20speaks.%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A51%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-27T00%3A10%3A51Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADOAuth2Constants.m%3AL53-62%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399%23issuecomment-151321170%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399%23discussion_r42701367%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399%23discussion_r43071111%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-Pull 8e116c669bfef7612abaab22a9dcd1b59fd4665b ADALiOS/ADALiOS/ADOAuth2Constants.m 5'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399#discussion_r42701367'>File: ADALiOS/ADALiOS/ADOAuth2Constants.m:L53-62</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle Could this be BROKER_MAX_PROTOCOL_VERSION or some such.  Right now it seems as if it is referring to the version of the broker rather than a a flavor of protocol that the broker speaks.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/399?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/399?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/399?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/399'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>