### PR TITLE
Delay callback cleanup

### DIFF
--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -68,36 +68,44 @@
     if (![info isWorkPlaceJoined])
     {
         AD_LOG_ERROR(@"Attempting to create device auth response while not workplace joined.", AD_ERROR_WPJ_REQUIRED, nil);
-        return nil;
     }
-    NSString* certAuths = [challengeData valueForKey:@"CertAuthorities"];
-    
-    if (certAuths)
+    else
     {
-        certAuths = [[certAuths adUrlFormDecode] stringByReplacingOccurrencesOfString:@" "
-                                                                           withString:@""];
-        NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
-        if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
-        {
-            AD_LOG_ERROR(@"Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
-            return nil;
-        }
-    }
-    else if ([challengeData valueForKey:@"CertThumbprint"])
-    {
+        NSString* certAuths = [challengeData valueForKey:@"CertAuthorities"];
         NSString* expectedThumbprint = [challengeData valueForKey:@"CertThumbprint"];
-        if (![NSString adSame:expectedThumbprint toString:[ADPkeyAuthHelper computeThumbprint:[info certificateData]]])
+        
+        if (certAuths)
         {
-            AD_LOG_ERROR(@"Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
-            return nil;
+            certAuths = [[certAuths adUrlFormDecode] stringByReplacingOccurrencesOfString:@" "
+                                                                               withString:@""];
+            NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
+            if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
+            {
+                AD_LOG_ERROR(@"Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                [info releaseData];
+                info = nil;
+            }
+        }
+        else if (expectedThumbprint)
+        {
+            if (![NSString adSame:expectedThumbprint toString:[ADPkeyAuthHelper computeThumbprint:[info certificateData]]])
+            {
+                AD_LOG_ERROR(@"Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                [info releaseData];
+                info = nil;
+            }
         }
     }
     
+    NSString* pKeyAuthHeader = @"CERTIFICATE NOT FOUND";
+    if (info)
+    {
+        pKeyAuthHeader = [NSString stringWithFormat:@"AuthToken=\"%@\",", [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer nonce:[challengeData valueForKey:@"nonce"] identity:info]];
+        
+        [info releaseData];
+        info = nil;
+    }
     
-    NSString* pKeyAuthHeader = [NSString stringWithFormat:@"AuthToken=\"%@\",", [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer nonce:[challengeData valueForKey:@"nonce"] identity:info]];
-    
-    [info releaseData];
-    info = nil;
     return [NSString stringWithFormat:@"PKeyAuth %@ Context=\"%@\", Version=\"%@\"", pKeyAuthHeader,[challengeData valueForKey:@"Context"],  [challengeData valueForKey:@"Version"]];
 }
 


### PR DESCRIPTION
In some circumstances this could get hit before trhe launchURL block, causing auth to fail incorrectly.
<a href='#crh-start'></a><a href='#crh-data-%7B%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23issuecomment-150064389%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A43%3A26Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Pull%2073cc421085433bac2c262399805bbc2694662595%20ADALiOS/ADALiOS/ADBrokerNotificationManager.m%2019%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23discussion_r42697557%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40RPangrle%20%20%5C%22might%20have%20a%20chance%5C%22%20or%20will%20always%20get%20the%20chance%3F%22%2C%20%22created_at%22%3A%20%222015-10-21T23%3A47%3A18Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22There%27s%20no%20particular%20way%20to%20guarantee%20always%20here.%20We%27re%20at%20Apple%27s%20mercy%20on%20the%20timing%20of%20various%20background/foreground%20notifications.%20They%20don%27t%20document%20the%20order%20of%20the%20foreground%20notifications%20compared%20to%20openURL%20and%20I%27ve%20seen%20them%20occur%20in%20both%20orders.%20There%20isn%27t%20an%20even%20later%20foreground%20notification%20for%20us%20to%20take%20advantage%20of.%5Cr%5Cn%5Cr%5CnThe%20hope%20is%20that%20by%20the%20point%20this%20notification%20gets%20hit%2C%20if%20the%20app%20was%20called%20via%20openUrl%2C%20that%20it%27s%20already%20in%20the%20queue%20%28which%20seems%20to%20be%20the%20case%29.%20However%20the%20app%20might%20not%20have%20been%20called%20via%20URL%2C%20meaning%20we%20still%20need%20to%20make%20sure%20we%20still%20hit%20the%20completion%20block%20so%20the%20caller%20isn%27t%20left%20hanging.%20%28Which%20would%20cause%20the%20app%20to%20get%20stuck.%29%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A14%3A43Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22Ok.%20%20Sucks%2C%20but%20I%20can%27t%20think%20of%20a%20better%20idea.%22%2C%20%22created_at%22%3A%20%222015-10-22T00%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/ADBrokerNotificationManager.m%3AL68-92%22%7D%7D%2C%20%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23issuecomment-150064389%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23discussion_r42697557%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23discussion_r42699308%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400%23discussion_r42700855%22%5D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [ ] <a href='#crh-comment-Pull 73cc421085433bac2c262399805bbc2694662595 ADALiOS/ADALiOS/ADBrokerNotificationManager.m 19'></a> <img src='http://www.codereviewhub.com/site/github-remaining.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400#discussion_r42697557'>File: ADALiOS/ADALiOS/ADBrokerNotificationManager.m:L68-92</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle  "might have a chance" or will always get the chance?
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> There's no particular way to guarantee always here. We're at Apple's mercy on the timing of various background/foreground notifications. They don't document the order of the foreground notifications compared to openURL and I've seen them occur in both orders. There isn't an even later foreground notification for us to take advantage of.
The hope is that by the point this notification gets hit, if the app was called via openUrl, that it's already in the queue (which seems to be the case). However the app might not have been called via URL, meaning we still need to make sure we still hit the completion block so the caller isn't left hanging. (Which would cause the app to get stuck.)
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> Ok.  Sucks, but I can't think of a better idea.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/400?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/400?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/400?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/400'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>