### PR TITLE
broker-aware adal should not call broker if authority validation is turned off 

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -142,6 +142,7 @@
 - (BOOL)canUseBroker
 {
     return _context.credentialsType == AD_CREDENTIALS_AUTO &&
+     _context.validateAuthority == YES &&
     [[UIApplication sharedApplication] canOpenURL:[[NSURL alloc] initWithString:[NSString stringWithFormat:@"%@://broker", brokerScheme]]];
 }
 


### PR DESCRIPTION
A small change to fix #397. Added the following condition before calling the broker: the authority validation must be on. See #397 for more detail.