### PR TITLE
Changed to access framework bundle for NSLocalizedString

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		4CAE461D18F75F0900659400 /* ADKeyChainHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 4CAE461C18F75F0900659400 /* ADKeyChainHelper.m */; };
 		6071B5E41C14C0B0006F6CC2 /* ADTestURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */; };
+		609EC5B71C3DAF9D00603EEF /* ADALFrameworkUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 609EC5B61C3DAF9D00603EEF /* ADALFrameworkUtils.m */; };
 		8B0965AE17F25770002BDFB8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B0965AD17F25770002BDFB8 /* Foundation.framework */; };
 		8B0965B517F25770002BDFB8 /* ADALiOS.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0965B417F25770002BDFB8 /* ADALiOS.m */; };
 		8B0965BC17F25770002BDFB8 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B0965BB17F25770002BDFB8 /* XCTest.framework */; };
@@ -146,6 +147,8 @@
 		4CAE461C18F75F0900659400 /* ADKeyChainHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADKeyChainHelper.m; sourceTree = "<group>"; };
 		6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLConnection.h; sourceTree = "<group>"; };
 		6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLConnection.m; sourceTree = "<group>"; };
+		609EC5B51C3DAB3E00603EEF /* ADALFrameworkUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADALFrameworkUtils.h; sourceTree = "<group>"; };
+		609EC5B61C3DAF9D00603EEF /* ADALFrameworkUtils.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADALFrameworkUtils.m; sourceTree = "<group>"; };
 		8B0965AA17F25770002BDFB8 /* libADALiOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libADALiOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B0965AD17F25770002BDFB8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8B0965B117F25770002BDFB8 /* ADALiOS-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALiOS-Prefix.pch"; sourceTree = "<group>"; };
@@ -440,6 +443,8 @@
 				D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */,
 				94351A9E1B3F67FB00CD5F5E /* NSUUID+ADExtensions.h */,
 				94351A9F1B3F67FB00CD5F5E /* NSUUID+ADExtensions.m */,
+				609EC5B51C3DAB3E00603EEF /* ADALFrameworkUtils.h */,
+				609EC5B61C3DAF9D00603EEF /* ADALFrameworkUtils.m */,
 			);
 			path = ADALiOS;
 			sourceTree = "<group>";
@@ -764,6 +769,7 @@
 				9722232F19A2C9F900092E85 /* ADWorkPlaceJoin.m in Sources */,
 				9727D4D31A8753C300774236 /* ADJwtHelper.m in Sources */,
 				8BB8345F18074B74007F9F0D /* ADAuthenticationResult.m in Sources */,
+				609EC5B71C3DAF9D00603EEF /* ADALFrameworkUtils.m in Sources */,
 				97345B92199160BD0044B1A6 /* ADPkeyAuthHelper.m in Sources */,
 				97A5224C1A1A75B2001D77CE /* ADHelpers.m in Sources */,
 				D6E43A5E1B02D955000F5BE2 /* ADBrokerKeyHelper.m in Sources */,

--- a/ADALiOS/ADALiOS/ADALFrameworkUtils.h
+++ b/ADALiOS/ADALiOS/ADALFrameworkUtils.h
@@ -1,0 +1,25 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.#in
+
+@interface ADALFrameworkUtils : NSObject
+
++ (NSString *)resourcePath;
++ (void)setResourcePath:(NSString *)resourcePath;
++ (NSBundle *)frameworkBundle;
+
+@end

--- a/ADALiOS/ADALiOS/ADALFrameworkUtils.m
+++ b/ADALiOS/ADALiOS/ADALFrameworkUtils.m
@@ -1,0 +1,73 @@
+// Copyright © Microsoft Open Technologies, Inc.
+//
+// All Rights Reserved
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// THIS CODE IS PROVIDED *AS IS* BASIS, WITHOUT WARRANTIES OR CONDITIONS
+// OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION
+// ANY IMPLIED WARRANTIES OR CONDITIONS OF TITLE, FITNESS FOR A
+// PARTICULAR PURPOSE, MERCHANTABILITY OR NON-INFRINGEMENT.
+//
+// See the Apache License, Version 2.0 for the specific language
+// governing permissions and limitations under the License.
+
+#import "ADALFrameworkUtils.h"
+#import "ADALiOS.h"
+
+@implementation ADALFrameworkUtils
+
+static NSString *_resourcePath = nil;
+
++ (NSString *)resourcePath
+{
+    return _resourcePath;
+}
+
++ (void)setResourcePath:(NSString *)resourcePath
+{
+    _resourcePath = resourcePath;
+}
+
+// Retrive the bundle containing the resources for the library. May return nil, if the bundle
+// cannot be loaded.
++ (NSBundle *)frameworkBundle
+{
+    static NSBundle       *bundle     = nil;
+    static dispatch_once_t predicate;
+    
+    @synchronized(self)
+    {
+        dispatch_once( &predicate,
+                      ^{
+                          
+                          NSString* mainBundlePath      = [[NSBundle mainBundle] resourcePath];
+                          AD_LOG_VERBOSE_F(@"Resources Loading", nil, @"Attempting to load resources from: %@", mainBundlePath);
+                          NSString* frameworkBundlePath = nil;
+                          
+                          if ( _resourcePath != nil )
+                          {
+                              frameworkBundlePath = [[mainBundlePath stringByAppendingPathComponent:_resourcePath] stringByAppendingPathComponent:@"ADALiOS.bundle"];
+                          }
+                          else
+                          {
+                              frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"ADALiOS.bundle"];
+                          }
+                          
+                          bundle = [NSBundle bundleWithPath:frameworkBundlePath];
+                          if (!bundle)
+                          {
+                              AD_LOG_INFO_F(@"Resource Loading", nil, @"Failed to load framework bundle. Application main bundle will be attempted.");
+                          }
+                      });
+    }
+    
+    return bundle;
+}
+
+
+@end

--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.h
@@ -25,6 +25,7 @@ typedef void (^ADBrokerCallback) (ADAuthenticationError* error, NSURL*);
 
 + (NSString *)resourcePath;
 + (void)setResourcePath:(NSString *)resourcePath;
++ (NSBundle *)frameworkBundle;
 
 + (ADAuthenticationBroker *)sharedInstance;
 

--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.h
@@ -23,10 +23,6 @@
 typedef void (^ADBrokerCallback) (ADAuthenticationError* error, NSURL*);
 @interface ADAuthenticationBroker : NSObject
 
-+ (NSString *)resourcePath;
-+ (void)setResourcePath:(NSString *)resourcePath;
-+ (NSBundle *)frameworkBundle;
-
 + (ADAuthenticationBroker *)sharedInstance;
 
 // Start the authentication process. Note that there are two different behaviours here dependent on whether the caller has provided

--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -27,6 +27,7 @@
 #import "ADAuthenticationSettings.h"
 #import "ADNTLMHandler.h"
 #import "ADCustomHeaderHandler.h"
+#import "ADALFrameworkUtils.h"
 
 NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a current ViewController";
 NSString *const AD_FAILED_NO_RESOURCES  = @"The required resource bundle could not be loaded. Please read the ADALiOS readme on how to build your application with ADAL provided authentication UI resources.";
@@ -112,54 +113,6 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
 
 #pragma mark - Private Methods
 
-static NSString *_resourcePath = nil;
-
-+ (NSString *)resourcePath
-{
-    return _resourcePath;
-}
-
-+ (void)setResourcePath:(NSString *)resourcePath
-{
-    _resourcePath = resourcePath;
-}
-
-// Retrive the bundle containing the resources for the library. May return nil, if the bundle
-// cannot be loaded.
-+ (NSBundle *)frameworkBundle
-{
-    static NSBundle       *bundle     = nil;
-    static dispatch_once_t predicate;
-    
-    @synchronized(self)
-    {
-        dispatch_once( &predicate,
-                      ^{
-
-                          NSString* mainBundlePath      = [[NSBundle mainBundle] resourcePath];
-                          AD_LOG_VERBOSE_F(@"Resources Loading", nil, @"Attempting to load resources from: %@", mainBundlePath);
-                          NSString* frameworkBundlePath = nil;
-                          
-                          if ( _resourcePath != nil )
-                          {
-                              frameworkBundlePath = [[mainBundlePath stringByAppendingPathComponent:_resourcePath] stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          else
-                          {
-                              frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          
-                          bundle = [NSBundle bundleWithPath:frameworkBundlePath];
-                          if (!bundle)
-                          {
-                              AD_LOG_INFO_F(@"Resource Loading", nil, @"Failed to load framework bundle. Application main bundle will be attempted.");
-                          }
-                      });
-    }
-    
-    return bundle;
-}
-
 +(NSString*) getStoryboardName
 {
     return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
@@ -172,7 +125,7 @@ static NSString *_resourcePath = nil;
 // Raises an error if both the library resources bundle and the application fail to locate resources.
 + (UIStoryboard *)storyboard: (ADAuthenticationError* __autoreleasing*) error
 {
-    NSBundle* bundle = [self frameworkBundle];//May be nil.
+    NSBundle* bundle = [ADALFrameworkUtils frameworkBundle];//May be nil.
     if (!bundle)
     {
         //The user did not use ADALiOS.bundle. The resources may be manually linked

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
@@ -122,7 +122,7 @@
     if (useAccessToken)
     {
         //Access token is good, just use it:
-        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:nil];
+        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
         ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheStoreItem:item multiResourceRefreshToken:NO];
         completionBlock(result);
         return;

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -117,7 +117,7 @@
     if (useAccessToken)
     {
         //Access token is good, just use it:
-        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:nil];
+        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
         ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheStoreItem:item multiResourceRefreshToken:NO];
         completionBlock(result);
         return;
@@ -296,7 +296,7 @@
                                    cacheItem:(ADTokenCacheStoreItem*)cacheItem
                              completionBlock:(ADAuthenticationCallback)completionBlock
 {
-    [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:nil];
+    [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:_correlationId];
     //Fill the data for the token refreshing:
     NSMutableDictionary *request_data = nil;
     

--- a/ADALiOS/ADALiOS/UIAlertView+Additions.m
+++ b/ADALiOS/ADALiOS/UIAlertView+Additions.m
@@ -1,4 +1,5 @@
 #import <objc/runtime.h>
+#import "ADAuthenticationBroker.h"
 
 @implementation UIAlertView (Additions)
 
@@ -8,14 +9,20 @@ static UIAlertView *alert;
 
 + (void)presentCredentialAlert:(void (^)(NSUInteger))handler {
     
-    alert = [[UIAlertView alloc] initWithTitle:NSLocalizedString(@"Enter your credentials", nil)
+    NSBundle* bundle = [ADAuthenticationBroker frameworkBundle];
+    if (!bundle)
+    {
+        bundle = [NSBundle mainBundle];
+    }
+    
+    alert = [[UIAlertView alloc] initWithTitle:NSLocalizedStringFromTableInBundle(@"Enter your credentials", nil, bundle, nil)
                                        message:nil
                                       delegate:nil
-                             cancelButtonTitle:NSLocalizedString(@"Cancel", nil)
+                             cancelButtonTitle:NSLocalizedStringFromTableInBundle(@"Cancel", nil, bundle, nil)
                              otherButtonTitles: nil];
     
     alert.alertViewStyle = UIAlertViewStyleLoginAndPasswordInput;
-    [alert addButtonWithTitle:NSLocalizedString(@"Login", nil)];
+    [alert addButtonWithTitle:NSLocalizedStringFromTableInBundle(@"Login", nil, bundle, nil)];
     [alert setDelegate:alert];
     
     if (handler)

--- a/ADALiOS/ADALiOS/UIAlertView+Additions.m
+++ b/ADALiOS/ADALiOS/UIAlertView+Additions.m
@@ -1,5 +1,6 @@
 #import <objc/runtime.h>
 #import "ADAuthenticationBroker.h"
+#import "ADALFrameworkUtils.h"
 
 @implementation UIAlertView (Additions)
 
@@ -9,7 +10,7 @@ static UIAlertView *alert;
 
 + (void)presentCredentialAlert:(void (^)(NSUInteger))handler {
     
-    NSBundle* bundle = [ADAuthenticationBroker frameworkBundle];
+    NSBundle* bundle = [ADALFrameworkUtils frameworkBundle];
     if (!bundle)
     {
         bundle = [NSBundle mainBundle];

--- a/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
+++ b/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
@@ -246,7 +246,6 @@
 				ORGANIZATIONNAME = MS;
 				TargetAttributes = {
 					8BA42AF517E3C150002D206E = {
-						DevelopmentTeam = UBF8T346G9;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;


### PR DESCRIPTION
The change is mainly for
1. Changed to access framework bundle for NSLocalizedString (for issue #380); 
2. Moved framework specific utils out of ADAuthenticationBroker to a new class "ADALFrameworkUtils" (for issue #448);

Besides, I also fixed the following:
2. Removed developer team property of test app (for issue #365); 
3. Fixed three places where correlation id is not properly passed as parameter.