### PR TITLE
Web Auth and Broker Notifications

### DIFF
--- a/ADAL/src/broker/ios/ADBrokerHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerHelper.m
@@ -16,12 +16,14 @@
 // See the Apache License, Version 2.0 for the specific language
 // governing permissions and limitations under the License.
 
+#import <objc/runtime.h>
+
+#import "NSDictionary+ADExtensions.h"
+
 #import "ADBrokerHelper.h"
 #import "ADBrokerNotificationManager.h"
 #import "ADOAuth2Constants.h"
-#import "NSDictionary+ADExtensions.h"
-
-#import <objc/runtime.h>
+#import "ADWebAuthController+Internal.h"
 
 typedef BOOL (*applicationOpenURLPtr)(id, SEL, UIApplication*, NSURL*, NSString*, id);
 IMP __original_ApplicationOpenURL = NULL;
@@ -102,6 +104,8 @@ BOOL __swizzle_ApplicationOpenURL(id self, SEL _cmd, UIApplication* application,
     [[ADBrokerNotificationManager sharedInstance] enableNotifications:completion];
     
     dispatch_async(dispatch_get_main_queue(), ^{
+        [[NSNotificationCenter defaultCenter] postNotificationName:ADWebAuthWillSwitchToBrokerApp object:nil];
+        
         [[UIApplication sharedApplication] openURL:appUrl];
     });
 }

--- a/ADAL/src/public/ADWebAuthController.h
+++ b/ADAL/src/public/ADWebAuthController.h
@@ -20,6 +20,18 @@
 
 #import "ADAuthenticationContext.h"
 
+/*! Fired at the start of a resource load in the webview. The URL of the load, if available, will be in the @"url" key in the userInfo dictionary */
+extern NSString* ADWebAuthDidStartLoadNotification;
+
+/*! Fired when a resource finishes loading in the webview. */
+extern NSString* ADWebAuthDidFinishLoadNotification;
+
+/*! Fired when web authentication fails due to reasons originating from the network. Look at the @"error" key in the userInfo dictionary for more details.*/
+extern NSString* ADWebAuthDidFailNotification;
+
+/*! Fired when authentication finishes */
+extern NSString* ADWebAuthDidCompleteNotification;
+
 @interface ADWebAuthController : NSObject
 
 //Cancel the web authentication session which might be happening right now

--- a/ADAL/src/public/ADWebAuthController.h
+++ b/ADAL/src/public/ADWebAuthController.h
@@ -32,10 +32,27 @@ extern NSString* ADWebAuthDidFailNotification;
 /*! Fired when authentication finishes */
 extern NSString* ADWebAuthDidCompleteNotification;
 
+/*! Fired before ADAL invokes the broker app */
+extern NSString* ADWebAuthWillSwitchToBrokerApp;
+
+/*! Fired when the application receives a response from the broker. Look at the @"response"
+    key in the userInfo dictionary for the broker response */
+extern NSString* ADWebAuthDidReceieveResponseFromBroker;
+
 @interface ADWebAuthController : NSObject
 
 //Cancel the web authentication session which might be happening right now
 //Note that it only works if there's an active web authentication session going on
 + (void)cancelCurrentWebAuthSession;
+
+#if TARGET_OS_IPHONE
+/*!
+ If the application was terminated between ADAL calling out to the broker app and
+ receiving a response, then the request can't be continued in a normal fashion. An
+ application can use this API to retrieve a response that was received from the
+ broker but we no longer had an active completion block to hand it to.
+ */
++ (ADAuthenticationResult *)responseFromInterruptedBrokerSession;
+#endif
 
 @end

--- a/ADAL/src/ui/ADWebAuthController+Internal.h
+++ b/ADAL/src/ui/ADWebAuthController+Internal.h
@@ -44,4 +44,8 @@ correlationId:(NSUUID*)correlationId
 //Note that it only works if there's an active web authentication session going on
 - (BOOL)cancelCurrentWebAuthSessionWithError:(ADAuthenticationError *)error;
 
+#if TARGET_OS_IPHONE
++ (void)setInterruptedBrokerResult:(ADAuthenticationResult*)result;
+#endif // TARGET_OS_IPHONE
+
 @end

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -46,6 +46,10 @@ NSString* ADWebAuthDidFailNotification = @"ADWebAuthDidFailNotification";
 /*! Fired when authentication finishes */
 NSString* ADWebAuthDidCompleteNotification = @"ADWebAuthDidCompleteNotification";
 
+NSString* ADWebAuthDidReceieveResponseFromBroker = @"ADWebAuthDidReceiveResponseFromBroker";
+
+NSString* ADADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
+
 // Private interface declaration
 @interface ADWebAuthController () <ADWebAuthDelegate>
 @end
@@ -386,6 +390,17 @@ NSString* ADWebAuthDidCompleteNotification = @"ADWebAuthDidCompleteNotification"
     dispatch_async(dispatch_get_main_queue(), ^{ [self endWebAuthenticationWithError:adError orURL:nil]; });
 }
 
+#if TARGET_OS_IPHONE
+static ADAuthenticationResult* s_result = nil;
+
++ (ADAuthenticationResult*)responseFromInterruptedBrokerSession
+{
+    ADAuthenticationResult* result = s_result;
+    s_result = nil;
+    return result;
+}
+#endif // TARGET_OS_IPHONE
+
 @end
 
 #pragma mark - Private Methods
@@ -415,8 +430,6 @@ NSString* ADWebAuthDidCompleteNotification = @"ADWebAuthDidCompleteNotification"
     return [NSURL URLWithString:[NSString stringWithFormat:@"%@&%@=%@",
                                  [url absoluteString], OAUTH2_CORRELATION_ID_REQUEST_VALUE, [correlationId UUIDString]]];
 }
-
-#pragma mark - Public Methods
 
 - (void)start:(NSURL *)startURL
           end:(NSURL *)endURL
@@ -470,5 +483,12 @@ correlationId:(NSUUID *)correlationId
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[ADHelpers addClientVersionToURL:startURL]];
     [_authenticationViewController startRequest:request];
 }
+
+#if TARGET_OS_IPHONE
++ (void)setInterruptedBrokerResult:(ADAuthenticationResult*)result
+{
+    s_result = result;
+}
+#endif // TARGET_OS_IPHONE
 
 @end

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -48,7 +48,7 @@ NSString* ADWebAuthDidCompleteNotification = @"ADWebAuthDidCompleteNotification"
 
 NSString* ADWebAuthDidReceieveResponseFromBroker = @"ADWebAuthDidReceiveResponseFromBroker";
 
-NSString* ADADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
+NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
 
 // Private interface declaration
 @interface ADWebAuthController () <ADWebAuthDelegate>

--- a/ADAL/src/ui/ADWebAuthDelegate.h
+++ b/ADAL/src/ui/ADWebAuthDelegate.h
@@ -20,8 +20,8 @@
 
 @required
 - (void)webAuthDidCancel;
-- (void)webAuthDidStartLoad;
-- (void)webAuthDidFinishLoad;
+- (void)webAuthDidStartLoad:(NSURL*)url;
+- (void)webAuthDidFinishLoad:(NSURL*)url;
 - (BOOL)webAuthShouldStartLoadRequest:(NSURLRequest*)request;
 - (void)webAuthDidCompleteWithURL:(NSURL *)endURL;
 - (void)webAuthDidFailWithError:(NSError *)error;

--- a/ADAL/src/ui/ios/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/ios/ADAuthenticationViewController.m
@@ -188,7 +188,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 {
 #pragma unused(webView)
     
-    [_delegate webAuthDidStartLoad];
+    [_delegate webAuthDidStartLoad:webView.request.URL];
 }
 
 - (void)stopSpinner
@@ -200,7 +200,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 - (void)webViewDidFinishLoad:(UIWebView *)webView
 {
 #pragma unused(webView)
-    [_delegate webAuthDidFinishLoad];
+    [_delegate webAuthDidFinishLoad:webView.request.URL];
 }
 
 - (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error

--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -171,7 +171,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     if ([_delegate webAuthShouldStartLoadRequest:request])
     {
         [listener use];
-        [_delegate webAuthDidStartLoad];
+        [_delegate webAuthDidStartLoad:request.URL];
     }
     else
     {
@@ -185,7 +185,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     (void)identifier;
     (void)dataSource;
     
-    [_delegate webAuthDidFinishLoad];
+    [_delegate webAuthDidFinishLoad:dataSource.request.URL];
 }
 
 - (void)stopSpinner

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppDelegate.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppDelegate.m
@@ -75,7 +75,7 @@
 {
     // Saves changes in the application's managed object context before the application terminates.
     [self saveContext];
-    [[BVSettings new] flushCodeCoverage];
+    [[ADTestAppSettings new] flushCodeCoverage];
 }
 
 - (void)saveContext

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
@@ -47,7 +47,7 @@ NSString* const sAADTestInstance = @"AAD Instance";
             NSLog(@"Bad data for the instance: '%@'. Contents: %@", instanceName, instanceData);
             continue;
         }
-        BVTestInstance* instance = [BVTestInstance getInstance:instanceData];
+        ADTestInstance* instance = [ADTestInstance getInstance:instanceData];
         [testAuthorities setObject:instance forKey:instanceName];
         break;
     }


### PR DESCRIPTION
#482 #315 

- Add notifications to allow developers to observe the web auth controller's behavior, and when broker calls out to app and comes back.
- Add an API to allow developers to retrieve a lost broker result (useful in App Resume situations, particularly around initial sign in)