### PR TITLE
Issues/osxuniversal loggerfix

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -531,7 +531,6 @@ return; \
                  }//broad item
              }//key
          }//!item.multiResourceRefreshToken
-         
          //The refresh token attempt failed and no other suitable refresh token found
          //call acquireToken
          [self requestTokenWithResource: resource
@@ -2173,18 +2172,19 @@ additionalHeaders:headerKeyValuePair
 
 
 
-+(BOOL) isResponseFromBroker:(NSString*) sourceApplication
-                    response:(NSURL*) response
++ (BOOL)isResponseFromBroker:(NSString*)sourceApplication
+                    response:(NSURL*)response
 {
     return response && [NSString adSame:sourceApplication toString:brokerAppIdentifier];
 }
 
 
-+(void) handleBrokerResponse:(NSURL*) response
++ (void)handleBrokerResponse:(NSURL*) response
 {
     ADAuthenticationCallback completionBlock = [ADBrokerNotificationManager sharedInstance].callbackForBroker;
     if (!completionBlock)
     {
+        AD_LOG_WARN(@"Received broker response, but no completion block.", nil);
         return;
     }
     
@@ -2214,9 +2214,11 @@ additionalHeaders:headerKeyValuePair
         
         if(!error)
         {
-            decryptedString =[[NSString alloc] initWithData:decrypted encoding:NSASCIIStringEncoding];
+            decryptedString = [[NSString alloc] initWithData:decrypted encoding:NSUTF8StringEncoding];
             //now compute the hash on the unencrypted data
-            if([NSString adSame:hash toString:[ADPkeyAuthHelper computeThumbprint:decrypted isSha2:YES]]){
+            AD_LOG_INFO_F(@"Received broker reponse", @"reponse = %@", decrypted);
+            if([NSString adSame:hash toString:[ADPkeyAuthHelper computeThumbprint:decrypted isSha2:YES]])
+            {
                 //create response from the decrypted payload
                 queryParamsMap = [NSDictionary adURLFormDecode:decryptedString];
                 [ADHelpers removeNullStringFrom:queryParamsMap];

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -1693,7 +1693,7 @@ additionalHeaders:nil
 {
     if ( !OSAtomicCompareAndSwapInt( 1, 0, &sDialogInProgress) )
     {
-        AD_LOG_WARN(@"UI Locking", @"The UI lock has already been released.")
+        AD_LOG_WARN(@"UI Locking", @"The UI lock has already been released.");
     }
 }
 

--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.h
@@ -32,7 +32,7 @@ typedef WebView   WebViewType;
 #if TARGET_OS_IPHONE
     : NSObject <UIWebViewDelegate>
 #else
-    : NSObject
+    : NSObject <WebResourceLoadDelegate, WebPolicyDelegate, WebFrameLoadDelegate>
 #endif
 {
 // OSX Universal Compatibility

--- a/ADALiOS/ADALiOS/ADAuthenticationWindowController.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationWindowController.h
@@ -20,7 +20,7 @@
 
 @protocol ADAuthenticationDelegate;
 
-@interface ADAuthenticationWindowController : NSWindowController <NSWindowDelegate>
+@interface ADAuthenticationWindowController : NSWindowController <NSWindowDelegate, WebResourceLoadDelegate>
 {
     IBOutlet WebView *_webView;
     __weak NSProgressIndicator *_progressIndicator;

--- a/ADALiOS/ADALiOS/ADDefaultTokenCacheStorePersistance.m
+++ b/ADALiOS/ADALiOS/ADDefaultTokenCacheStorePersistance.m
@@ -69,7 +69,7 @@ const int16_t LOWER_VERSION = 0;
             //A new, incompatible version of the cache is stored, ignore the cache:
             AD_LOG_ERROR_F(@"Future file format", AD_ERROR_CACHE_PERSISTENCE,
                            @"The version (%d.%d) of the cache file is not supported.",
-                           _upperVersion, _lowerVersion)
+                           _upperVersion, _lowerVersion);
             return nil;
         }
         

--- a/ADALiOS/ADALiOS/ADKeyChainHelper.m
+++ b/ADALiOS/ADALiOS/ADKeyChainHelper.m
@@ -87,10 +87,10 @@ extern NSString* const sKeyChainlog;
     
     if (block != nil)
     {
-        SecAccessRef access = block((__bridge CFStringRef)[attributes objectForKey:kSecAttrLabel]);
+        SecAccessRef access = block((__bridge CFStringRef)[attributes objectForKey:(id)kSecAttrLabel]);
         if (access != NULL)
         {
-            [attributes setObject:(id)access forKey:kSecAttrAccess];
+            [attributes setObject:(id)access forKey:(id)kSecAttrAccess];
             CFRelease(access);
         }
     }
@@ -98,8 +98,8 @@ extern NSString* const sKeyChainlog;
 #endif // !TARGET_OS_IPHONE
     
 #if !TARGET_OS_IPHONE
-    [attributes removeObjectForKey:kSecAttrCreationDate];
-    [attributes removeObjectForKey:kSecAttrModificationDate];
+    [attributes removeObjectForKey:(id)kSecAttrCreationDate];
+    [attributes removeObjectForKey:(id)kSecAttrModificationDate];
 #endif
     
     [attributes setObject:_classValue forKey:(__bridge id)kSecClass];

--- a/ADALiOS/ADALiOS/ADLogger.h
+++ b/ADALiOS/ADALiOS/ADLogger.h
@@ -34,10 +34,10 @@ typedef enum
 /*! Sets the logging level for the internal logging messages. Messages with
  priority lower than the specified level will be ignored.
  @param logLevel: desired logging level. The higher the number, the more logging information is included. */
-+(void) setLevel: (ADAL_LOG_LEVEL)logLevel;
++ (void)setLevel:(ADAL_LOG_LEVEL)logLevel;
 
 /*! Returns the current log level. See setLevel for details */
-+(ADAL_LOG_LEVEL) getLevel;
++ (ADAL_LOG_LEVEL)getLevel;
 
 /*! Main logging function. Macros like ADAL_LOG_ERROR are provided on top for convenience
  @param logLevel: The applicable priority of the logged message. Use AD_LOG_LEVEL_NO_LOG to disable all logging.
@@ -45,7 +45,7 @@ typedef enum
  @param additionalInformation: Full details. May contain parameter names, stack traces, etc. May be nil.
  @param errorCode: if an explicit error has occurred, this code will contain its code.
  */
-+(void) log:(ADAL_LOG_LEVEL)logLevel
++ (void)log:(ADAL_LOG_LEVEL)logLevel
     message:(NSString*)message
   errorCode:(NSInteger)errorCode
        info:(NSString*)additionalInformation;
@@ -63,49 +63,49 @@ typedef enum
  @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
  This parameter can be nil.
  */
-+(void) logToken: (NSString*) token
-       tokenType: (NSString*) tokenType
-       expiresOn: (NSDate*) expiresOn
-   correlationId: (NSUUID*) correlationId;
++ (void)logToken:(NSString*)token
+       tokenType:(NSString*)tokenType
+       expiresOn:(NSDate*)expiresOn
+   correlationId:(NSUUID*)correlationId;
 
 
 //The block declaration. Needs to be weak to ensure that the pointer does not hold static reference
 //to the parent class of the callback.
-typedef void (^LogCallback)(ADAL_LOG_LEVEL logLevel,
-                            NSString* message,
-                            NSString* additionalInformation,
-                            NSInteger errorCode);
+typedef void (^ADLogCallback)(ADAL_LOG_LEVEL logLevel,
+                              NSString* message,
+                              NSString* additionalInformation,
+                              NSInteger errorCode);
 
 /*! Provided block will be called when the logged messages meet the priority threshold
  @param callback: The block to be executed when suitable messages are logged. By default, when
  callback is set, messages will contingue to be logged through NSLog. Such logging can be disabled
  through setNSLogging. */
-+(void) setLogCallBack: (LogCallback) callback;
++ (void) setLogCallBack:(ADLogCallback) callback;
 
 /*! Returns previously set callback call or nil, if the user has not set such callback. */
-+(LogCallback) getLogCallBack;
++ (ADLogCallback)getLogCallBack;
 
 /*! By default, logging sends messages through standard NSLog. This function allows to disable this
  behavior. Disabling is useful if faster logging is implemented through the callback. */
-+(void) setNSLogging: (BOOL) nslogging;
++ (void)setNSLogging:(BOOL)nslogging;
 
 /*! YES if the messages are logged through NSLog.*/
-+(BOOL) getNSLogging;
++ (BOOL)getNSLogging;
 
 /*! Returns diagnostic trace data to be sent to the Auzure Active Directory servers. */
-+(NSDictionary*) adalId;
++ (NSDictionary*)adalId;
 
 /*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
  the actual contents, but still want to log something that can be correlated. */
-+(NSString*) getHash: (NSString*) input;
++ (NSString*)getHash:(NSString*)input;
 
 /*! Sets correlation id to be used in the requests sent to server. */
-+(void) setCorrelationId: (NSUUID*) correlationId;
++ (void)setCorrelationId:(NSUUID*)correlationId;
 
 /*! Gets correlation Id. */
-+(NSUUID*) getCorrelationId;
++ (NSUUID*)getCorrelationId;
 
-+(NSString*) getAdalVersion;
++ (NSString*)getAdalVersion;
 
 @end
 

--- a/ADALiOS/ADALiOS/ADLogger.h
+++ b/ADALiOS/ADALiOS/ADLogger.h
@@ -28,10 +28,11 @@ typedef enum
     ADAL_LOG_LEVEL_VERBOSE,
     ADAL_LOG_LAST = ADAL_LOG_LEVEL_VERBOSE,
 } ADAL_LOG_LEVEL;
+
 @interface ADLogger : NSObject
 
 /*! Sets the logging level for the internal logging messages. Messages with
- priority lower than the specified level will be ignored. 
+ priority lower than the specified level will be ignored.
  @param logLevel: desired logging level. The higher the number, the more logging information is included. */
 +(void) setLevel: (ADAL_LOG_LEVEL)logLevel;
 
@@ -44,10 +45,16 @@ typedef enum
  @param additionalInformation: Full details. May contain parameter names, stack traces, etc. May be nil.
  @param errorCode: if an explicit error has occurred, this code will contain its code.
  */
-+(void) log: (ADAL_LOG_LEVEL)logLevel
-    message: (NSString*) message
-  errorCode: (NSInteger) errorCode
-additionalInformation: (NSString*) additionalInformation;
++(void) log:(ADAL_LOG_LEVEL)logLevel
+    message:(NSString*)message
+  errorCode:(NSInteger)errorCode
+       info:(NSString*)additionalInformation;
+
+/*! Convience logging fucntion. Allows the creation of additionalInformation strings using format strings. */
++ (void)log:(ADAL_LOG_LEVEL)level
+    message:(NSString*)message
+  errorCode:(NSInteger)code
+     format:(NSString*)format, ... __attribute__((format(__NSString__, 4, 5)));
 
 /*! Logs obtaining of a token. The method does not log the actual token, only its hash.
  @param token: the token to log.
@@ -55,7 +62,7 @@ additionalInformation: (NSString*) additionalInformation;
  @param expiresOn: the time when an access token will stop to be valid. Nil for refresh token types.
  @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
  This parameter can be nil.
-*/
+ */
 +(void) logToken: (NSString*) token
        tokenType: (NSString*) tokenType
        expiresOn: (NSDate*) expiresOn
@@ -88,6 +95,10 @@ typedef void (^LogCallback)(ADAL_LOG_LEVEL logLevel,
 /*! Returns diagnostic trace data to be sent to the Auzure Active Directory servers. */
 +(NSDictionary*) adalId;
 
+/*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
+ the actual contents, but still want to log something that can be correlated. */
++(NSString*) getHash: (NSString*) input;
+
 /*! Sets correlation id to be used in the requests sent to server. */
 +(void) setCorrelationId: (NSUUID*) correlationId;
 
@@ -99,46 +110,29 @@ typedef void (^LogCallback)(ADAL_LOG_LEVEL logLevel,
 @end
 
 //A simple macro for single-line logging:
-#define AD_LOG(level, msg, code, info) \
-{ \
-            [ADLogger log: level \
-                  message: msg \
-                errorCode: code \
-    additionalInformation: info]; \
-}
+#define AD_LOG(_level, _msg, _code, _info) [ADLogger log:_level message:_msg errorCode:_code info:_info]
 
 #define FIRST_ARG(ARG,...) ARG
 
 //Allows formatting, e.g. AD_LOG_FORMAT(ADAL_LOG_LEVEL_INFO, "Something", "Check this: %@ and this: %@", this1, this2)
 //If we make this a method, we will lose the warning when the string formatting parameters do not match the actual parameters.
-#define AD_LOG_FORMAT(level, msg, code, info...) \
-{ \
-    if (FIRST_ARG(info))/*Avoid crash in logging*/ \
-    { \
-        NSString* logInfo = [NSString stringWithFormat:info]; \
-        [ADLogger log: level \
-              message: msg \
-            errorCode: code \
-additionalInformation: logInfo]; \
-    } \
-    else \
-    { \
-        [ADLogger log: level \
-              message: msg \
-            errorCode: code \
-additionalInformation: @"Bad logging: nil info specified."]; \
-    } \
-}
+#define AD_LOG_F(_level, _msg, _code, _fmt, ...) [ADLogger log:_level message:_msg errorCode:_code format:_fmt, ##__VA_ARGS__ ]
 
-#define AD_LOG_ERROR(message, code, info) AD_LOG(ADAL_LOG_LEVEL_ERROR, message, code, info)
-#define AD_LOG_WARN(message, info) AD_LOG(ADAL_LOG_LEVEL_WARN, message, AD_ERROR_SUCCEEDED, info)
-#define AD_LOG_INFO(message, info) AD_LOG(ADAL_LOG_LEVEL_INFO, message, AD_ERROR_SUCCEEDED, info)
-#define AD_LOG_VERBOSE(message, info) AD_LOG(ADAL_LOG_LEVEL_VERBOSE, message, AD_ERROR_SUCCEEDED, info)
+#define AD_LOG_ERROR(_message, _code, _info)    AD_LOG(ADAL_LOG_LEVEL_ERROR, _message, _code, _info)
+#define AD_LOG_WARN(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_WARN, _message, AD_ERROR_SUCCEEDED, _info)
+#define AD_LOG_INFO(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_INFO, _message, AD_ERROR_SUCCEEDED, _info)
+#define AD_LOG_VERBOSE(_message, _info)         AD_LOG(ADAL_LOG_LEVEL_VERBOSE, _message, AD_ERROR_SUCCEEDED, _info)
 
-#define AD_LOG_ERROR_F(message, code, info...) AD_LOG_FORMAT(ADAL_LOG_LEVEL_ERROR, message, code, info)
-#define AD_LOG_WARN_F(message, info...) AD_LOG_FORMAT(ADAL_LOG_LEVEL_WARN, message, AD_ERROR_SUCCEEDED, info)
-#define AD_LOG_INFO_F(message, info...) AD_LOG_FORMAT(ADAL_LOG_LEVEL_INFO, message, AD_ERROR_SUCCEEDED, info)
-#define AD_LOG_VERBOSE_F(message, info...) AD_LOG_FORMAT(ADAL_LOG_LEVEL_VERBOSE, message, AD_ERROR_SUCCEEDED, info)
+#define AD_LOG_ERROR_F(_msg, _code, _fmt, ...)        AD_LOG_F(ADAL_LOG_LEVEL_ERROR, _msg, _code, _fmt, ##__VA_ARGS__)
+#define AD_LOG_WARN_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_WARN, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
+#define AD_LOG_INFO_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_INFO, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
+#define AD_LOG_VERBOSE_F(_msg, _fmt, ...)             AD_LOG_F(ADAL_LOG_LEVEL_VERBOSE, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
 
-
+#ifndef DebugLog
+#ifdef DEBUG
+#   define DebugLog(fmt, ...) NSLog((@"%s[%d][%@] " fmt), __PRETTY_FUNCTION__, __LINE__, [[NSThread currentThread] isEqual:[NSThread mainThread]] ? @"main" : @"work", ##__VA_ARGS__);
+#else
+#   define DebugLog(...)
+#endif
+#endif
 

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -187,7 +187,7 @@
     }
     
     if (!CC_SHA256([plainData bytes], (CC_LONG)[plainData length], hashBytes)) {
-        [ADLogger log:ADAL_LOG_LEVEL_ERROR message:@"Could not compute SHA265 hash." errorCode:AD_ERROR_UNEXPECTED additionalInformation:nil ];
+        [ADLogger log:ADAL_LOG_LEVEL_ERROR message:@"Could not compute SHA265 hash." errorCode:AD_ERROR_UNEXPECTED info:nil ];
         if (hashBytes)
             free(hashBytes);
         if (signedHashBytes)
@@ -203,7 +203,7 @@
                                     signedHashBytes,
                                     &signedHashBytesSize);
     
-    [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"Status returned from data signing - " errorCode:status additionalInformation:nil ];
+    [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"Status returned from data signing - " errorCode:status info:nil ];
     signedHash = [NSData dataWithBytes:signedHashBytes
                                 length:(NSUInteger)signedHashBytesSize];
     
@@ -259,7 +259,7 @@
                                                          error:&error];
     NSString* returnValue = nil;
     if (! jsonData) {
-        [ADLogger log:ADAL_LOG_LEVEL_ERROR message:[NSString stringWithFormat:@"Got an error: %@",error] errorCode:error.code additionalInformation:nil ];
+        [ADLogger log:ADAL_LOG_LEVEL_ERROR message:[NSString stringWithFormat:@"Got an error: %@",error] errorCode:error.code info:nil ];
     } else {
         returnValue = SAFE_ARC_AUTORELEASE([[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding]);
     }

--- a/ADALiOS/ADALiOS/NSDictionary+ADExtensions.m
+++ b/ADALiOS/ADALiOS/NSDictionary+ADExtensions.m
@@ -27,7 +27,7 @@
 // Always returns a dictionary, even if the string is nil, empty or contains no pairs
 + (NSDictionary *)adURLFormDecode:(NSString *)string
 {
-    NSMutableDictionary *parameters = [[NSMutableDictionary alloc] initWithCapacity:6];
+    NSMutableDictionary *parameters = [NSMutableDictionary new];
     
     if ( nil != string && string.length != 0 )
     {

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -949,9 +949,6 @@ const int sAsyncContextTimeout = 10;
     NSUUID* second = [NSUUID UUID];
     mContext.correlationId = second;
     XCTAssertEqual(mContext.correlationId, second);
-    
-    mContext.correlationId = nil;
-    XCTAssertNil(mContext.correlationId);
 }
 
 -(void) testCorrelationIdRefreshToken

--- a/ADALiOS/ADALiOSTests/ADLoggerTests.m
+++ b/ADALiOS/ADALiOSTests/ADLoggerTests.m
@@ -58,7 +58,7 @@ dispatch_semaphore_t sLoggerTestCompletedSignal;
         {
             NSString* message = [NSString stringWithFormat:@"Test%dMessage%d %s", i, j, __PRETTY_FUNCTION__];
             NSString* info = [NSString stringWithFormat:@"Test%dnfo%d %s", i, j, __PRETTY_FUNCTION__];
-            [ADLogger log:j message:message errorCode:1 additionalInformation:info];
+            [ADLogger log:j message:message errorCode:1 info:info];
             if (j <= i)//Meets the error bar
             {
                 ADAssertLogsContainValue(TEST_LOG_MESSAGE, message);
@@ -77,9 +77,9 @@ dispatch_semaphore_t sLoggerTestCompletedSignal;
 {
     [self adSetLogTolerance:ADAL_LOG_LEVEL_ERROR];
     //Neither of these calls should throw. See the method body for details:
-    [ADLogger log:ADAL_LOG_LEVEL_NO_LOG message:@"Message" errorCode:AD_ERROR_SUCCEEDED additionalInformation:@"info" ];
-    [ADLogger log:ADAL_LOG_LEVEL_ERROR message:nil errorCode:AD_ERROR_SUCCEEDED additionalInformation:@"info" ];
-    [ADLogger log:ADAL_LOG_LEVEL_ERROR message:@"message" errorCode:AD_ERROR_SUCCEEDED additionalInformation:nil];
+    [ADLogger log:ADAL_LOG_LEVEL_NO_LOG message:@"Message" errorCode:AD_ERROR_SUCCEEDED info:@"info" ];
+    [ADLogger log:ADAL_LOG_LEVEL_ERROR message:nil errorCode:AD_ERROR_SUCCEEDED info:@"info" ];
+    [ADLogger log:ADAL_LOG_LEVEL_ERROR message:@"message" errorCode:AD_ERROR_SUCCEEDED info:nil];
 }
 
 -(void) threadProc
@@ -93,12 +93,12 @@ dispatch_semaphore_t sLoggerTestCompletedSignal;
             @autoreleasepool//Needed, as the code inside the loop creates objects:
             {
                 [ADLogger setLogCallBack:nil];
-                [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"test" errorCode:1 additionalInformation:@"info"];
+                [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"test" errorCode:1 info:@"info"];
                 [ADLogger setLogCallBack:^(ADAL_LOG_LEVEL logLevel, NSString *message, NSString *additionalInformation, NSInteger errorCode)
                  {
                      [log appendFormat:@"%d; %@; %@; %ld;", logLevel, message, additionalInformation, (long)errorCode];
                  }];
-                [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"test1" errorCode:1 additionalInformation:@"info1"];
+                [ADLogger log:ADAL_LOG_LEVEL_INFO message:@"test1" errorCode:1 info:@"info1"];
                 [ADLogger setLogCallBack:nil];
                 NSRange all = {0, log.length};
                 [log deleteCharactersInRange:all];//Clear to avoid memory spike

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.h
@@ -203,3 +203,9 @@ typedef enum
 //Verifes that "error" local variable is nil. If not prints the error
 #define ADAssertNoError XCTAssertNil(error, "Unexpected error occurred: %@", error.errorDetails)
 
+#define ADTestWaitAndRunLoop(_sem) { \
+    while (dispatch_semaphore_wait(_sem, DISPATCH_TIME_NOW)) { \
+        [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]]; \
+    } \
+}
+

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
@@ -117,7 +117,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
         [sErrorCodesLog appendString:sTestBegin];
     }
     
-    LogCallback logCallback = ^(ADAL_LOG_LEVEL logLevel,
+    ADLogCallback logCallback = ^(ADAL_LOG_LEVEL logLevel,
                                 NSString* message,
                                 NSString* additionalInformation,
                                 NSInteger errorCode)


### PR DESCRIPTION
Bring over fixes to variadic logger macros to OS X Universal
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/403?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/403'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>