### PR TITLE
Improved Keychain Logging to make logs concise and helpful.

### DIFF
--- a/ADALiOS/ADALiOS/ADKeyChainHelper.m
+++ b/ADALiOS/ADALiOS/ADKeyChainHelper.m
@@ -183,7 +183,6 @@ extern NSString* const sKeyChainlog;
             //Success:
             return (__bridge_transfer NSArray*)all;
         case errSecItemNotFound:
-            AD_LOG_VERBOSE_F(sKeyChainlog, nil, @"No cache items found.");
             return [NSArray new];//Empty one
         default:
         {


### PR DESCRIPTION
(Referring to #435) Keychain logging is now more concise and more reflecting the operation flow.
E.g., logs of keychain will be something like:
Found x tokens for user y in keychain.
Found AT/RT/MRRT for resource id + client id + authority
Found expired AT for resource id + client id + authority
No AT/RT/MRRT was found for resource id + client id  + authority.