### PR TITLE
Issues/broker dev/keychain store tomb stone

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext+TokenCaching.h
@@ -23,17 +23,21 @@
 - (ADTokenCacheStoreItem*)findCacheItemWithKey:(ADTokenCacheStoreKey*) key
                                         userId:(ADUserIdentifier*)userId
                                 useAccessToken:(BOOL*) useAccessToken
+                          requestCorrelationId:(NSUUID*) requestCorrelationId
                                          error:(ADAuthenticationError* __autoreleasing*) error;
 
 //Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
 //the item to be stored.
 - (void)updateCacheToResult:(ADAuthenticationResult*)result
                   cacheItem:(ADTokenCacheStoreItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken;
+           withRefreshToken:(NSString*)refreshToken
+       requestCorrelationId:(NSUUID*)requestCorrelationId;
+
 - (void)updateCacheToResult:(ADAuthenticationResult*)result
               cacheInstance:(id<ADTokenCacheStoring>)tokenCacheStoreInstance
                   cacheItem:(ADTokenCacheStoreItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken;
+           withRefreshToken:(NSString*)refreshToken
+       requestCorrelationId:(NSUUID*)requestCorrelationId;
 
 - (ADTokenCacheStoreItem*)extractCacheItemWithKey:(ADTokenCacheStoreKey*)key
                                            userId:(ADUserIdentifier*)userId

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireAssertion.m
@@ -80,6 +80,7 @@
         ADTokenCacheStoreItem* cacheItem = [_context findCacheItemWithKey:key
                                                                    userId:_identifier
                                                            useAccessToken:&accessTokenUsable
+                                                     requestCorrelationId:_correlationId
                                                                     error:&error];
         if (error)
         {
@@ -155,7 +156,7 @@
              {
                  BOOL useAccessToken;
                  ADAuthenticationError* error = nil;
-                 ADTokenCacheStoreItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier useAccessToken:&useAccessToken error:&error];
+                 ADTokenCacheStoreItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier useAccessToken:&useAccessToken requestCorrelationId:_correlationId error:&error];
                  if (error)
                  {
                      completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -81,7 +81,7 @@
     {
         //Cache should be used in this case:
         BOOL accessTokenUsable;
-        ADTokenCacheStoreItem* cacheItem = [_context findCacheItemWithKey:key userId:_identifier useAccessToken:&accessTokenUsable error:&error];
+        ADTokenCacheStoreItem* cacheItem = [_context findCacheItemWithKey:key userId:_identifier useAccessToken:&accessTokenUsable requestCorrelationId:_correlationId error:&error];
         if (error)
         {
             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -151,7 +151,7 @@
              {
                  BOOL useAccessToken;
                  ADAuthenticationError* error;
-                 ADTokenCacheStoreItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier useAccessToken:&useAccessToken error:&error];
+                 ADTokenCacheStoreItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier useAccessToken:&useAccessToken requestCorrelationId:_correlationId error:&error];
                  if (error)
                  {
                      completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -243,7 +243,7 @@
                   {
                       if (AD_SUCCEEDED == result.status)
                       {
-                          [_context updateCacheToResult:result cacheItem:nil withRefreshToken:nil];
+                          [_context updateCacheToResult:result cacheItem:nil withRefreshToken:nil requestCorrelationId:_correlationId];
                           result = [ADAuthenticationContext updateResult:result toUser:_identifier];
                       }
                       completionBlock(result);
@@ -350,7 +350,8 @@
          {
              [_context updateCacheToResult:result
                                  cacheItem:resultItem
-                          withRefreshToken:refreshToken];
+                          withRefreshToken:refreshToken
+                      requestCorrelationId:_correlationId];
          }
          result = [ADAuthenticationContext updateResult:result toUser:_identifier];//Verify the user (just in case)
          

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+Broker.m
@@ -67,6 +67,10 @@
     NSDictionary* queryParamsMap = [NSDictionary adURLFormDecode:qp];
     ADAuthenticationResult* result;
     
+    NSUUID* correlationId = [queryParamsMap valueForKey:OAUTH2_CORRELATION_ID_RESPONSE] ?
+    [[NSUUID alloc] initWithUUIDString:[queryParamsMap valueForKey:OAUTH2_CORRELATION_ID_RESPONSE]]
+    : nil;
+    
     if([queryParamsMap valueForKey:OAUTH2_ERROR_DESCRIPTION]){
         result = [ADAuthenticationResult resultFromBrokerResponse:queryParamsMap];
     }
@@ -78,10 +82,6 @@
         NSString* encryptedBase64Response = [queryParamsMap valueForKey:BROKER_RESPONSE_KEY];
         NSString* msgVer = [queryParamsMap valueForKey:BROKER_MESSAGE_VERSION];
         NSInteger protocolVersion = 1;
-        
-        NSUUID* correlationId = [queryParamsMap valueForKey:OAUTH2_CORRELATION_ID_RESPONSE] ?
-        [[NSUUID alloc] initWithUUIDString:[queryParamsMap valueForKey:OAUTH2_CORRELATION_ID_RESPONSE]]
-        : nil;
         
         if (msgVer)
         {
@@ -131,7 +131,8 @@
         
         [ctx updateCacheToResult:result
                        cacheItem:nil
-                withRefreshToken:nil];
+                withRefreshToken:nil
+         requestCorrelationId:[correlationId UUIDString]];
         
         NSString* userId = [[[result tokenCacheStoreItem] userInformation] userId];
         [ADAuthenticationContext updateResult:result

--- a/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationResult+Internal.m
@@ -146,6 +146,7 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
     
     item = [ADTokenCacheStoreItem new];
     [item setAccessTokenType:@"Bearer"];
+    [item setMarkAsDead:NO];
     BOOL isMRRT = [item fillItemWithResponse:response];
     return [[ADAuthenticationResult alloc] initWithItem:item multiResourceRefreshToken:isMRRT correlationId:correlationId];
 }

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem+Internal.m
@@ -196,6 +196,7 @@
     FILL_FIELD(accessToken, OAUTH2_ACCESS_TOKEN);
     FILL_FIELD(refreshToken, OAUTH2_REFRESH_TOKEN);
     FILL_FIELD(accessTokenType, OAUTH2_TOKEN_TYPE);
+    FILL_FIELD(correlationId, OAUTH2_CORRELATION_ID_RESPONSE);
     
     [self fillExpiration:responseDictionary];
     

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.h
@@ -46,6 +46,13 @@
 
 @property (retain) ADUserInformation* userInformation;
 
+/*! Correlation ID of the request through which we get the token.
+ If the token is tombstoned, the value will be the correlation ID of the request that we got the error from.  */
+@property (retain) NSString* correlationId;
+
+/* Whether the token is tombstoned. */
+@property BOOL markAsDead;
+
 /*! If true, the cache store item does not store actual access token, but instead a refresh token that can be
  used to obtain access token for any resource within the same user, authority and client id. This property is calculated
  from the value of other properties: it is true if: resource is nil, accessToken is nil and refresh token is not nil or empty.*/

--- a/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoreItem.m
@@ -49,6 +49,8 @@
     item.expiresOn = [self.expiresOn copyWithZone:zone];
     item.userInformation = [self.userInformation copyWithZone:zone];
     item.sessionKey = [self.sessionKey copyWithZone:zone];
+    item.correlationId = [self.correlationId copyWithZone:zone];
+    item.markAsDead = [self markAsDead];
     
     return item;
 }
@@ -106,6 +108,8 @@
     [aCoder encodeObject:self.sessionKey forKey:@"sessionKey"];
     [aCoder encodeObject:self.expiresOn forKey:@"expiresOn"];
     [aCoder encodeObject:self.userInformation forKey:@"userInformation"];
+    [aCoder encodeObject:self.correlationId forKey:@"correlationId"];
+    [aCoder encodeBool:self.markAsDead forKey:@"markAsDead"];
 }
 
 //Deserializer:
@@ -124,6 +128,8 @@
         self.refreshToken = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"refreshToken"];
         self.expiresOn = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"expiresOn"];
         self.userInformation = [aDecoder decodeObjectOfClass:[ADUserInformation class] forKey:@"userInformation"];
+        self.correlationId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"correlationId"];
+        self.markAsDead = [aDecoder decodeBoolForKey:@"markAsDead"];
     }
     return self;
 }

--- a/ADALiOS/ADALiOS/ADTokenCacheStoring.h
+++ b/ADALiOS/ADALiOS/ADTokenCacheStoring.h
@@ -66,4 +66,27 @@
                    userId:(NSString *)userId
                     error:(ADAuthenticationError * __autoreleasing *)error;
 
+/*! Mark a cache item as dead instead of removing it.
+ @param item: the item being marked as dead. Key will be extracted from the item.
+ @param userId: The user for which the item will be removed. Can be nil, in which case items for all users with
+ the specified key will be removed.
+ @param error: in case of an error, if this parameter is not nil, it will be filled with
+ the error details. */
+- (void)tombstoneItem:(ADTokenCacheStoreItem *)item
+        requestCorrelationId:(NSString *)requestCorrelationId
+                error:(ADAuthenticationError * __autoreleasing *)error;
+
+/*! Returns all of the dead items for a given key. Multiple items may present,
+ if the same resource was accessed by more than one user. The returned
+ array should contain only ADTokenCacheStoreItem objects. Returns an empty array,
+ if no items are found. Returns nil (and sets the error parameter) in case of error.
+ @param key: the key of the cache item.
+ @param userId: The specific user whose item is needed.
+ @param error: in case of an error, if this parameter is not nil, it will be filled with
+ the error details.
+ */
+- (NSArray<ADTokenCacheStoreItem *> *)getTombstonedItemsWithKey:(ADTokenCacheStoreKey*)key
+                                                         userId:(NSString *)userId
+                                                error:(ADAuthenticationError* __autoreleasing*)error;
+
 @end

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -1018,6 +1018,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil([mContext findCacheItemWithKey:nil
                                          userId:nil
                                  useAccessToken:&useAccessToken
+                           requestCorrelationId:nil
                                           error:nil]);
     
     ADTokenCacheStoreItem* item = [self adCreateCacheItem];
@@ -1042,6 +1043,7 @@ const int sAsyncContextTimeout = 10;
     ADTokenCacheStoreItem* found = [mContext findCacheItemWithKey:key
                                                            userId:userId
                                                    useAccessToken:&useAccessToken
+                                             requestCorrelationId:nil
                                                             error:&error];
     ADAssertNoError;
     XCTAssertTrue(useAccessToken);
@@ -1054,6 +1056,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil([mContext findCacheItemWithKey:key
                                          userId:userId
                                  useAccessToken:&useAccessToken
+                           requestCorrelationId:nil
                                           error:&error]);
 }
 

--- a/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
+++ b/ADALiOS/ADALiOSTests/XCTestCase+TestHelperMethods.m
@@ -321,6 +321,8 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     item.expiresOn = [NSDate dateWithTimeIntervalSinceNow:3600];
     item.userInformation = [self adCreateUserInformation];
     item.accessTokenType = @"access token type";
+    item.correlationId = [[NSUUID UUID] UUIDString];
+    item.markAsDead = NO;
     
     [self adVerifyPropertiesAreSet:item];
     
@@ -377,7 +379,9 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     //Add here calculated properties that cannot be initialized and shouldn't be checked for initialization:
     NSDictionary* const exceptionProperties = @{
                                                 NSStringFromClass([ADTokenCacheStoreItem class]):[NSSet setWithObjects:@"multiResourceRefreshToken",
-                                                                                                  @"sessionKey",nil], };
+                                                                                                  @"sessionKey",
+                                                                                                  @"markAsDead",//it is BOOL, so exampt from the check
+                                                                                                  nil], };
     
     //Enumerate all properties and ensure that they are set to non-default values:
     unsigned int propertyCount;


### PR DESCRIPTION
Referring #445 
Tombstone feature added to ADKeychainTokenCacheStore.Now if an item will be marked as dead and left in keychain rather than being deleted.

In particular, the following changes are made:

1) property *correlationId* is added to ADTokenCacheStoreItem. If the token is tombstoned, the value will be the correlation ID of the request that we got the error from; if not, it is the correlation ID of the request through which we get the token.

2) property *markAsDead* is added to ADTokenCacheStoreItem. It shows whether the token is tombstoned.


3) unit tests for tombstone feature is added. 