### PR TITLE
ADPKeyAuthHelper needs to still return a string even if there's no cert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7
 before_install:
 #  - sudo easy_install cpp-coveralls
 script: 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
@@ -507,23 +507,24 @@ static volatile int sDialogInProgress = 0;
 {
     //pkeyauth word length=8 + 1 whitespace
     wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
-    wwwAuthHeaderValue = [wwwAuthHeaderValue stringByReplacingOccurrencesOfString:@"\""
-                                                                       withString:@""];
-    NSArray* headerPairs = [wwwAuthHeaderValue componentsSeparatedByString:@","];
-    NSMutableDictionary* headerKeyValuePair = [[NSMutableDictionary alloc]init];
-    for(int i=0; i<[headerPairs count]; ++i) {
-        NSArray* pair = [headerPairs[i] componentsSeparatedByString:@"="];
-        [headerKeyValuePair setValue:pair[1] forKey:[pair[0] adTrimmedString]];
+    
+    NSDictionary* authHeaderParams = [wwwAuthHeaderValue authHeaderParams];
+    
+    if (!authHeaderParams)
+    {
+        AD_LOG_ERROR_F(@"Unparseable wwwAuthHeader received.", AD_ERROR_WPJ_REQUIRED, @"%@", wwwAuthHeaderValue);
     }
+    
     NSString* authHeader = [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer
-                                                        challengeData:headerKeyValuePair];
-    [headerKeyValuePair removeAllObjects];
-    [headerKeyValuePair setObject:authHeader forKey:@"Authorization"];
+                                                        challengeData:authHeaderParams];
+    
+    NSDictionary* additionalHeaders = @{ @"Authorization" : authHeader };
+
     
     [self requestWithServer:authorizationServer
                 requestData:request_data
             handledPkeyAuth:TRUE
-          additionalHeaders:headerKeyValuePair
+          additionalHeaders:additionalHeaders
                  completion:completionBlock];
 }
 

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.h
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.h
@@ -27,10 +27,10 @@ typedef enum
 
 @interface ADPkeyAuthHelper : NSObject
 
-+ (NSString*)createDeviceAuthResponse:(NSString*)authorizationServer
-                         challengeData:(NSDictionary*)challengeData;
++ (nonnull NSString*)createDeviceAuthResponse:(nonnull NSString*)authorizationServer
+                                challengeData:(nullable NSDictionary*)challengeData;
 
-+ (NSString*)computeThumbprint:(NSData*)data
-                        isSha2:(BOOL)isSha2;
++ (nonnull NSString*)computeThumbprint:(nonnull NSData*)data
+                                isSha2:(BOOL)isSha2;
 
 @end

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -68,36 +68,44 @@
     if (![info isWorkPlaceJoined])
     {
         AD_LOG_ERROR(@"Attempting to create device auth response while not workplace joined.", AD_ERROR_WPJ_REQUIRED, nil);
-        return nil;
     }
-    NSString* certAuths = [challengeData valueForKey:@"CertAuthorities"];
-    
-    if (certAuths)
+    else
     {
-        certAuths = [[certAuths adUrlFormDecode] stringByReplacingOccurrencesOfString:@" "
-                                                                           withString:@""];
-        NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
-        if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
-        {
-            AD_LOG_ERROR(@"Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
-            return nil;
-        }
-    }
-    else if ([challengeData valueForKey:@"CertThumbprint"])
-    {
+        NSString* certAuths = [challengeData valueForKey:@"CertAuthorities"];
         NSString* expectedThumbprint = [challengeData valueForKey:@"CertThumbprint"];
-        if (![NSString adSame:expectedThumbprint toString:[ADPkeyAuthHelper computeThumbprint:[info certificateData]]])
+        
+        if (certAuths)
         {
-            AD_LOG_ERROR(@"Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
-            return nil;
+            certAuths = [[certAuths adUrlFormDecode] stringByReplacingOccurrencesOfString:@" "
+                                                                               withString:@""];
+            NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
+            if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
+            {
+                AD_LOG_ERROR(@"Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                [info releaseData];
+                info = nil;
+            }
+        }
+        else if (expectedThumbprint)
+        {
+            if (![NSString adSame:expectedThumbprint toString:[ADPkeyAuthHelper computeThumbprint:[info certificateData]]])
+            {
+                AD_LOG_ERROR(@"Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                [info releaseData];
+                info = nil;
+            }
         }
     }
     
+    NSString* pKeyAuthHeader = @"CERTIFICATE NOT FOUND";
+    if (info)
+    {
+        pKeyAuthHeader = [NSString stringWithFormat:@"AuthToken=\"%@\",", [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer nonce:[challengeData valueForKey:@"nonce"] identity:info]];
+        
+        [info releaseData];
+        info = nil;
+    }
     
-    NSString* pKeyAuthHeader = [NSString stringWithFormat:@"AuthToken=\"%@\",", [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer nonce:[challengeData valueForKey:@"nonce"] identity:info]];
-    
-    [info releaseData];
-    info = nil;
     return [NSString stringWithFormat:@"PKeyAuth %@ Context=\"%@\", Version=\"%@\"", pKeyAuthHeader,[challengeData valueForKey:@"Context"],  [challengeData valueForKey:@"Version"]];
 }
 

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -97,7 +97,7 @@
         }
     }
     
-    NSString* pKeyAuthHeader = @"CERTIFICATE NOT FOUND";
+    NSString* pKeyAuthHeader = @"";
     if (info)
     {
         pKeyAuthHeader = [NSString stringWithFormat:@"AuthToken=\"%@\",", [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer nonce:[challengeData valueForKey:@"nonce"] identity:info]];

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -28,12 +28,12 @@
 
 @implementation ADPkeyAuthHelper
 
-+ (NSString*) computeThumbprint:(NSData*) data{
++ (nonnull NSString*) computeThumbprint:(nonnull NSData*) data{
     return [ADPkeyAuthHelper computeThumbprint:data isSha2:NO];
 }
 
 
-+ (NSString*) computeThumbprint:(NSData*) data isSha2:(BOOL) isSha2{
++ (nonnull NSString*) computeThumbprint:(nonnull NSData*) data isSha2:(BOOL) isSha2{
     
     //compute SHA-1 thumbprint
     int length = CC_SHA1_DIGEST_LENGTH;
@@ -61,11 +61,16 @@
 }
 
 
-+ (NSString*)createDeviceAuthResponse:(NSString*)authorizationServer
-                        challengeData:(NSDictionary*) challengeData
++ (nonnull NSString*)createDeviceAuthResponse:(NSString*)authorizationServer
+                                challengeData:(NSDictionary*) challengeData
 {
     ADRegistrationInformation *info = [[ADWorkPlaceJoin WorkPlaceJoinManager] getRegistrationInformation];
-    if (![info isWorkPlaceJoined])
+    
+    if (!challengeData)
+    {
+        // Error should have been logged before this where there is more information on why the challenge data was bad
+    }
+    else if (![info isWorkPlaceJoined])
     {
         AD_LOG_INFO(@"PKeyAuth: Received PKeyAuth request but no WPJ info.", nil);
     }
@@ -76,8 +81,6 @@
         
         if (certAuths)
         {
-            certAuths = [[certAuths adUrlFormDecode] stringByReplacingOccurrencesOfString:@" "
-                                                                               withString:@""];
             NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
             if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
             {
@@ -110,7 +113,8 @@
 }
 
 
-+ (NSString*) getOrgUnitFromIssuer:(NSString*) issuer{
++ (NSString*)getOrgUnitFromIssuer:(NSString*)issuer
+{
     NSString *regexString = @"[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexString options:0 error:NULL];
     
@@ -124,8 +128,9 @@
     return nil;
 }
 
-+ (BOOL) isValidIssuer:(NSString*) certAuths
-    keychainCertIssuer:(NSString*) keychainCertIssuer{
++ (BOOL)isValidIssuer:(NSString*)certAuths
+   keychainCertIssuer:(NSString*)keychainCertIssuer
+{
     NSString *regexString = @"OU=[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}";
     keychainCertIssuer = [keychainCertIssuer uppercaseString];
     certAuths = [certAuths uppercaseString];

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -67,7 +67,7 @@
     ADRegistrationInformation *info = [[ADWorkPlaceJoin WorkPlaceJoinManager] getRegistrationInformation];
     if (![info isWorkPlaceJoined])
     {
-        AD_LOG_ERROR(@"Attempting to create device auth response while not workplace joined.", AD_ERROR_WPJ_REQUIRED, nil);
+        AD_LOG_INFO(@"PKeyAuth: Received PKeyAuth request but no WPJ info.", nil);
     }
     else
     {
@@ -81,7 +81,7 @@
             NSString* issuerOU = [ADPkeyAuthHelper getOrgUnitFromIssuer:[info certificateIssuer]];
             if (![self isValidIssuer:certAuths keychainCertIssuer:issuerOU])
             {
-                AD_LOG_ERROR(@"Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                AD_LOG_ERROR(@"PKeyAuth Error: Certificate Authority specified by device auth request does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
                 [info releaseData];
                 info = nil;
             }
@@ -90,7 +90,7 @@
         {
             if (![NSString adSame:expectedThumbprint toString:[ADPkeyAuthHelper computeThumbprint:[info certificateData]]])
             {
-                AD_LOG_ERROR(@"Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
+                AD_LOG_ERROR(@"PKeyAuth Error: Certificate Thumbprint does not match certificate in keychain.", AD_ERROR_WPJ_REQUIRED, nil);
                 [info releaseData];
                 info = nil;
             }

--- a/ADALiOS/ADALiOS/NSString+ADHelperMethods.h
+++ b/ADALiOS/ADALiOS/NSString+ADHelperMethods.h
@@ -80,4 +80,6 @@
 
 - (NSString*) adComputeSHA256;
 
+- (NSDictionary*)authHeaderParams;
+
 @end

--- a/ADALiOS/ADALiOS/NSString+ADHelperMethods.m
+++ b/ADALiOS/ADALiOS/NSString+ADHelperMethods.m
@@ -415,6 +415,16 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
     return toReturn;
 }
 
+
+// Decodes the parameters that come in the Authorization header. We expect them in the following
+// format:
+//
+// <key>="<value>", key="<value>", key="<value>"
+// i.e. version="1.0",CertAuthorities="OU=MyOrganization,CN=MyThingy,DN=windows,DN=net,Context="context!"
+//
+// This parser is lenient on whitespace, and on the presence of enclosing quotation marks. It also
+// will allow commented out quotation marks
+
 - (NSDictionary*)authHeaderParams
 {
     NSMutableDictionary* params = [NSMutableDictionary new];

--- a/ADALiOS/ADALiOSTests/ADTestNSStringHelperMethods.m
+++ b/ADALiOS/ADALiOSTests/ADTestNSStringHelperMethods.m
@@ -292,4 +292,38 @@
     XCTAssertFalse([NSString adSame:nil toString:text]);
 }
 
+- (void)testAuthParams
+{
+    NSString* pkeyAuthString = @"nonce=\"I am a nonce!\", CertAuthorities=\"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net\", Version=\"1.0\", Context=\"Look at me! I'm a context!\"";
+    
+    NSDictionary* expected = @{ @"nonce" : @"I am a nonce!",
+                                @"CertAuthorities" : @"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net",
+                                @"Version" : @"1.0",
+                                @"Context" : @"Look at me! I'm a context!"
+                                };
+    
+    NSDictionary* authHeaders = [pkeyAuthString authHeaderParams];
+    
+    XCTAssertEqualObjects(expected, authHeaders);
+}
+
+- (void)testAuthParamErrors
+{
+    NSString* unterminatedString = @"key1=\"value1\",key2=\"value2";
+    XCTAssertNil([unterminatedString authHeaderParams]);
+    
+    NSString* tooManyCommas = @"key1=\"value1\",,,,,,,key2=\"value2\"";
+    XCTAssertNil([tooManyCommas authHeaderParams]);
+    
+    NSString* nothingButCommas = @",,,,,,,,,,,,";
+    XCTAssertNil([nothingButCommas authHeaderParams]);
+    
+    NSString* emptyString = @"";
+    // In this case we expect an empty dictionary back
+    XCTAssertEqualObjects([emptyString authHeaderParams], @{});
+    
+    NSString* noComma = @"key1=\"value1\"key2=\"value2\"";
+    XCTAssertNil([noComma authHeaderParams]);
+}
+
 @end


### PR DESCRIPTION
I got overzealous in code cleanup. We rely on this method still returning something.
<a href='#crh-start'></a><a href='#crh-data-%7B%22processed%22%3A%20%5B%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150390807%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150410100%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150410767%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150411893%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150412087%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-151304022%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-151304046%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-151335560%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-151563711%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-151565940%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-152044092%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/commit/f66a1bad453056bfa9a76be4c952a69903dfe6c1%23commitcomment-13997472%22%2C%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/commit/f66a1bad453056bfa9a76be4c952a69903dfe6c1%23commitcomment-14055997%22%5D%2C%20%22comments%22%3A%20%7B%22General%20Comment%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401%23issuecomment-150390807%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40RPangrle%20Is%20there%20a%20test%20that%20would%20catch%20this%20in%20the%20future%3F%22%2C%20%22created_at%22%3A%20%222015-10-22T23%3A58%3A19Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22adding%20nonnull%20to%20the%20return%20type%20would%20guarantee%20that%20at%20least%20something%20gets%20returned.%20Not%20sure%20what%20extent%20we%27d%20want%20to%20test%20that.%22%2C%20%22created_at%22%3A%20%222015-10-23T01%3A56%3A45Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22What%20I%20mean%20is%20that%20you%20removed%20some%20code%2C%20and%20that%20led%20to%20a%20problem.%20%20Is%20there%20a%20test%20that%20would%20have%20caught%20whatever%20that%20problem%20was%3F%20%20Or%20is%20that%20what%20happened%3F%22%2C%20%22created_at%22%3A%20%222015-10-23T02%3A02%3A09Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22I%27m%20not%20sure%20how%20much%20it%20cares%20about%20the%20specific%20response.%20I%20can%20add%20a%20test%20for%20the%20basic%20no-wpj%20case%2C%20but%20yeah%2C%20the%20really%20big%20issue%20here%20is%20that%20we%20can%27t%20return%20nil.%22%2C%20%22created_at%22%3A%20%222015-10-23T02%3A08%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-23T02%3A10%3A08Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40RPangrle%20Was%20there%20a%20bug%20in%20the%20current%20auth%20header%20parsing%3F%22%2C%20%22created_at%22%3A%20%222015-10-26T22%3A33%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%3Agun%3A%22%2C%20%22created_at%22%3A%20%222015-10-26T22%3A33%3A40Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yes%2C%20It%20was%20splitting%20on%20the%20%27%3D%27%20character%2C%20the%20string%20being%20passed%20in%20looked%20like%3A%5Cr%5Cn%5Cr%5CnVersion%3D%5C%221.0%5C%22%2C%20CertAuthorities%3D%5C%22OU%3D%3Cguid%3E%2CCN%3DMICROSOFT-ACCESS%2CDN%3Dwindows%2CDN%3Dnet%5C%22%2CContext%3D%5C%22%3Cbig%20maybe%20base64%20encoded%20blob%3E%5C%22%5Cr%5Cn%5Cr%5CnSplitting%20on%20the%20%3D%20meant%20that%20the%20cert%20authorities%20came%20through%20as%20simply%20the%20string%20%5C%22OU%5C%22%20and%20failed.%22%2C%20%22created_at%22%3A%20%222015-10-27T01%3A23%3A44Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%40RPangrle%20Did%20you%20see%20my%20other%20comment%20about%20adding%20a%20comment%20header%3F%22%2C%20%22created_at%22%3A%20%222015-10-27T16%3A43%3A07Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22Yeah.%20I%20just%20haven%27t%20had%20an%20opportunity%20to%20get%20to%20it%20yet.%22%2C%20%22created_at%22%3A%20%222015-10-27T16%3A51%3A05Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/7004783%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RPangrle%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3Ashipit%3A%22%2C%20%22created_at%22%3A%20%222015-10-29T01%3A01%3A31Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22General%20Comment%22%7D%2C%20%22Commit%20f66a1bad453056bfa9a76be4c952a69903dfe6c1%20ADALiOS/ADALiOS/NSString%252BADHelperMethods.m%204%20418%22%3A%20%7B%22html_url%22%3A%20%22https%3A//github.com/AzureAD/azure-activedirectory-library-for-objc/commit/f66a1bad453056bfa9a76be4c952a69903dfe6c1%23commitcomment-13997472%22%2C%20%22comments%22%3A%20%5B%7B%22body%22%3A%20%22%40RPangrle%20Could%20you%20add%20a%20comment%20header%20with%20an%20example%20of%20what%20is%20being%20parsed.%22%2C%20%22created_at%22%3A%20%222015-10-26T22%3A32%3A38Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%2C%20%7B%22body%22%3A%20%22%3A%2B1%3A%22%2C%20%22created_at%22%3A%20%222015-10-29T01%3A01%3A50Z%22%2C%20%22user%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%2C%20%22html_url%22%3A%20%22https%3A//github.com/RandalliLama%22%7D%7D%5D%2C%20%22title%22%3A%20%22File%3A%20ADALiOS/ADALiOS/NSString%2BADHelperMethods.m%3AL418%20%28f66a1ba%29%22%7D%7D%2C%20%22approved%22%3A%20%7B%22https%3A//github.com/RandalliLama%22%3A%20%7B%22avatar_url%22%3A%20%22https%3A//avatars.githubusercontent.com/u/4307330%3Fv%3D3%22%7D%7D%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>

<img src='http://www.codereviewhub.com/site/github-approved-avatar.png'><a href='https://github.com/RandalliLama'><img src='https://avatars.githubusercontent.com/u/4307330?v=3' width=34 height=34></a>

- [x] <a href='#crh-comment-General Comment'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401#issuecomment-150390807'>General Comment</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle Is there a test that would catch this in the future?
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> adding nonnull to the return type would guarantee that at least something gets returned. Not sure what extent we'd want to test that.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> What I mean is that you removed some code, and that led to a problem.  Is there a test that would have caught whatever that problem was?  Or is that what happened?
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> I'm not sure how much it cares about the specific response. I can add a test for the basic no-wpj case, but yeah, the really big issue here is that we can't return nil.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> :shipit:
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle Was there a bug in the current auth header parsing?
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> :shipit::gun:
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Yes, It was splitting on the '=' character, the string being passed in looked like:
Version="1.0", CertAuthorities="OU=<guid>,CN=MICROSOFT-ACCESS,DN=windows,DN=net",Context="<big maybe base64 encoded blob>"
Splitting on the = meant that the cert authorities came through as simply the string "OU" and failed.
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle Did you see my other comment about adding a comment header?
- <a href='https://github.com/RPangrle'><img border=0 src='https://avatars.githubusercontent.com/u/7004783?v=3' height=16 width=16'></a> Yeah. I just haven't had an opportunity to get to it yet.
- [x] <a href='#crh-comment-Commit f66a1bad453056bfa9a76be4c952a69903dfe6c1 ADALiOS/ADALiOS/NSString%2BADHelperMethods.m 4 418'></a> <img src='http://www.codereviewhub.com/site/github-completed.png' height=16 width=60>&nbsp;<b><a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/commit/f66a1bad453056bfa9a76be4c952a69903dfe6c1#commitcomment-13997472'>File: ADALiOS/ADALiOS/NSString+ADHelperMethods.m:L418 (f66a1ba)</a></b>
- <a href='https://github.com/RandalliLama'><img border=0 src='https://avatars.githubusercontent.com/u/4307330?v=3' height=16 width=16'></a> @RPangrle Could you add a comment header with an example of what is being parsed.


<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/401?mark_as_completed=1'><img src='http://www.codereviewhub.com/site/github-mark-as-completed.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/401?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/401?approve=0'><img src='http://www.codereviewhub.com/site/github-undo-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/401'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>