### PR TITLE
Copy changes from #462 over to broker-dev.

### DIFF
--- a/ADALiOS/ADALiOS/ADALFrameworkUtils.m
+++ b/ADALiOS/ADALiOS/ADALFrameworkUtils.m
@@ -39,32 +39,33 @@ static NSString *_resourcePath = nil;
 {
     static NSBundle       *bundle     = nil;
     static dispatch_once_t predicate;
-    
-    @synchronized(self)
-    {
-        dispatch_once( &predicate,
-                      ^{
-                          
-                          NSString* mainBundlePath      = [[NSBundle mainBundle] resourcePath];
-                          AD_LOG_VERBOSE_F(@"Resources Loading", nil, @"Attempting to load resources from: %@", mainBundlePath);
-                          NSString* frameworkBundlePath = nil;
-                          
-                          if ( _resourcePath != nil )
-                          {
-                              frameworkBundlePath = [[mainBundlePath stringByAppendingPathComponent:_resourcePath] stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          else
-                          {
-                              frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"ADALiOS.bundle"];
-                          }
-                          
-                          bundle = [NSBundle bundleWithPath:frameworkBundlePath];
-                          if (!bundle)
-                          {
-                              AD_LOG_INFO_F(@"Resource Loading", nil, @"Failed to load framework bundle. Application main bundle will be attempted.");
-                          }
-                      });
-    }
+    dispatch_once( &predicate, ^{
+        
+        NSString* mainBundlePath      = [[NSBundle mainBundle] resourcePath];
+        AD_LOG_VERBOSE_F(@"Resources Loading", nil, @"Attempting to load resources from: %@", mainBundlePath);
+        NSString* frameworkBundlePath = nil;
+        
+        if ( _resourcePath != nil )
+        {
+            frameworkBundlePath = [[mainBundlePath stringByAppendingPathComponent:_resourcePath] stringByAppendingPathComponent:@"ADALiOS.bundle"];
+        }
+        else
+        {
+            frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:@"ADALiOS.bundle"];
+        }
+        
+        bundle = [NSBundle bundleWithPath:frameworkBundlePath];
+        if (bundle)
+        {
+            return;
+        }
+        
+        bundle = [NSBundle bundleForClass:[ADALFrameworkUtils class]];
+        if (!bundle)
+        {
+            AD_LOG_INFO_F(@"Resource Loading", nil, @"Failed to load framework bundle. Application main bundle will be attempted.");
+        }
+    });
     
     return bundle;
 }


### PR DESCRIPTION
From @nick-m42's PR (#462)

> Add support for accessing resources in bundle when pod is built as a framework.
>
> When the cocoapod is built as a framework (use_frameworks!) the bundle path for resources changes. This patch finds the new path if its a framework.
