### PR TITLE
Issues/osx broker datefix

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationError.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationError.m
@@ -76,7 +76,11 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
                     userInfo: (NSDictionary*) userInfo
 {
     THROW_ON_NIL_EMPTY_ARGUMENT(domain);
-    THROW_ON_NIL_EMPTY_ARGUMENT(details);
+    
+    if (!details)
+    {
+        details = @"";
+    }
     
     {
         NSString* message = [NSString stringWithFormat:@"Error raised: %lu", (long)code];
@@ -111,8 +115,6 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
 +(ADAuthenticationError*) errorFromArgument: (id) argumentValue
                                argumentName: (NSString*)argumentName
 {
-    THROW_ON_NIL_EMPTY_ARGUMENT(argumentName);
-    
     //Constructs the applicable message and return the error:
     NSString* errorMessage = [NSString stringWithFormat:ADInvalidArgumentMessage, argumentName, argumentValue];
     return [self errorWithDomainInternal:ADInvalidArgumentDomain
@@ -125,7 +127,6 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
 +(ADAuthenticationError*) errorFromUnauthorizedResponse: (NSInteger) responseCode
                                            errorDetails: (NSString*) errorDetails
 {
-    THROW_ON_NIL_EMPTY_ARGUMENT(errorDetails);
     return [self errorWithDomainInternal:ADUnauthorizedResponseErrorDomain
                                     code:responseCode
                        protocolErrorCode:nil
@@ -135,7 +136,6 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
 
 +(ADAuthenticationError*) errorFromNSError: (NSError*) error errorDetails: (NSString*) errorDetails
 {
-    THROW_ON_NIL_EMPTY_ARGUMENT(errorDetails);
     return [self errorWithDomainInternal:error.domain
                                     code:error.code
                        protocolErrorCode:nil
@@ -147,7 +147,6 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
                                           protocolCode: (NSString*) protocolCode
                                           errorDetails: (NSString*) errorDetails
 {
-    THROW_ON_NIL_EMPTY_ARGUMENT(errorDetails);
     return [self errorWithDomainInternal:ADAuthenticationErrorDomain
                                     code:code
                        protocolErrorCode:protocolCode
@@ -157,7 +156,6 @@ NSString* const ADCancelError = @"The user has cancelled the authorization.";
 
 +(ADAuthenticationError*) unexpectedInternalError: (NSString*) errorDetails
 {
-    THROW_ON_NIL_EMPTY_ARGUMENT(errorDetails);
     return [self errorFromAuthenticationError:AD_ERROR_UNEXPECTED
                                  protocolCode:nil
                                  errorDetails:errorDetails];

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -159,9 +159,9 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
     
     if ( expires_in != nil )
     {
-        if ( [expires_in respondsToSelector:@selector(longValue)] )
+        if ( [expires_in respondsToSelector:@selector(doubleValue)] )
         {
-            expires = [NSDate dateWithTimeIntervalSince1970:[expires_in longValue]];
+            expires = [NSDate dateWithTimeIntervalSince1970:[expires_in doubleValue]];
         }
         else
         {

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -159,16 +159,9 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
     
     if ( expires_in != nil )
     {
-        if ( [expires_in isKindOfClass:[NSString class]] )
+        if ( [expires_in respondsToSelector:@selector(longValue)] )
         {
-            NSNumberFormatter *formatter = [[NSNumberFormatter alloc] init];
-            SAFE_ARC_AUTORELEASE(formatter);
-            
-            expires = [NSDate dateWithTimeIntervalSinceNow:[formatter numberFromString:expires_in].longValue];
-        }
-        else if ( [expires_in isKindOfClass:[NSNumber class]] )
-        {
-            expires = [NSDate dateWithTimeIntervalSinceNow:((NSNumber *)expires_in).longValue];
+            expires = [NSDate dateWithTimeIntervalSince1970:[expires_in longValue]];
         }
         else
         {

--- a/ADALiOS/ADALiOSTests/ADAuthenticationErrorTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationErrorTests.m
@@ -57,16 +57,6 @@
     XCTAssertThrows([[ADAuthenticationError alloc] initWithDomain:@"domain" code:123 userInfo:nil], @"Parameterless init should throw. At: '%s'", __PRETTY_FUNCTION__);
 }
 
--(void)testErrorFromArgumentNameNil
-{
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:@"val" argumentName:nil],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:@"" argumentName:nil],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:nil argumentName:nil],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
-}
-
 -(void)testErrorFromArgumentNil
 {
     NSString* parameter = @"parameter123456 %@";
@@ -91,16 +81,6 @@
     ADAssertLogsContain(TEST_LOG_INFO, "argument");
     ADAssertLogsContainValue(TEST_LOG_INFO, parameter);
     ADAssertLogsContainValue(TEST_LOG_INFO, parameterValue);
-}
-
--(void)testErrorFromUnauthorizedResponseBadDetails
-{
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromUnauthorizedResponse:AD_ERROR_MISSING_AUTHENTICATE_HEADER errorDetails:nil],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromUnauthorizedResponse:AD_ERROR_MISSING_AUTHENTICATE_HEADER errorDetails:@""],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
-    XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromUnauthorizedResponse:AD_ERROR_MISSING_AUTHENTICATE_HEADER errorDetails:@" \t"],
-                                 NSException, NSInvalidArgumentException, "Nil argument name should throw.");
 }
 
 -(void)testErrorFromUnauthorizedResponseNormal

--- a/ADALiOS/ADALiOSTests/ADAuthenticationResultTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationResultTests.m
@@ -128,4 +128,32 @@
     [self verifyErrorResult:resultFromEmptyAccessToken errorCode:AD_ERROR_UNEXPECTED];
 }
 
+- (void)testBrokerResponse
+{
+    // Not a complete IDToken, but enough to get past the parser. If you're seeing this test fail and have recently
+    // changed the idtoken code then this might have to be tweaked.
+    NSString* idtokenJSON = @"{\"typ\":\"JWT\",\"aud\":\"c3c7f5e5-7153-44d4-90e6-329686d48d76\",\"iss\":\"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048/\",\"iat\":1387224169,\"nbf\":1387224169,\"exp\":1387227769,\"ver\":\"1.0\",\"tid\":\"6fd1f5cd-a94c-4335-889b-6c598e6d8048\",\"oid\":\"53c6acf2-2742-4538-918d-e78257ec8516\",\"upn\":\"myfakeuser@contoso.com\",\"unique_name\":\"myfakeuser@contoso.com\",\"sub\":\"0DxnAlLi12IvGL_dG3dDMk3zp6AQHnjgogyim5AWpSc\",\"family_name\":\"User\",\"given_name\":\"Fake\"}";
+    
+    NSDictionary* response = @{
+                               @"access_token" : @"MyFakeAccessToken",
+                               @"refresh_token" : @"MyFakeRefreshToken",
+                               @"resource" : @"MyFakeResource",
+                               @"expires_on" : @"1444166530.336707",
+                               @"client_id" : @"27AD83C9-FC05-4A6C-AF01-36EDA42ED18F",
+                               @"correlation_id" : @"5EF4B8D0-A734-441B-887D-FBB8257C0784",
+                               @"id_token" : [idtokenJSON adBase64UrlEncode],
+                               @"user_id" : @"myfakeuser@contoso.com"
+                               };
+    ADAuthenticationResult* result = [ADAuthenticationResult resultFromBrokerResponse:response];
+    XCTAssertNotNil(result);
+    XCTAssertNotNil(result.tokenCacheStoreItem);
+    XCTAssertNotNil(result.tokenCacheStoreItem.expiresOn);
+    XCTAssertEqual(result.tokenCacheStoreItem.expiresOn.timeIntervalSince1970, 1444166530.336707);
+    XCTAssertEqualObjects(result.tokenCacheStoreItem.accessToken, @"MyFakeAccessToken");
+    XCTAssertEqualObjects(result.tokenCacheStoreItem.refreshToken, @"MyFakeRefreshToken");
+    XCTAssertEqualObjects(result.tokenCacheStoreItem.resource, @"MyFakeResource");
+    XCTAssertEqualObjects(result.tokenCacheStoreItem.clientId, @"27AD83C9-FC05-4A6C-AF01-36EDA42ED18F");
+    XCTAssertEqualObjects(result.tokenCacheStoreItem.userInformation.userId, @"myfakeuser@contoso.com");
+}
+
 @end


### PR DESCRIPTION
Fix expiration date parsing on osx universal
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/AzureAD/azure-activedirectory-library-for-objc/pull/404?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/404'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>