### PR TITLE
Make ADCredentialsType a per-context setting

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationContext.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.h
@@ -86,6 +86,26 @@ typedef enum
     AD_FORCE_PROMPT,
 } ADPromptBehavior;
 
+/*!
+ Controls where would the credentials dialog reside
+ */
+typedef enum
+{
+    /*!
+     The SDK determines automatically the most suitable option, optimized for user experience.
+     E.g. it may invoke another application for a single sign on, if such application is present.
+     This is the default option.
+     */
+    AD_CREDENTIALS_AUTO,
+    
+    /*!
+     The SDK will present an embedded dialog within the application. It will not invoke external
+     application or browser.
+     */
+    AD_CREDENTIALS_EMBEDDED,
+    
+} ADCredentialsType;
+
 @class ADAuthenticationResult;
 
 /*! The completion block declaration. */
@@ -179,6 +199,9 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
 /*! Unique identifier passed to the server and returned back with errors. Useful during investigations to correlate the
  requests and the responses from the server. If nil, a new UUID is generated on every request. */
 @property (strong, getter=getCorrelationId, setter=setCorrelationId:) NSUUID* correlationId;
+
+/*! See the ADCredentialsType enumeration definition for details */
+@property ADCredentialsType credentialsType;
 
 /*! The parent view controller for the authentication view controller UI. This property will be used only if
  a custom web view is NOT specified. */

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -135,7 +135,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
         _authority = extractedAuthority;
         _validateAuthority = bValidate;
         _tokenCacheStore = tokenCache;
-        _credentialsType = AD_CREDENTIALS_AUTO;
+        _credentialsType = AD_CREDENTIALS_EMBEDDED;
     }
     return self;
 }

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -135,6 +135,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
         _authority = extractedAuthority;
         _validateAuthority = bValidate;
         _tokenCacheStore = tokenCache;
+        _credentialsType = AD_CREDENTIALS_AUTO;
     }
     return self;
 }

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -203,7 +203,7 @@
 
 #if !AD_BROKER
     //call the broker.
-    if([ADAuthenticationRequest canUseBroker])
+    if([self canUseBroker])
     {
         [self callBroker:completionBlock];
         return;

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.h
@@ -19,9 +19,9 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
 @interface ADAuthenticationRequest (Broker)
 
-+ (BOOL)canUseBroker;
-
 + (void)internalHandleBrokerResponse:(NSURL*)response;
+
+- (BOOL)canUseBroker;
 
 - (void)callBroker:(ADAuthenticationCallback)completionBlock;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -29,12 +29,6 @@
 
 @implementation ADAuthenticationRequest (Broker)
 
-+ (BOOL)canUseBroker
-{
-    return [[ADAuthenticationSettings sharedInstance] credentialsType] == AD_CREDENTIALS_AUTO &&
-    [[UIApplication sharedApplication] canOpenURL:[[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://broker", brokerScheme]]];
-}
-
 + (BOOL)respondsToUrl:(NSString*)url
 {
     BOOL schemeIsInPlist = NO; // find out if the sceme is in the plist file.
@@ -143,6 +137,12 @@
     
     completionBlock(result);
     [ADBrokerNotificationManager sharedInstance].callbackForBroker = nil;
+}
+
+- (BOOL)canUseBroker
+{
+    return _context.credentialsType == AD_CREDENTIALS_AUTO &&
+    [[UIApplication sharedApplication] canOpenURL:[[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://broker", brokerScheme]]];
 }
 
 - (void)callBroker:(ADAuthenticationCallback)completionBlock

--- a/ADALiOS/ADALiOS/ADAuthenticationSettings.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationSettings.h
@@ -18,26 +18,6 @@
 #import <Foundation/Foundation.h>
 
 @protocol ADTokenCacheStoring;
-/*!
- Controls where would the credentials dialog reside
- */
-typedef enum
-{
-    /*!
-     The SDK determines automatically the most suitable option, optimized for user experience.
-     E.g. it may invoke another application for a single sign on, if such application is present.
-     This is the default option.
-     */
-    AD_CREDENTIALS_AUTO,
-    
-    /*!
-     The SDK will present an embedded dialog within the application. It will not invoke external
-     application or browser.
-     */
-    AD_CREDENTIALS_EMBEDDED,
-    
-} ADCredentialsType;
-
 /*! The class stores global settings for the ADAL library. It is a singleton class
  and the alloc, init and new should not be called directly. The "sharedInstance" selector
  should be used instead to provide the settings instance. The class is not thread-safe.
@@ -46,9 +26,6 @@ typedef enum
 
 /*! The static instance of the singleton settings class*/
 +(ADAuthenticationSettings*) sharedInstance;
-
-/*! See the ADCredentialsType enumeration definition for details */
-@property ADCredentialsType credentialsType;
 
 /*! The timeout used for any of the web requests. Specified in seconds. */
 @property int requestTimeOut;

--- a/ADALiOS/ADALiOS/ADAuthenticationSettings.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationSettings.m
@@ -30,7 +30,6 @@
     if (self)
     {
         //Initialize the defaults here:
-        self.credentialsType = AD_CREDENTIALS_AUTO;
         self.requestTimeOut = 300;//in seconds.
         self.expirationBuffer = 300;//in seconds, ensures catching of clock differences between the server and the device
         self.enableFullScreen = YES;

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -63,7 +63,6 @@ const int sAsyncContextTimeout = 10;
     [self adTestBegin:ADAL_LOG_LEVEL_ERROR];//Majority of the tests rely on errors
     mAuthority = @"https://login.windows.net/msopentechbv.onmicrosoft.com";
     mDefaultTokenCache = (ADKeychainTokenCacheStore*)([ADAuthenticationSettings sharedInstance].defaultTokenCacheStore);
-    [ADAuthenticationSettings sharedInstance].credentialsType = AD_CREDENTIALS_EMBEDDED;
     XCTAssertNotNil(mDefaultTokenCache);
     XCTAssertTrue([mDefaultTokenCache isKindOfClass:[ADKeychainTokenCacheStore class]]);
     mRedirectURL = [NSURL URLWithString:@"http://todolistclient/"];
@@ -87,6 +86,8 @@ const int sAsyncContextTimeout = 10;
     [testContext->mExpectedRequest2 setObject:OAUTH2_REFRESH_TOKEN forKey:OAUTH2_GRANT_TYPE];
     [testContext->mExpectedRequest2 setObject:mResource forKey:OAUTH2_RESOURCE];
     [testContext->mExpectedRequest2 setObject:mClientId forKey:OAUTH2_CLIENT_ID];
+    
+    testContext.credentialsType = AD_CREDENTIALS_EMBEDDED;
     
     //Clear the cache between the tests:
     [mDefaultTokenCache removeAllWithError:&error];


### PR DESCRIPTION
Moved ADCredentialsType from ADAuthenticationSettings to ADAuthenticationContext to make it a per-context setting. #417 