### PR TITLE
Rename "ADAuthenticationBroker" to "ADWebAuthController"

### DIFF
--- a/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
+++ b/ADALiOS/ADALiOS.xcodeproj/project.pbxproj
@@ -23,7 +23,7 @@
 		8B343443183304FE002DE1DC /* ADWebRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B343440183304FE002DE1DC /* ADWebRequest.m */; };
 		8B343444183304FE002DE1DC /* ADWebResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B343442183304FE002DE1DC /* ADWebResponse.m */; };
 		8B3434471833057F002DE1DC /* UIApplication+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B3434461833057F002DE1DC /* UIApplication+ADExtensions.m */; };
-		8B34344A18330591002DE1DC /* ADAuthenticationBroker.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B34344918330591002DE1DC /* ADAuthenticationBroker.m */; };
+		8B34344A18330591002DE1DC /* ADWebAuthController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B34344918330591002DE1DC /* ADWebAuthController.m */; };
 		8B34344F183305A6002DE1DC /* ADAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B34344C183305A6002DE1DC /* ADAuthenticationViewController.m */; };
 		8B343450183305A6002DE1DC /* ADAuthenticationWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B34344E183305A6002DE1DC /* ADAuthenticationWebViewController.m */; };
 		8B59893A180DE00300744AEE /* ADAuthenticationOperation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B598939180DE00300744AEE /* ADAuthenticationOperation.m */; };
@@ -65,7 +65,7 @@
 		8BB8346918077F1B007F9F0D /* ADAuthenticationSettings.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 8BB83463180764B6007F9F0D /* ADAuthenticationSettings.h */; };
 		8BB8346B1807BE3F007F9F0D /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8346A1807BE3F007F9F0D /* ADAuthenticationContextTests.m */; };
 		8BB8346D1807C5F5007F9F0D /* ADAuthenticationParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8346C1807C5F5007F9F0D /* ADAuthenticationParametersTests.m */; };
-		8BBE6FAE193EA1C60039C23E /* ADAuthenticationBroker.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 8B34344818330591002DE1DC /* ADAuthenticationBroker.h */; };
+		8BBE6FAE193EA1C60039C23E /* ADWebAuthController.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 8B34344818330591002DE1DC /* ADWebAuthController.h */; };
 		8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF678518358544004E0F4D /* ADUserInformationTests.m */; };
 		8BBF6788183588EC004E0F4D /* ADTokenCacheStoreItemTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF6787183588EC004E0F4D /* ADTokenCacheStoreItemTest.m */; };
 		8BD14619182189C800796E79 /* ADAuthenticationParameters+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD14618182189C800796E79 /* ADAuthenticationParameters+Internal.m */; };
@@ -123,7 +123,7 @@
 			files = (
 				D6FB3E3D1B30FF510032F883 /* ADUserIdentifier.h in Copy Files */,
 				97DFE4671AE38903008109E1 /* ADAL.h in Copy Files */,
-				8BBE6FAE193EA1C60039C23E /* ADAuthenticationBroker.h in Copy Files */,
+				8BBE6FAE193EA1C60039C23E /* ADWebAuthController.h in Copy Files */,
 				8B79592118F5ECA700EBF96E /* ADLogger.h in Copy Files */,
 				8B79592018F5E93A00EBF96E /* ADTokenCacheStoring.h in Copy Files */,
 				8B6114041872347E007759C2 /* ADInstanceDiscovery.h in Copy Files */,
@@ -143,6 +143,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04F7A0D71C5037370053BBD5 /* ADWebAuthController+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADWebAuthController+Internal.h"; sourceTree = "<group>"; };
 		6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLConnection.h; sourceTree = "<group>"; };
 		6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLConnection.m; sourceTree = "<group>"; };
 		609EC5B51C3DAB3E00603EEF /* ADALFrameworkUtils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADALFrameworkUtils.h; sourceTree = "<group>"; };
@@ -171,8 +172,8 @@
 		8B343442183304FE002DE1DC /* ADWebResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebResponse.m; sourceTree = "<group>"; };
 		8B3434451833057F002DE1DC /* UIApplication+ADExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UIApplication+ADExtensions.h"; sourceTree = "<group>"; };
 		8B3434461833057F002DE1DC /* UIApplication+ADExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UIApplication+ADExtensions.m"; sourceTree = "<group>"; };
-		8B34344818330591002DE1DC /* ADAuthenticationBroker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationBroker.h; sourceTree = "<group>"; };
-		8B34344918330591002DE1DC /* ADAuthenticationBroker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationBroker.m; sourceTree = "<group>"; };
+		8B34344818330591002DE1DC /* ADWebAuthController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthController.h; sourceTree = "<group>"; };
+		8B34344918330591002DE1DC /* ADWebAuthController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthController.m; sourceTree = "<group>"; };
 		8B34344B183305A6002DE1DC /* ADAuthenticationViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationViewController.h; sourceTree = "<group>"; };
 		8B34344C183305A6002DE1DC /* ADAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewController.m; sourceTree = "<group>"; };
 		8B34344D183305A6002DE1DC /* ADAuthenticationWebViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationWebViewController.h; sourceTree = "<group>"; };
@@ -526,12 +527,13 @@
 			children = (
 				8B3434451833057F002DE1DC /* UIApplication+ADExtensions.h */,
 				8B3434461833057F002DE1DC /* UIApplication+ADExtensions.m */,
-				8B34344818330591002DE1DC /* ADAuthenticationBroker.h */,
-				8B34344918330591002DE1DC /* ADAuthenticationBroker.m */,
+				8B34344818330591002DE1DC /* ADWebAuthController.h */,
+				8B34344918330591002DE1DC /* ADWebAuthController.m */,
 				8B34344B183305A6002DE1DC /* ADAuthenticationViewController.h */,
 				8B34344C183305A6002DE1DC /* ADAuthenticationViewController.m */,
 				8B34344D183305A6002DE1DC /* ADAuthenticationWebViewController.h */,
 				8B34344E183305A6002DE1DC /* ADAuthenticationWebViewController.m */,
+				04F7A0D71C5037370053BBD5 /* ADWebAuthController+Internal.h */,
 			);
 			name = iOS;
 			sourceTree = "<group>";
@@ -762,7 +764,7 @@
 				D6E43A761B04142C000F5BE2 /* ADAuthenticationRequest+Broker.m in Sources */,
 				8B92DB6C181ADE44004AAB0E /* NSString+ADHelperMethods.m in Sources */,
 				8B59894E1810BEAC00744AEE /* ADTokenCacheStoreItem.m in Sources */,
-				8B34344A18330591002DE1DC /* ADAuthenticationBroker.m in Sources */,
+				8B34344A18330591002DE1DC /* ADWebAuthController.m in Sources */,
 				8B59893A180DE00300744AEE /* ADAuthenticationOperation.m in Sources */,
 				8BD14619182189C800796E79 /* ADAuthenticationParameters+Internal.m in Sources */,
 				9722232F19A2C9F900092E85 /* ADWorkPlaceJoin.m in Sources */,

--- a/ADALiOS/ADALiOS/ADAuthenticationContext.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationContext.m
@@ -21,7 +21,7 @@
 #import "ADAuthenticationResult.h"
 #import "ADAuthenticationResult+Internal.h"
 #import "ADOAuth2Constants.h"
-#import "ADAuthenticationBroker.h"
+#import "ADWebAuthController.h"
 #import "ADAuthenticationSettings.h"
 #import "NSURL+ADExtensions.h"
 #import "NSDictionary+ADExtensions.h"

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
@@ -24,7 +24,8 @@
 #import "ADWebResponse.h"
 #import "ADPkeyAuthHelper.h"
 #import "ADAuthenticationSettings.h"
-#import "ADAuthenticationBroker.h"
+#import "ADWebAuthController.h"
+#import "ADWebAuthController+Internal.h"
 #import "ADHelpers.h"
 #import "NSURL+ADExtensions.h"
 #import "ADUserIdentifier.h"
@@ -383,7 +384,7 @@ static volatile int sDialogInProgress = 0;
 - (void)launchWebView:(NSString*)startUrl
       completionBlock:(void (^)(ADAuthenticationError*, NSURL*))completionBlock
 {
-    [[ADAuthenticationBroker sharedInstance] start:[NSURL URLWithString:startUrl]
+    [[ADWebAuthController sharedInstance] start:[NSURL URLWithString:startUrl]
                                                end:[NSURL URLWithString:_redirectUri]
                             refreshTokenCredential:_refreshTokenCredential
                                   parentController:_context.parentController

--- a/ADALiOS/ADALiOS/ADWebAuthController+Internal.h
+++ b/ADALiOS/ADALiOS/ADWebAuthController+Internal.h
@@ -23,6 +23,8 @@
 typedef void (^ADBrokerCallback) (ADAuthenticationError* error, NSURL*);
 @interface ADWebAuthController (Internal)
 
++ (ADWebAuthController *)sharedInstance;
+
 // Start the authentication process. Note that there are two different behaviours here dependent on whether the caller has provided
 // a WebView to host the browser interface. If no WebView is provided, then a full window is launched that hosts a WebView to run
 // the authentication process.
@@ -34,5 +36,9 @@ parentController:(UIViewController *)parent
    fullScreen:(BOOL)fullScreen
 correlationId:(NSUUID*)correlationId
    completion: (ADBrokerCallback) completionBlock;
+
+//Cancel the web authentication session which might be happening right now
+//Note that it only works if there's an active web authentication session going on
+- (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError*)error;
 
 @end

--- a/ADALiOS/ADALiOS/ADWebAuthController+Internal.h
+++ b/ADALiOS/ADALiOS/ADWebAuthController+Internal.h
@@ -21,9 +21,7 @@
 #import "ADAuthenticationContext.h"
 
 typedef void (^ADBrokerCallback) (ADAuthenticationError* error, NSURL*);
-@interface ADAuthenticationBroker : NSObject
-
-+ (ADAuthenticationBroker *)sharedInstance;
+@interface ADWebAuthController (Internal)
 
 // Start the authentication process. Note that there are two different behaviours here dependent on whether the caller has provided
 // a WebView to host the browser interface. If no WebView is provided, then a full window is launched that hosts a WebView to run
@@ -36,9 +34,5 @@ parentController:(UIViewController *)parent
    fullScreen:(BOOL)fullScreen
 correlationId:(NSUUID*)correlationId
    completion: (ADBrokerCallback) completionBlock;
-
-- (void)cancel;
-
-- (BOOL)cancelWithError:(ADAuthenticationError*)error;
 
 @end

--- a/ADALiOS/ADALiOS/ADWebAuthController.h
+++ b/ADALiOS/ADALiOS/ADWebAuthController.h
@@ -16,17 +16,17 @@
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
 
+@class ADAuthenticationError;
 
-#import "ADLogger.h"
 #import "ADAuthenticationContext.h"
-#import "ADTokenCacheStoring.h"
-#import "ADAuthenticationError.h"
-#import "ADAuthenticationResult.h"
-#import "ADTokenCacheStoreItem.h"
-#import "ADUserInformation.h"
-#import "ADTokenCacheStoreKey.h"
-#import "ADAuthenticationSettings.h"
-#import "ADWebAuthController.h"
-#import "ADErrorCodes.h"
-#import "ADAuthenticationParameters.h"
-#import "ADUserIdentifier.h"
+
+@interface ADWebAuthController : NSObject
+
++ (ADWebAuthController *)sharedInstance;
+
+//Cancel the web authentication session which might be happening right now
+//Note that it only works if there's an active web authentication session going on
+- (void)cancelCurrentWebAuthSession;
+- (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError*)error;
+
+@end

--- a/ADALiOS/ADALiOS/ADWebAuthController.h
+++ b/ADALiOS/ADALiOS/ADWebAuthController.h
@@ -22,11 +22,8 @@
 
 @interface ADWebAuthController : NSObject
 
-+ (ADWebAuthController *)sharedInstance;
-
 //Cancel the web authentication session which might be happening right now
 //Note that it only works if there's an active web authentication session going on
-- (void)cancelCurrentWebAuthSession;
-- (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError*)error;
++ (void)cancelCurrentWebAuthSession;
 
 @end

--- a/ADALiOS/ADALiOS/ADWebAuthController.m
+++ b/ADALiOS/ADALiOS/ADWebAuthController.m
@@ -23,7 +23,8 @@
 #import "ADAuthenticationDelegate.h"
 #import "ADAuthenticationWebViewController.h"
 #import "ADAuthenticationViewController.h"
-#import "ADAuthenticationBroker.h"
+#import "ADWebAuthController.h"
+#import "ADWebAuthController+Internal.h"
 #import "ADAuthenticationSettings.h"
 #import "ADNTLMHandler.h"
 #import "ADCustomHeaderHandler.h"
@@ -35,11 +36,11 @@ NSString *const AD_IPAD_STORYBOARD = @"ADAL_iPad_Storyboard";
 NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
 
 // Private interface declaration
-@interface ADAuthenticationBroker () <ADAuthenticationDelegate>
+@interface ADWebAuthController () <ADAuthenticationDelegate>
 @end
 
 // Implementation
-@implementation ADAuthenticationBroker
+@implementation ADWebAuthController
 {
     UIViewController*                   _parentController;
     ADAuthenticationViewController*     _authenticationViewController;
@@ -52,9 +53,9 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
 
 #pragma mark Shared Instance Methods
 
-+ (ADAuthenticationBroker *)sharedInstance
++ (ADWebAuthController *)sharedInstance
 {
-    static ADAuthenticationBroker *broker     = nil;
+    static ADWebAuthController *broker     = nil;
     static dispatch_once_t          predicate;
     
     dispatch_once( &predicate, ^{
@@ -111,170 +112,12 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
     return self;
 }
 
-#pragma mark - Private Methods
-
-+(NSString*) getStoryboardName
-{
-    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
-    ? AD_IPAD_STORYBOARD
-    : AD_IPHONE_STORYBOARD;
-}
-
-// Retrieve the current storyboard from the resources for the library. Attempts to use ADALiOS bundle first
-// and if the bundle is not present, assumes that the resources are build with the application itself.
-// Raises an error if both the library resources bundle and the application fail to locate resources.
-+ (UIStoryboard *)storyboard: (ADAuthenticationError* __autoreleasing*) error
-{
-    NSBundle* bundle = [ADALFrameworkUtils frameworkBundle];//May be nil.
-    if (!bundle)
-    {
-        //The user did not use ADALiOS.bundle. The resources may be manually linked
-        //to the app by referencing the storyboards directly.
-        bundle = [NSBundle mainBundle];
-    }
-    NSString* storyboardName = [self getStoryboardName];
-    if ([bundle pathForResource:storyboardName ofType:@"storyboardc"])
-    {
-        //Despite Apple's documentation, storyboard with name actually throws, crashing
-        //the app if the story board is not present, hence the if above.
-        UIStoryboard* storyBoard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
-        if (storyBoard)
-            return storyBoard;
-    }
-    
-    ADAuthenticationError* adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES protocolCode:nil errorDetails:AD_FAILED_NO_RESOURCES];
-    if (error)
-    {
-        *error = adError;
-    }
-    return nil;
-}
-
--(NSURL*) addToURL: (NSURL*) url
-     correlationId: (NSUUID*) correlationId
-{
-    return [NSURL URLWithString:[NSString stringWithFormat:@"%@&%@=%@",
-                                 [url absoluteString], OAUTH2_CORRELATION_ID_REQUEST_VALUE, [correlationId UUIDString]]];
-}
-
-#pragma mark - Public Methods
-
-- (void)start:(NSURL *)startURL
-          end:(NSURL *)endURL
-refreshTokenCredential:(NSString*)refreshTokenCredential
-parentController:(UIViewController *)parent
-      webView:(WebViewType *)webView
-   fullScreen:(BOOL)fullScreen
-correlationId:(NSUUID *)correlationId
-   completion:(ADBrokerCallback)completionBlock
-{
-    THROW_ON_NIL_ARGUMENT(startURL);
-    THROW_ON_NIL_ARGUMENT(endURL);
-    THROW_ON_NIL_ARGUMENT(correlationId);
-    THROW_ON_NIL_ARGUMENT(completionBlock)
-    //AD_LOG_VERBOSE(@"Authorization", startURL.absoluteString);
-    
-    startURL = [self addToURL:startURL correlationId:correlationId];//Append the correlation id
-    
-    // Save the completion block
-    _completionBlock = [completionBlock copy];
-    ADAuthenticationError* error = nil;
-    
-    [ADURLProtocol registerProtocol];
-    
-	if(![NSString adIsStringNilOrBlank:refreshTokenCredential])
-    {
-        [ADCustomHeaderHandler addCustomHeaderValue:refreshTokenCredential
-                                       forHeaderKey:@"x-ms-RefreshTokenCredential"
-                                       forSingleUse:YES];
-    }
-
-    if (webView)
-    {
-        AD_LOG_INFO(@"Authorization UI", nil, @"Use the application provided WebView.");
-        // Use the application provided WebView
-        _authenticationWebViewController = [[ADAuthenticationWebViewController alloc] initWithWebView:webView startAtURL:startURL endAtURL:endURL];
-        
-        if ( _authenticationWebViewController )
-        {
-            // Show the authentication view
-            _authenticationWebViewController.delegate = self;
-            [_authenticationWebViewController start];
-        }
-        else
-        {
-            // Dispatch the completion block
-            error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES
-                                                           protocolCode:nil
-                                                           errorDetails:AD_FAILED_NO_RESOURCES];
-        }
-    }
-    else
-    {
-        if (!parent)
-        {
-            // Must have a parent view controller to start the authentication view
-            parent = [UIApplication adCurrentViewController];
-        }
-        
-        if (parent)
-        {
-            _parentController = parent;
-            // Load our resource bundle, find the navigation controller for the authentication view, and then the authentication view
-            UINavigationController *navigationController = [[self.class storyboard:&error] instantiateViewControllerWithIdentifier:@"LogonNavigator"];
-            
-            if (navigationController)
-            {
-                _authenticationViewController = (ADAuthenticationViewController *)[navigationController.viewControllers objectAtIndex:0];
-                
-                _authenticationViewController.delegate = self;
-                
-                if ( fullScreen == YES )
-                    [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
-                else
-                    [navigationController setModalPresentationStyle:UIModalPresentationFormSheet];
-                
-                // Show the authentication view
-                [parent presentViewController:navigationController animated:YES completion:^{
-                    // Instead of loading the URL immediately on completion, get the UI on the screen
-                    // and then dispatch the call to load the authorization URL
-                    dispatch_async( dispatch_get_main_queue(), ^{
-                        [_authenticationViewController startWithURL:startURL
-                                                           endAtURL:endURL];
-                    });
-                }];
-            }
-            else //Navigation controller
-            {
-                error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES
-                                                               protocolCode:nil
-                                                               errorDetails:AD_FAILED_NO_RESOURCES];
-            }
-        }
-        else //Parent
-        {
-            error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_NO_MAIN_VIEW_CONTROLLER
-                                                           protocolCode:nil
-                                                           errorDetails:AD_FAILED_NO_CONTROLLER];
-            
-        }
-    }
-    
-    //Error occurred above. Dispatch the callback to the caller:
-    if (error)
-    {
-        dispatch_async( [ADAuthenticationSettings sharedInstance].dispatchQueue, ^{
-            _completionBlock( error, nil );
-        });
-    }
-}
-
-- (void)cancel
+- (void)cancelCurrentWebAuthSession
 {
     [self webAuthenticationDidCancel];
 }
 
-- (BOOL)cancelWithError:(ADAuthenticationError*)error
+- (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError*)error
 {
     return [self endWebAuthenticationWithError:error orURL:nil];
 }
@@ -361,6 +204,168 @@ correlationId:(NSUUID *)correlationId
     ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error errorDetails:error.localizedDescription];
     
     [self endWebAuthenticationWithError:adError orURL:nil];
+}
+
+@end
+
+@implementation ADWebAuthController (Internal)
+
+#pragma mark - Private Methods
+
++(NSString*) getStoryboardName
+{
+    return (UI_USER_INTERFACE_IDIOM() == UIUserInterfaceIdiomPad)
+    ? AD_IPAD_STORYBOARD
+    : AD_IPHONE_STORYBOARD;
+}
+
+// Retrieve the current storyboard from the resources for the library. Attempts to use ADALiOS bundle first
+// and if the bundle is not present, assumes that the resources are build with the application itself.
+// Raises an error if both the library resources bundle and the application fail to locate resources.
++ (UIStoryboard *)storyboard: (ADAuthenticationError* __autoreleasing*) error
+{
+    NSBundle* bundle = [ADALFrameworkUtils frameworkBundle];//May be nil.
+    if (!bundle)
+    {
+        //The user did not use ADALiOS.bundle. The resources may be manually linked
+        //to the app by referencing the storyboards directly.
+        bundle = [NSBundle mainBundle];
+    }
+    NSString* storyboardName = [self getStoryboardName];
+    if ([bundle pathForResource:storyboardName ofType:@"storyboardc"])
+    {
+        //Despite Apple's documentation, storyboard with name actually throws, crashing
+        //the app if the story board is not present, hence the if above.
+        UIStoryboard* storyBoard = [UIStoryboard storyboardWithName:storyboardName bundle:bundle];
+        if (storyBoard)
+            return storyBoard;
+    }
+    
+    ADAuthenticationError* adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES protocolCode:nil errorDetails:AD_FAILED_NO_RESOURCES];
+    if (error)
+    {
+        *error = adError;
+    }
+    return nil;
+}
+
+-(NSURL*) addToURL: (NSURL*) url
+     correlationId: (NSUUID*) correlationId
+{
+    return [NSURL URLWithString:[NSString stringWithFormat:@"%@&%@=%@",
+                                 [url absoluteString], OAUTH2_CORRELATION_ID_REQUEST_VALUE, [correlationId UUIDString]]];
+}
+
+#pragma mark - Public Methods
+
+- (void)start:(NSURL *)startURL
+          end:(NSURL *)endURL
+refreshTokenCredential:(NSString*)refreshTokenCredential
+parentController:(UIViewController *)parent
+      webView:(WebViewType *)webView
+   fullScreen:(BOOL)fullScreen
+correlationId:(NSUUID *)correlationId
+   completion:(ADBrokerCallback)completionBlock
+{
+    THROW_ON_NIL_ARGUMENT(startURL);
+    THROW_ON_NIL_ARGUMENT(endURL);
+    THROW_ON_NIL_ARGUMENT(correlationId);
+    THROW_ON_NIL_ARGUMENT(completionBlock)
+    //AD_LOG_VERBOSE(@"Authorization", startURL.absoluteString);
+    
+    startURL = [self addToURL:startURL correlationId:correlationId];//Append the correlation id
+    
+    // Save the completion block
+    _completionBlock = [completionBlock copy];
+    ADAuthenticationError* error = nil;
+    
+    [ADURLProtocol registerProtocol];
+    
+    if(![NSString adIsStringNilOrBlank:refreshTokenCredential])
+    {
+        [ADCustomHeaderHandler addCustomHeaderValue:refreshTokenCredential
+                                       forHeaderKey:@"x-ms-RefreshTokenCredential"
+                                       forSingleUse:YES];
+    }
+    
+    if (webView)
+    {
+        AD_LOG_INFO(@"Authorization UI", nil, @"Use the application provided WebView.");
+        // Use the application provided WebView
+        _authenticationWebViewController = [[ADAuthenticationWebViewController alloc] initWithWebView:webView startAtURL:startURL endAtURL:endURL];
+        
+        if ( _authenticationWebViewController )
+        {
+            // Show the authentication view
+            _authenticationWebViewController.delegate = self;
+            [_authenticationWebViewController start];
+        }
+        else
+        {
+            // Dispatch the completion block
+            error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES
+                                                           protocolCode:nil
+                                                           errorDetails:AD_FAILED_NO_RESOURCES];
+        }
+    }
+    else
+    {
+        if (!parent)
+        {
+            // Must have a parent view controller to start the authentication view
+            parent = [UIApplication adCurrentViewController];
+        }
+        
+        if (parent)
+        {
+            _parentController = parent;
+            // Load our resource bundle, find the navigation controller for the authentication view, and then the authentication view
+            UINavigationController *navigationController = [[self.class storyboard:&error] instantiateViewControllerWithIdentifier:@"LogonNavigator"];
+            
+            if (navigationController)
+            {
+                _authenticationViewController = (ADAuthenticationViewController *)[navigationController.viewControllers objectAtIndex:0];
+                
+                _authenticationViewController.delegate = self;
+                
+                if ( fullScreen == YES )
+                    [navigationController setModalPresentationStyle:UIModalPresentationFullScreen];
+                else
+                    [navigationController setModalPresentationStyle:UIModalPresentationFormSheet];
+                
+                // Show the authentication view
+                [parent presentViewController:navigationController animated:YES completion:^{
+                    // Instead of loading the URL immediately on completion, get the UI on the screen
+                    // and then dispatch the call to load the authorization URL
+                    dispatch_async( dispatch_get_main_queue(), ^{
+                        [_authenticationViewController startWithURL:startURL
+                                                           endAtURL:endURL];
+                    });
+                }];
+            }
+            else //Navigation controller
+            {
+                error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_MISSING_RESOURCES
+                                                               protocolCode:nil
+                                                               errorDetails:AD_FAILED_NO_RESOURCES];
+            }
+        }
+        else //Parent
+        {
+            error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_NO_MAIN_VIEW_CONTROLLER
+                                                           protocolCode:nil
+                                                           errorDetails:AD_FAILED_NO_CONTROLLER];
+            
+        }
+    }
+    
+    //Error occurred above. Dispatch the callback to the caller:
+    if (error)
+    {
+        dispatch_async( [ADAuthenticationSettings sharedInstance].dispatchQueue, ^{
+            _completionBlock( error, nil );
+        });
+    }
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADWebAuthController.m
+++ b/ADALiOS/ADALiOS/ADWebAuthController.m
@@ -112,9 +112,9 @@ NSString *const AD_IPHONE_STORYBOARD = @"ADAL_iPhone_Storyboard";
     return self;
 }
 
-- (void)cancelCurrentWebAuthSession
++ (void)cancelCurrentWebAuthSession
 {
-    [self webAuthenticationDidCancel];
+    [[ADWebAuthController sharedInstance] webAuthenticationDidCancel];
 }
 
 - (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError*)error

--- a/ADALiOS/ADALiOS/UIAlertView+Additions.m
+++ b/ADALiOS/ADALiOS/UIAlertView+Additions.m
@@ -1,5 +1,5 @@
 #import <objc/runtime.h>
-#import "ADAuthenticationBroker.h"
+#import "ADWebAuthController.h"
 #import "ADALFrameworkUtils.h"
 
 @implementation UIAlertView (Additions)


### PR DESCRIPTION
For Issue #447 
1. Renamed "ADAuthenticationBroker" to "ADWebAuthController"; 
2. Moved functions not suitable to be public from ADWebAuthController to ADWebAuthController (Internal) except the cancel functions.