### PR TITLE
We should not call -canOpenURL when checking redirect URI validity as…

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -31,27 +31,24 @@
 
 + (BOOL)respondsToUrl:(NSString*)url
 {
-    BOOL schemeIsInPlist = NO; // find out if the sceme is in the plist file.
-    NSBundle* mainBundle = [NSBundle mainBundle];
-    NSArray* cfBundleURLTypes = [mainBundle objectForInfoDictionaryKey:@"CFBundleURLTypes"];
-    if ([cfBundleURLTypes isKindOfClass:[NSArray class]] && [cfBundleURLTypes lastObject]) {
-        NSDictionary* cfBundleURLTypes0 = [cfBundleURLTypes objectAtIndex:0];
-        if ([cfBundleURLTypes0 isKindOfClass:[NSDictionary class]]) {
-            NSArray* cfBundleURLSchemes = [cfBundleURLTypes0 objectForKey:@"CFBundleURLSchemes"];
-            if ([cfBundleURLSchemes isKindOfClass:[NSArray class]]) {
-                for (NSString* scheme in cfBundleURLSchemes) {
-                    if ([scheme isKindOfClass:[NSString class]] && [url hasPrefix:scheme]) {
-                        schemeIsInPlist = YES;
-                        break;
-                    }
-                }
-            }
+    NSArray* urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
+    
+    NSString* scheme = [[NSURL URLWithString:url] scheme];
+    if (!scheme)
+    {
+        return NO;
+    }
+    
+    for (NSDictionary* urlRole in urlTypes)
+    {
+        NSArray* urlSchemes = [urlRole objectForKey:@"CFBundleURLSchemes"];
+        if ([urlSchemes containsObject:scheme])
+        {
+            return YES;
         }
     }
     
-    BOOL canOpenUrl = [[UIApplication sharedApplication] canOpenURL:[NSURL URLWithString: url]];
-    
-    return schemeIsInPlist && canOpenUrl;
+    return NO;
 }
 
 + (void)internalHandleBrokerResponse:(NSURL *)response


### PR DESCRIPTION
… that requires an app to put its own scheme on LSApplicationQuerySchemes, which strikes me as a bit much, if it's in the info.plist file that should be sufficient for proving that it's call-able.