### PR TITLE
Create an internal ADLogger header.

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -233,6 +233,7 @@
 		8BFEF065182DA57800122C0C /* ADALiOSBundle-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ADALiOSBundle-Info.plist"; sourceTree = "<group>"; };
 		8BFEF067182DA57800122C0C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8BFEF069182DA57800122C0C /* ADALiOSBundle-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALiOSBundle-Prefix.pch"; sourceTree = "<group>"; };
+		9434C3361BF6B72E0095E122 /* ADLogger+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADLogger+Internal.h"; sourceTree = "<group>"; };
 		94351A9E1B3F67FB00CD5F5E /* NSUUID+ADExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSUUID+ADExtensions.h"; sourceTree = "<group>"; };
 		94351A9F1B3F67FB00CD5F5E /* NSUUID+ADExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSUUID+ADExtensions.m"; sourceTree = "<group>"; };
 		949B3A9A1B3DEAAD00381438 /* ADAuthenticationRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationRequest.h; sourceTree = "<group>"; };
@@ -402,6 +403,7 @@
 				8B611400186E517D007759C2 /* ADInstanceDiscovery.m */,
 				8B92DB6E181B2335004AAB0E /* ADLogger.h */,
 				8B92DB6F181B2335004AAB0E /* ADLogger.m */,
+				9434C3361BF6B72E0095E122 /* ADLogger+Internal.h */,
 				8B7E6FC61856A1E8000DC3C8 /* ADOAuth2Constants.h */,
 				8B7E6FC71856A1E8000DC3C8 /* ADOAuth2Constants.m */,
 				8B59894C1810BEAC00744AEE /* ADTokenCacheStoreItem.h */,

--- a/ADALiOS/ADALiOS/ADALiOS.h
+++ b/ADALiOS/ADALiOS/ADALiOS.h
@@ -29,7 +29,7 @@
 #define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
 #define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
 
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 #import "ADAuthenticationError.h"
 #import "NSString+ADHelperMethods.h"

--- a/ADALiOS/ADALiOS/ADBrokerKeyHelper.m
+++ b/ADALiOS/ADALiOS/ADBrokerKeyHelper.m
@@ -23,7 +23,7 @@
 #import "ADKeyChainHelper.h"
 #import <CommonCrypto/CommonCryptor.h>
 #import <Security/Security.h>
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 
 @implementation ADBrokerKeyHelper
 

--- a/ADALiOS/ADALiOS/ADJwtHelper.m
+++ b/ADALiOS/ADALiOS/ADJwtHelper.m
@@ -17,7 +17,7 @@
 // governing permissions and limitations under the License.
 
 #import "ADJwtHelper.h"
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 #import "NSString+ADHelperMethods.h"
 #import <CommonCrypto/CommonDigest.h>

--- a/ADALiOS/ADALiOS/ADLogger+Internal.h
+++ b/ADALiOS/ADALiOS/ADLogger+Internal.h
@@ -1,0 +1,93 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import "ADLogger.h"
+
+//A simple macro for single-line logging:
+#define AD_LOG(_level, _msg, _code, _info) [ADLogger log:_level message:_msg errorCode:_code info:_info]
+
+#define FIRST_ARG(ARG,...) ARG
+
+//Allows formatting, e.g. AD_LOG_FORMAT(ADAL_LOG_LEVEL_INFO, "Something", "Check this: %@ and this: %@", this1, this2)
+//If we make this a method, we will lose the warning when the string formatting parameters do not match the actual parameters.
+#define AD_LOG_F(_level, _msg, _code, _fmt, ...) [ADLogger log:_level message:_msg errorCode:_code format:_fmt, ##__VA_ARGS__ ]
+
+#define AD_LOG_ERROR(_message, _code, _info)    AD_LOG(ADAL_LOG_LEVEL_ERROR, _message, _code, _info)
+#define AD_LOG_WARN(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_WARN, _message, AD_ERROR_SUCCEEDED, _info)
+#define AD_LOG_INFO(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_INFO, _message, AD_ERROR_SUCCEEDED, _info)
+#define AD_LOG_VERBOSE(_message, _info)         AD_LOG(ADAL_LOG_LEVEL_VERBOSE, _message, AD_ERROR_SUCCEEDED, _info)
+
+#define AD_LOG_ERROR_F(_msg, _code, _fmt, ...)        AD_LOG_F(ADAL_LOG_LEVEL_ERROR, _msg, _code, _fmt, ##__VA_ARGS__)
+#define AD_LOG_WARN_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_WARN, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
+#define AD_LOG_INFO_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_INFO, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
+#define AD_LOG_VERBOSE_F(_msg, _fmt, ...)             AD_LOG_F(ADAL_LOG_LEVEL_VERBOSE, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
+
+#ifndef DebugLog
+#ifdef DEBUG
+#   define DebugLog(fmt, ...) NSLog((@"%s[%d][%@] " fmt), __PRETTY_FUNCTION__, __LINE__, [[NSThread currentThread] isEqual:[NSThread mainThread]] ? @"main" : @"work", ##__VA_ARGS__);
+#else
+#   define DebugLog(...)
+#endif
+#endif
+
+@interface ADLogger (Internal)
+
+/*! Returns diagnostic trace data to be sent to the Auzure Active Directory servers. */
++ (NSDictionary*)adalId;
+
+/*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
+ the actual contents, but still want to log something that can be correlated. */
++ (NSString*)getHash:(NSString*)input;
+
++ (NSString*)getAdalVersion;
+
++ (NSString*)getCPUInfo;
+
+/*! Returns previously set callback call or nil, if the user has not set such callback. */
++ (LogCallback)getLogCallBack;
+
+/*! Main logging function. Macros like ADAL_LOG_ERROR are provided on top for convenience
+ @param logLevel: The applicable priority of the logged message. Use AD_LOG_LEVEL_NO_LOG to disable all logging.
+ @param message: Short text defining the operation/condition.
+ @param additionalInformation: Full details. May contain parameter names, stack traces, etc. May be nil.
+ @param errorCode: if an explicit error has occurred, this code will contain its code.
+ */
++ (void)log:(ADAL_LOG_LEVEL)logLevel
+    message:(NSString*)message
+  errorCode:(NSInteger)errorCode
+       info:(NSString*)additionalInformation;
+
+/*! Convience logging fucntion. Allows the creation of additionalInformation strings using format strings. */
++ (void)log:(ADAL_LOG_LEVEL)level
+    message:(NSString*)message
+  errorCode:(NSInteger)code
+     format:(NSString*)format, ... __attribute__((format(__NSString__, 4, 5)));
+
+/*! Logs obtaining of a token. The method does not log the actual token, only its hash.
+ @param token: the token to log.
+ @param tokenType: "access token", "refresh token", "multi-resource refresh token"
+ @param expiresOn: the time when an access token will stop to be valid. Nil for refresh token types.
+ @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
+ This parameter can be nil.
+ */
++ (void)logToken:(NSString*)token
+       tokenType:(NSString*)tokenType
+       expiresOn:(NSDate*)expiresOn
+   correlationId:(NSUUID*)correlationId;
+
+@end

--- a/ADALiOS/ADALiOS/ADLogger.h
+++ b/ADALiOS/ADALiOS/ADLogger.h
@@ -34,39 +34,10 @@ typedef enum
 /*! Sets the logging level for the internal logging messages. Messages with
  priority lower than the specified level will be ignored. 
  @param logLevel: desired logging level. The higher the number, the more logging information is included. */
-+(void) setLevel: (ADAL_LOG_LEVEL)logLevel;
++ (void)setLevel:(ADAL_LOG_LEVEL)logLevel;
 
 /*! Returns the current log level. See setLevel for details */
-+(ADAL_LOG_LEVEL) getLevel;
-
-/*! Main logging function. Macros like ADAL_LOG_ERROR are provided on top for convenience
- @param logLevel: The applicable priority of the logged message. Use AD_LOG_LEVEL_NO_LOG to disable all logging.
- @param message: Short text defining the operation/condition.
- @param additionalInformation: Full details. May contain parameter names, stack traces, etc. May be nil.
- @param errorCode: if an explicit error has occurred, this code will contain its code.
- */
-+(void) log:(ADAL_LOG_LEVEL)logLevel
-    message:(NSString*)message
-  errorCode:(NSInteger)errorCode
-       info:(NSString*)additionalInformation;
-
-/*! Convience logging fucntion. Allows the creation of additionalInformation strings using format strings. */
-+ (void)log:(ADAL_LOG_LEVEL)level
-    message:(NSString*)message
-  errorCode:(NSInteger)code
-     format:(NSString*)format, ... __attribute__((format(__NSString__, 4, 5)));
-
-/*! Logs obtaining of a token. The method does not log the actual token, only its hash.
- @param token: the token to log.
- @param tokenType: "access token", "refresh token", "multi-resource refresh token"
- @param expiresOn: the time when an access token will stop to be valid. Nil for refresh token types.
- @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
- This parameter can be nil.
-*/
-+(void) logToken: (NSString*) token
-       tokenType: (NSString*) tokenType
-       expiresOn: (NSDate*) expiresOn
-   correlationId: (NSUUID*) correlationId;
++ (ADAL_LOG_LEVEL)getLevel;
 
 
 //The block declaration. Needs to be weak to ensure that the pointer does not hold static reference
@@ -80,59 +51,20 @@ typedef void (^LogCallback)(ADAL_LOG_LEVEL logLevel,
  @param callback: The block to be executed when suitable messages are logged. By default, when
  callback is set, messages will contingue to be logged through NSLog. Such logging can be disabled
  through setNSLogging. */
-+(void) setLogCallBack: (LogCallback) callback;
-
-/*! Returns previously set callback call or nil, if the user has not set such callback. */
-+(LogCallback) getLogCallBack;
++ (void)setLogCallBack:(LogCallback)callback;
 
 /*! By default, logging sends messages through standard NSLog. This function allows to disable this
  behavior. Disabling is useful if faster logging is implemented through the callback. */
-+(void) setNSLogging: (BOOL) nslogging;
++ (void)setNSLogging:(BOOL)nslogging;
 
 /*! YES if the messages are logged through NSLog.*/
-+(BOOL) getNSLogging;
-
-/*! Returns diagnostic trace data to be sent to the Auzure Active Directory servers. */
-+(NSDictionary*) adalId;
-
-/*! Calculates a hash of the passed string. Useful for logging tokens, where we do not log
- the actual contents, but still want to log something that can be correlated. */
-+(NSString*) getHash: (NSString*) input;
++ (BOOL)getNSLogging;
 
 /*! Sets correlation id to be used in the requests sent to server. */
-+(void) setCorrelationId: (NSUUID*) correlationId;
++ (void)setCorrelationId:(NSUUID*)correlationId;
 
 /*! Gets correlation Id. */
-+(NSUUID*) getCorrelationId;
-
-+(NSString*) getAdalVersion;
++ (NSUUID*)getCorrelationId;
 
 @end
-
-//A simple macro for single-line logging:
-#define AD_LOG(_level, _msg, _code, _info) [ADLogger log:_level message:_msg errorCode:_code info:_info]
-
-#define FIRST_ARG(ARG,...) ARG
-
-//Allows formatting, e.g. AD_LOG_FORMAT(ADAL_LOG_LEVEL_INFO, "Something", "Check this: %@ and this: %@", this1, this2)
-//If we make this a method, we will lose the warning when the string formatting parameters do not match the actual parameters.
-#define AD_LOG_F(_level, _msg, _code, _fmt, ...) [ADLogger log:_level message:_msg errorCode:_code format:_fmt, ##__VA_ARGS__ ]
-
-#define AD_LOG_ERROR(_message, _code, _info)    AD_LOG(ADAL_LOG_LEVEL_ERROR, _message, _code, _info)
-#define AD_LOG_WARN(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_WARN, _message, AD_ERROR_SUCCEEDED, _info)
-#define AD_LOG_INFO(_message, _info)            AD_LOG(ADAL_LOG_LEVEL_INFO, _message, AD_ERROR_SUCCEEDED, _info)
-#define AD_LOG_VERBOSE(_message, _info)         AD_LOG(ADAL_LOG_LEVEL_VERBOSE, _message, AD_ERROR_SUCCEEDED, _info)
-
-#define AD_LOG_ERROR_F(_msg, _code, _fmt, ...)        AD_LOG_F(ADAL_LOG_LEVEL_ERROR, _msg, _code, _fmt, ##__VA_ARGS__)
-#define AD_LOG_WARN_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_WARN, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
-#define AD_LOG_INFO_F(_msg, _fmt, ...)                AD_LOG_F(ADAL_LOG_LEVEL_INFO, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
-#define AD_LOG_VERBOSE_F(_msg, _fmt, ...)             AD_LOG_F(ADAL_LOG_LEVEL_VERBOSE, _msg, AD_ERROR_SUCCEEDED, _fmt, ##__VA_ARGS__)
-
-#ifndef DebugLog
-#ifdef DEBUG
-#   define DebugLog(fmt, ...) NSLog((@"%s[%d][%@] " fmt), __PRETTY_FUNCTION__, __LINE__, [[NSThread currentThread] isEqual:[NSThread mainThread]] ? @"main" : @"work", ##__VA_ARGS__);
-#else
-#   define DebugLog(...)
-#endif
-#endif
 

--- a/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
+++ b/ADALiOS/ADALiOS/ADPkeyAuthHelper.m
@@ -22,7 +22,7 @@
 #import "ADRegistrationInformation.h"
 #import "NSString+ADHelperMethods.h"
 #import "ADWorkPlaceJoin.h"
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 #import "ADJwtHelper.h"
 

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
@@ -21,7 +21,7 @@
 #import "ADAuthenticationError.h"
 #import "ADOAuth2Constants.h"
 #import "ADUserInformation.h"
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "NSString+ADHelperMethods.h"
 
 @implementation ADTokenCacheStoreItem (Internal)

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -18,7 +18,7 @@
 
 
 #import "ADUserIdentifier.h"
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 #import "ADUserInformation.h"
 

--- a/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
+++ b/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
@@ -19,7 +19,7 @@
 #import "ADWorkPlaceJoinUtil.h"
 #import "ADRegistrationInformation.h"
 #import "ADWorkPlaceJoinConstants.h"
-#import "ADLogger.h"
+#import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 
 @implementation ADWorkPlaceJoinUtil


### PR DESCRIPTION
This was needed to be able to remove some warnings in tokenbroker without adding more public APIs.