### PR TITLE
Family of Client IDs

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -444,7 +444,6 @@
 		946818A81C59B80800CA0378 /* ADAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewController.m; sourceTree = "<group>"; };
 		94DD18C91C5A00BC00F80C62 /* ADAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewController.m; sourceTree = "<group>"; };
 		94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ADAL Mac Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		94DD18E51C5ACFBF00F80C62 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		94DD19011C5AD39A00F80C62 /* ADALiOSTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ADALiOSTests-Info.plist"; sourceTree = "<group>"; };
 		94DD19021C5AD39A00F80C62 /* ADBrokerKeyHelperTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADBrokerKeyHelperTests.m; sourceTree = "<group>"; };
 		94DD19031C5AD39A00F80C62 /* ADKeychainTokenCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADKeychainTokenCacheTests.m; sourceTree = "<group>"; };
@@ -520,7 +519,6 @@
 				8B0965AF17F25770002BDFB8 /* src */,
 				8B0965C317F25770002BDFB8 /* tests */,
 				9453C3151C57EE57006B9E79 /* resouces */,
-				94DD18E21C5ACFBF00F80C62 /* ADAL Mac Tests */,
 				8B0965AC17F25770002BDFB8 /* Frameworks */,
 				8B0965AB17F25770002BDFB8 /* Products */,
 			);
@@ -883,14 +881,6 @@
 				9453C4731C5874FB006B9E79 /* ADBrokerHelper.m */,
 			);
 			path = mac;
-			sourceTree = "<group>";
-		};
-		94DD18E21C5ACFBF00F80C62 /* ADAL Mac Tests */ = {
-			isa = PBXGroup;
-			children = (
-				94DD18E51C5ACFBF00F80C62 /* Info.plist */,
-			);
-			path = "ADAL Mac Tests";
 			sourceTree = "<group>";
 		};
 		94DD19001C5AD39A00F80C62 /* ios */ = {
@@ -2126,6 +2116,7 @@
 				94DD18EC1C5ACFBF00F80C62 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};

--- a/ADAL/src/ADOAuth2Constants.h
+++ b/ADAL/src/ADOAuth2Constants.h
@@ -54,6 +54,8 @@ extern NSString *const OAUTH2_SAML2_BEARER_VALUE;
 extern NSString *const OAUTH2_SCOPE_OPENID_VALUE;
 extern NSString *const OAUTH2_ASSERTION;
 
+extern NSString *const ADAL_CLIENT_FAMILY_ID;
+
 extern NSString *const BROKER_MAX_PROTOCOL_VERSION;
 extern NSString *const BROKER_MESSAGE_VERSION;
 extern NSString *const BROKER_RESPONSE_KEY;

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -54,6 +54,8 @@ NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 NSString *const OAUTH2_SCOPE_OPENID_VALUE = @"openid";
 
+NSString *const ADAL_CLIENT_FAMILY_ID = @"family";
+
 NSString *const BROKER_MAX_PROTOCOL_VERSION              = @"max_protocol_ver";
 
 NSString *const BROKER_MESSAGE_VERSION          = @"msg_protocol_ver";

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -54,7 +54,7 @@ NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 NSString *const OAUTH2_SCOPE_OPENID_VALUE = @"openid";
 
-NSString *const ADAL_CLIENT_FAMILY_ID = @"family";
+NSString *const ADAL_CLIENT_FAMILY_ID = @"fociu";
 
 NSString *const BROKER_MAX_PROTOCOL_VERSION              = @"max_protocol_ver";
 

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -54,7 +54,7 @@ NSString *const OAUTH2_SAML11_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:
 NSString *const OAUTH2_SAML2_BEARER_VALUE = @"urn:ietf:params:oauth:grant-type:saml2-bearer";
 NSString *const OAUTH2_SCOPE_OPENID_VALUE = @"openid";
 
-NSString *const ADAL_CLIENT_FAMILY_ID = @"fociu";
+NSString *const ADAL_CLIENT_FAMILY_ID = @"fid";
 
 NSString *const BROKER_MAX_PROTOCOL_VERSION              = @"max_protocol_ver";
 

--- a/ADAL/src/cache/ADAuthenticationContext+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationContext+TokenCaching.h
@@ -22,23 +22,26 @@
 
 //Checks the cache for item that can be used to get directly or indirectly an access token.
 //Checks the multi-resource refresh tokens too.
-- (ADTokenCacheItem*)findCacheItemWithKey:(ADTokenCacheKey*) key
-                                        userId:(ADUserIdentifier*)userId
-                                useAccessToken:(BOOL*) useAccessToken
-                                         error:(ADAuthenticationError* __autoreleasing*) error;
+- (ADTokenCacheItem*)findCacheItemWithKey:(ADTokenCacheKey *)key
+                                   userId:(ADUserIdentifier *)userId
+                                    error:(ADAuthenticationError * __autoreleasing *)error;
+
+- (ADTokenCacheItem *)findFamilyItemForUser:(ADUserIdentifier *)userIdentifier
+                                      error:(ADAuthenticationError * __autoreleasing *)error;
 
 //Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
 //the item to be stored.
-- (void)updateCacheToResult:(ADAuthenticationResult*)result
-                  cacheItem:(ADTokenCacheItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken;
-- (void)updateCacheToResult:(ADAuthenticationResult*)result
-              cacheInstance:(id<ADTokenCacheAccessor>)tokenCacheStoreInstance
-                  cacheItem:(ADTokenCacheItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken;
+- (void)updateCacheToResult:(ADAuthenticationResult *)result
+                  cacheItem:(ADTokenCacheItem *)cacheItem
+           withRefreshToken:(NSString *)refreshToken;
 
-- (ADTokenCacheItem*)extractCacheItemWithKey:(ADTokenCacheKey*)key
-                                           userId:(ADUserIdentifier*)userId
-                                            error:(ADAuthenticationError* __autoreleasing*)error;
+- (void)updateCacheToResult:(ADAuthenticationResult *)result
+              cacheInstance:(id<ADTokenCacheAccessor>)tokenCacheStoreInstance
+                  cacheItem:(ADTokenCacheItem *)cacheItem
+           withRefreshToken:(NSString *)refreshToken;
+
+- (ADTokenCacheItem *)extractCacheItemWithKey:(ADTokenCacheKey *)key
+                                       userId:(ADUserIdentifier *)userId
+                                        error:(ADAuthenticationError * __autoreleasing *)error;
 
 @end

--- a/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
@@ -116,6 +116,16 @@
 - (ADTokenCacheItem *)findFamilyItemForUser:(ADUserIdentifier *)userIdentifier
                                       error:(ADAuthenticationError * __autoreleasing *)error
 {
+    if (!userIdentifier)
+    {
+        return nil;
+    }
+    
+    if (!userIdentifier.userId)
+    {
+        return nil;
+    }
+    
     NSArray* items = [[self tokenCacheStore] getItemsWithKey:nil
                                                       userId:userIdentifier.userId
                                                        error:error];

--- a/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
@@ -29,8 +29,8 @@
 //Gets an item from the cache, where userId may be nil. Raises error, if items for multiple users
 //are present and user id is not specified.
 - (ADTokenCacheItem*)extractCacheItemWithKey:(ADTokenCacheKey*)key
-                                           userId:(ADUserIdentifier*)userId
-                                            error:(ADAuthenticationError* __autoreleasing*)error
+                                      userId:(ADUserIdentifier*)userId
+                                       error:(ADAuthenticationError* __autoreleasing*)error
 {
     if (!key || !self.tokenCacheStore)
     {
@@ -54,16 +54,15 @@
 
 //Checks the cache for item that can be used to get directly or indirectly an access token.
 //Checks the multi-resource refresh tokens too.
-- (ADTokenCacheItem*)findCacheItemWithKey:(ADTokenCacheKey*) key
-                                        userId:(ADUserIdentifier*)userId
-                                useAccessToken:(BOOL*) useAccessToken
-                                         error:(ADAuthenticationError* __autoreleasing*) error
+- (ADTokenCacheItem *)findCacheItemWithKey:(ADTokenCacheKey *) key
+                                    userId:(ADUserIdentifier *)userId
+                                     error:(ADAuthenticationError * __autoreleasing *)error
 {
     if (!key || !self.tokenCacheStore)
     {
         return nil;//Nothing to return
     }
-    ADAuthenticationError* localError;
+    ADAuthenticationError* localError = nil;
     ADTokenCacheItem* item = [self extractCacheItemWithKey:key userId:userId error:&localError];
     if (localError)
     {
@@ -71,27 +70,22 @@
         {
             *error = localError;
         }
-        return nil;//Quick return if an error was detected.
+        return nil;
     }
     
-    if (item)
+    if (item.accessToken && !item.isExpired)
     {
-        *useAccessToken = item.accessToken && !item.isExpired;
-        if (*useAccessToken)
-        {
-            return item;
-        }
-        else if (![NSString adIsStringNilOrBlank:item.refreshToken])
-        {
-            return item;//Suitable direct refresh token found.
-        }
-        else
-        {
-            //We have a cache item that cannot be used anymore, remove it from the cache:
-            [self.tokenCacheStore removeItem:item error:nil];
-        }
+        return item;
     }
-    *useAccessToken = false;//No item with suitable access token exists
+    
+    if (![NSString adIsStringNilOrBlank:item.refreshToken])
+    {
+        // Suitable direct refresh token found.
+        return item;
+    }
+    
+    // We have a cache item that cannot be used anymore, remove it from the cache:
+    [self.tokenCacheStore removeItem:item error:nil];
     
     if (![NSString adIsStringNilOrBlank:key.resource])
     {
@@ -117,6 +111,30 @@
         return broadItem;
     }
     return nil;//Nothing suitable
+}
+
+- (ADTokenCacheItem *)findFamilyItemForUser:(ADUserIdentifier *)userIdentifier
+                                      error:(ADAuthenticationError * __autoreleasing *)error
+{
+    NSArray* items = [[self tokenCacheStore] getItemsWithKey:nil
+                                                      userId:userIdentifier.userId
+                                                       error:error];
+    if (!items || items.count == 0)
+    {
+        return nil;
+    }
+    
+    for (ADTokenCacheItem* item in items)
+    {
+        if (![NSString adIsStringNilOrBlank:item.familyId] &&
+            ![NSString adIsStringNilOrBlank:item.refreshToken])
+        {
+            // Return the first item we see with a family ID and a RT
+            return item;
+        }
+    }
+    
+    return nil;
 }
 
 //Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains

--- a/ADAL/src/cache/ADTokenCacheAccessor.h
+++ b/ADAL/src/cache/ADTokenCacheAccessor.h
@@ -36,6 +36,19 @@
                                         error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
 /*!
+    @param key      The key of the item. May be nil, in which case all items that match
+                    other parameters will be returned.
+    @param userId   The specific user whose item is needed. May be nil, in which
+                    case the item for the first user in the cache will be returned.
+    @param error    Will be set only in case of ambiguity. E.g. if userId is nil
+                    and we have tokens from multiple users. If the cache item is not
+                    present, the error will not be set.
+ */
+- (nullable NSArray <ADTokenCacheItem *> *)getItemsWithKey:(nullable ADTokenCacheKey *)key
+                                                    userId:(nullable NSString *)userId
+                                                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*!
     Ensures the cache contains an item matching the passed in item, adding or updating the
     item as necessary.
     

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -197,6 +197,7 @@
     FILL_FIELD(accessToken, OAUTH2_ACCESS_TOKEN);
     FILL_FIELD(refreshToken, OAUTH2_REFRESH_TOKEN);
     FILL_FIELD(accessTokenType, OAUTH2_TOKEN_TYPE);
+    FILL_FIELD(familyId, ADAL_CLIENT_FAMILY_ID);
     
     [self fillExpiration:responseDictionary];
     

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -46,26 +46,28 @@
 
 //Multi-resource refresh tokens are stored separately, as they apply to all resources. As such,
 //we create a special, "broad" cache item, with nil resource and access token:
--(BOOL) isMultiResourceRefreshToken
+- (BOOL)isMultiResourceRefreshToken
 {
     return [NSString adIsStringNilOrBlank:self.resource]
         && [NSString adIsStringNilOrBlank:self.accessToken]
        && ![NSString adIsStringNilOrBlank:self.refreshToken];
 }
 
--(id) copyWithZone:(NSZone*) zone
+- (id)copyWithZone:(NSZone*) zone
 {
     ADTokenCacheItem* item = [[self.class allocWithZone:zone] init];
     
     item.resource = [self.resource copyWithZone:zone];
     item.authority = [self.authority copyWithZone:zone];
     item.clientId = [self.clientId copyWithZone:zone];
+    item.familyId = [self.familyId copyWithZone:zone];
     item.accessToken = [self.accessToken copyWithZone:zone];
     item.accessTokenType = [self.accessTokenType copyWithZone:zone];
     item.refreshToken = [self.refreshToken copyWithZone:zone];
     item.expiresOn = [self.expiresOn copyWithZone:zone];
     item.userInformation = [self.userInformation copyWithZone:zone];
     item.sessionKey = [self.sessionKey copyWithZone:zone];
+    
     
     return item;
 }
@@ -78,7 +80,7 @@
                                             error:error];
 }
 
--(BOOL) isExpired
+- (BOOL)isExpired
 {
     if (nil == self.expiresOn)
     {
@@ -89,7 +91,7 @@
     return [self.expiresOn compare:[NSDate dateWithTimeIntervalSinceNow:expirationBuffer]] == NSOrderedAscending;
 }
 
--(BOOL) isEmptyUser
+- (BOOL)isEmptyUser
 {
     //The userInformation object cannot be constructed with empty or blank string,
     //so its presence guarantees that the user is not empty:
@@ -97,7 +99,7 @@
 }
 
 /*! Verifies if the user (as defined by userId) is the same between the two items. */
--(BOOL) isSameUser: (ADTokenCacheItem*) other
+- (BOOL)isSameUser:(ADTokenCacheItem*) other
 {
     THROW_ON_NIL_ARGUMENT(other);
     
@@ -106,17 +108,18 @@
     return (nil != other.userInformation && [self.userInformation.userId isEqualToString:other.userInformation.userId]);
 }
 
-+(BOOL) supportsSecureCoding
++ (BOOL)supportsSecureCoding
 {
     return YES;
 }
 
 //Serializer:
--(void) encodeWithCoder:(NSCoder *)aCoder
+- (void) encodeWithCoder:(NSCoder *)aCoder
 {
     [aCoder encodeObject:self.resource forKey:@"resource"];
     [aCoder encodeObject:self.authority forKey:@"authority"];
     [aCoder encodeObject:self.clientId forKey:@"clientId"];
+    [aCoder encodeObject:self.familyId forKey:@"familyId"];
     [aCoder encodeObject:self.accessToken forKey:@"accessToken"];
     [aCoder encodeObject:self.accessTokenType forKey:@"accessTokenType"];
     [aCoder encodeObject:self.refreshToken forKey:@"refreshToken"];
@@ -126,7 +129,7 @@
 }
 
 //Deserializer:
--(id) initWithCoder:(NSCoder *)aDecoder
+- (id)initWithCoder:(NSCoder *)aDecoder
 {
     self = [super init];
     if (self)
@@ -134,6 +137,7 @@
         self.resource = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"resource"];
         self.authority = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"authority"];
         self.clientId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"clientId"];
+        self.familyId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"familyId"];
         self.accessToken = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"accessToken"];
         self.accessTokenType = [aDecoder decodeObjectOfClass:[NSString class]
                                                       forKey:@"accessTokenType"];

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -193,35 +193,6 @@ static NSString* const s_libraryString = @"MSOpenTech.ADAL." TOSTRING(KEYCHAIN_V
     return item;
 }
 
-- (NSArray<ADTokenCacheItem *> *)getItemsWithKey:(ADTokenCacheKey *)key
-                                               userId:(NSString *)userId
-                                                error:(ADAuthenticationError * __autoreleasing* )error
-{
-    NSArray* items = [self keychainItemsWithKey:key userId:userId error:error];
-    if (!items)
-    {
-        [self logItemRetrievalStatus:nil key:key userId:userId];
-        return nil;
-    }
-    
-    NSMutableArray* tokenItems = [[NSMutableArray<ADTokenCacheItem *> alloc] initWithCapacity:items.count];
-    SAFE_ARC_AUTORELEASE(tokenItems);
-    for (NSDictionary* attrs in items)
-    {
-        ADTokenCacheItem* item = [self itemFromKeyhainAttributes:attrs];
-        if (!item)
-        {
-            continue;
-        }
-        
-        [tokenItems addObject:item];
-    }
-    
-    [self logItemRetrievalStatus:tokenItems key:key userId:userId];
-    return tokenItems;
-    
-}
-
 #pragma mark -
 #pragma mark ADTokenCacheAccessor implementation
 
@@ -339,6 +310,35 @@ static NSString* const s_libraryString = @"MSOpenTech.ADAL." TOSTRING(KEYCHAIN_V
     }
     
     return query;
+}
+
+- (NSArray<ADTokenCacheItem *> *)getItemsWithKey:(ADTokenCacheKey *)key
+                                          userId:(NSString *)userId
+                                           error:(ADAuthenticationError * __autoreleasing* )error
+{
+    NSArray* items = [self keychainItemsWithKey:key userId:userId error:error];
+    if (!items)
+    {
+        [self logItemRetrievalStatus:nil key:key userId:userId];
+        return nil;
+    }
+    
+    NSMutableArray* tokenItems = [[NSMutableArray<ADTokenCacheItem *> alloc] initWithCapacity:items.count];
+    SAFE_ARC_AUTORELEASE(tokenItems);
+    for (NSDictionary* attrs in items)
+    {
+        ADTokenCacheItem* item = [self itemFromKeyhainAttributes:attrs];
+        if (!item)
+        {
+            continue;
+        }
+        
+        [tokenItems addObject:item];
+    }
+    
+    [self logItemRetrievalStatus:tokenItems key:key userId:userId];
+    return tokenItems;
+    
 }
 
 /*!

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -27,22 +27,25 @@
 @interface ADTokenCacheItem : NSObject<NSCopying , NSSecureCoding>
 
 /*! Applicable resource. Should be nil, in case the item stores multi-resource refresh token. */
-@property (retain) NSString* resource;
+@property (copy) NSString* resource;
 
-@property (retain) NSString* authority;
+@property (copy) NSString* authority;
 
-@property (retain) NSString* clientId;
+@property (copy) NSString* clientId;
+
+@property (copy) NSString* familyId;
 
 /*! The access token received. Should be nil, in case the item stores multi-resource refresh token. */
-@property (retain) NSString* accessToken;
+@property (copy) NSString* accessToken;
 
-@property (retain) NSString* accessTokenType;
+@property (copy) NSString* accessTokenType;
 
-@property (retain) NSString* refreshToken;
+@property (copy) NSString* refreshToken;
 
-@property (retain) NSData* sessionKey;
+@property (copy) NSData* sessionKey;
 
-@property (retain) NSDate* expiresOn;
+@property (copy) NSDate* expiresOn;
+
 
 @property (retain) ADUserInformation* userInformation;
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -81,7 +81,6 @@
     if (![ADAuthenticationContext isForcedAuthorization:_promptBehavior] && [_context hasCacheStore])
     {
         //Cache should be used in this case:
-        BOOL accessTokenUsable;
         ADTokenCacheItem* cacheItem = [_context findCacheItemWithKey:key
                                                               userId:_identifier
                                                                error:&error];
@@ -101,7 +100,7 @@
         ADTokenCacheItem* familyItem = [_context findFamilyItemForUser:_identifier error:&error];
         if (familyItem)
         {
-            [self attemptToUseCacheItem:cacheItem completionBlock:completionBlock];
+            [self attemptToUseCacheItem:familyItem completionBlock:completionBlock];
             return;
         }
     }

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -82,7 +82,9 @@
     {
         //Cache should be used in this case:
         BOOL accessTokenUsable;
-        ADTokenCacheItem* cacheItem = [_context findCacheItemWithKey:key userId:_identifier useAccessToken:&accessTokenUsable error:&error];
+        ADTokenCacheItem* cacheItem = [_context findCacheItemWithKey:key
+                                                              userId:_identifier
+                                                               error:&error];
         if (error)
         {
             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -92,10 +94,15 @@
         if (cacheItem)
         {
             //Found a promising item in the cache, try using it:
-            [self attemptToUseCacheItem:cacheItem
-                         useAccessToken:accessTokenUsable
-                        completionBlock:completionBlock];
+            [self attemptToUseCacheItem:cacheItem completionBlock:completionBlock];
             return; //The tryRefreshingFromCacheItem has taken care of the token obtaining
+        }
+        
+        ADTokenCacheItem* familyItem = [_context findFamilyItemForUser:_identifier error:&error];
+        if (familyItem)
+        {
+            [self attemptToUseCacheItem:cacheItem completionBlock:completionBlock];
+            return;
         }
     }
     
@@ -105,7 +112,6 @@
 /*Attemps to use the cache. Returns YES if an attempt was successful or if an
  internal asynchronous call will proceed the processing. */
 - (void)attemptToUseCacheItem:(ADTokenCacheItem*)item
-               useAccessToken:(BOOL)useAccessToken
               completionBlock:(ADAuthenticationCallback)completionBlock
 {
     //All of these should be set before calling this method:
@@ -116,7 +122,7 @@
     
     [self ensureRequest];
     
-    if (useAccessToken)
+    if (item.accessToken && !item.isExpired)
     {
         //Access token is good, just use it:
         [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
@@ -151,9 +157,8 @@
              ADTokenCacheKey* broadKey = [ADTokenCacheKey keyWithAuthority:_context.authority resource:nil clientId:_clientId error:nil];
              if (broadKey)
              {
-                 BOOL useAccessToken;
                  ADAuthenticationError* error;
-                 ADTokenCacheItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier useAccessToken:&useAccessToken error:&error];
+                 ADTokenCacheItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier error:&error];
                  if (error)
                  {
                      completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -172,7 +177,6 @@
                      
                      //Call recursively with the cache item containing a multi-resource refresh token:
                      [self attemptToUseCacheItem:broadItem
-                                  useAccessToken:NO
                                  completionBlock:completionBlock];
                      return;//The call above takes over, no more processing
                  }//broad item

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -79,6 +79,15 @@ typedef enum
                               newRefreshToken:(NSString *)newRefreshToken
                                newAccessToken:(NSString *)newAccessToken;
 
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                                correlationId:(NSUUID *)correlationId
+                              newRefreshToken:(NSString *)newRefreshToken
+                               newAccessToken:(NSString *)newAccessToken
+                             additionalFields:(NSDictionary *)additionalFields;
+
 /*! Verifies that the correct error is returned when any method was passed invalid arguments.
  */
 - (void)adValidateForInvalidArgument:(NSString *)argument

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -71,6 +71,14 @@ typedef enum
 - (ADTestURLResponse *)adDefaultRefreshResponse:(NSString *)newRefreshToken
                                     accessToken:(NSString *)newAccessToken;
 
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                                correlationId:(NSUUID *)correlationId
+                              newRefreshToken:(NSString *)newRefreshToken
+                               newAccessToken:(NSString *)newAccessToken;
+
 /*! Verifies that the correct error is returned when any method was passed invalid arguments.
  */
 - (void)adValidateForInvalidArgument:(NSString *)argument

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -502,12 +502,42 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
                               newRefreshToken:(NSString *)newRefreshToken
                                newAccessToken:(NSString *)newAccessToken
 {
+    return [self adResponseRefreshToken:oldRefreshToken
+                              authority:authority
+                               resource:resource
+                               clientId:clientId
+                          correlationId:correlationId
+                        newRefreshToken:newRefreshToken
+                         newAccessToken:newAccessToken
+                       additionalFields:nil];
+}
+
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                                correlationId:(NSUUID *)correlationId
+                              newRefreshToken:(NSString *)newRefreshToken
+                               newAccessToken:(NSString *)newAccessToken
+                             additionalFields:(NSDictionary *)additionalFields
+{
     NSString* requestUrlString = [NSString stringWithFormat:@"%@/oauth2/token?x-client-Ver=" ADAL_VERSION_STRING, authority];
     
     NSDictionary* headers = nil;
     if (correlationId)
     {
         headers = @{ OAUTH2_CORRELATION_ID_REQUEST_VALUE : [correlationId UUIDString] };
+    }
+    
+    NSDictionary* jsonBody = @{ OAUTH2_REFRESH_TOKEN : newRefreshToken,
+                                OAUTH2_ACCESS_TOKEN : newAccessToken,
+                                OAUTH2_RESOURCE : resource };
+    
+    if (additionalFields)
+    {
+        NSMutableDictionary* combinedDictionary = [NSMutableDictionary dictionaryWithDictionary:jsonBody];
+        [combinedDictionary addEntriesFromDictionary:additionalFields];
+        jsonBody = combinedDictionary;
     }
     
     ADTestURLResponse* response =
@@ -520,9 +550,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
                       responseURLString:@"https://contoso.com"
                            responseCode:400
                        httpHeaderFields:@{}
-                       dictionaryAsJSON:@{ OAUTH2_REFRESH_TOKEN : newRefreshToken,
-                                           OAUTH2_ACCESS_TOKEN : newAccessToken,
-                                           OAUTH2_RESOURCE : resource }];
+                       dictionaryAsJSON:jsonBody];
     
     return response;
 


### PR DESCRIPTION
#453 

Implementation of family-of-client-IDs as far as we understand it right now. ADAL_CLIENT_FAMILY_ID is a made up value for now until we get what the real key will be from the server guys.

This change caches the "family ID" that we get from the server, and when we try to acquire a token, and don't have an AT or RT for that client ID available we look through the cache for an item for that user tagged with a family ID.