### PR TITLE
Issues/hotfix broker becomeactive delay

### DIFF
--- a/ADALiOS/ADALiOS/ADALiOS.h
+++ b/ADALiOS/ADALiOS/ADALiOS.h
@@ -20,11 +20,11 @@
 //version in static define until we identify a better place:
 #define ADAL_VER_HIGH       2
 #define ADAL_VER_LOW        0
-#define ADAL_VER_PATCH      1
+#define ADAL_VER_PATCH      2
 
 #define STR_ADAL_VER_HIGH   "2"
 #define STR_ADAL_VER_LOW    "0"
-#define STR_ADAL_VER_PATCH  "1"
+#define STR_ADAL_VER_PATCH  "2"
 
 #define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
 #define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -62,7 +62,7 @@
 
 + (void)internalHandleBrokerResponse:(NSURL *)response
 {
-    ADAuthenticationCallback completionBlock = [ADBrokerNotificationManager sharedInstance].callbackForBroker;
+    ADAuthenticationCallback completionBlock = [ADBrokerNotificationManager sharedInstance].copyAndClearCallback;
     if (!completionBlock)
     {
         return;
@@ -142,7 +142,6 @@
     }
     
     completionBlock(result);
-    [ADBrokerNotificationManager sharedInstance].callbackForBroker = nil;
 }
 
 - (void)callBroker:(ADAuthenticationCallback)completionBlock

--- a/ADALiOS/ADALiOS/ADBrokerNotificationManager.h
+++ b/ADALiOS/ADALiOS/ADBrokerNotificationManager.h
@@ -21,12 +21,10 @@
 
 @interface ADBrokerNotificationManager : NSObject
 
-@property (copy) ADAuthenticationCallback callbackForBroker;
++ (ADBrokerNotificationManager*)sharedInstance;
 
-+(ADBrokerNotificationManager*)sharedInstance;
+- (void)enableOnActiveNotification:(ADAuthenticationCallback)callback;
 
--(void) enableOnActiveNotification:(ADAuthenticationCallback) callback;
-
--(void) runCompletionBlock:(ADAuthenticationResult*) result;
+- (ADAuthenticationCallback)copyAndClearCallback;
 
 @end


### PR DESCRIPTION
Add a 1 second delay to UIApplicationDidBecomeActive clean up.
Fix synchronization semantics around the broker callback