### PR TITLE
Support for building pod as a framework

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -153,7 +153,13 @@ static NSString *_resourcePath = nil;
                           bundle = [NSBundle bundleWithPath:frameworkBundlePath];
                           if (!bundle)
                           {
-                              AD_LOG_INFO_F(@"Resource Loading", @"Failed to load framework bundle. Application main bundle will be attempted.");
+                              // If bundle can't be found try the framework in case pod was built as module
+                              bundle = [NSBundle bundleForClass:[ADAuthenticationBroker class]];
+                              
+                              if (!bundle)
+                              {
+                                  AD_LOG_INFO_F(@"Resource Loading", @"Failed to load framework bundle. Application main bundle will be attempted.");
+                              }
                           }
                       });
     }


### PR DESCRIPTION
Add support for accessing resources in bundle when pod is built as a framework.

When the cocoapod is built as a framework (`use_frameworks!`) the bundle path for resources changes. This patch finds the new path if its a framework. Can the CocoaPods version also be bumped so this will be pulled by OneDriveSDK?

Thanks.