### PR TITLE
Set endpoint ivar in ADClientMetrics if endpoint is ADFS - crash fix

### DIFF
--- a/ADALiOS/ADALiOS/ADClientMetrics.m
+++ b/ADALiOS/ADALiOS/ADClientMetrics.m
@@ -61,6 +61,7 @@ const NSString* HeaderLastEndpoint = @"x-client-last-endpoint";
     @synchronized(self)
     {
         if([ADHelpers isADFSInstance:endPoint]){
+            _endpoint = endPoint;
             return;
         }
         if(_isPending){

--- a/ADALiOS/ADALiOSTests/ADClientMetricsTests.m
+++ b/ADALiOS/ADALiOSTests/ADClientMetricsTests.m
@@ -47,4 +47,19 @@
     XCTAssertEqual([header count], 4);
 }
 
+-(void)testMetricsWithAdsfEndpointFollowedByNonAdsf {
+    ADClientMetrics* metrics = [ADClientMetrics new];
+    NSMutableDictionary* header = [NSMutableDictionary new];
+    
+    [metrics beginClientMetricsRecordForEndpoint:@"https://sts.concoso.com/adfs/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    [metrics endClientMetricsRecord:@"error"];
+    XCTAssertEqual([header count], 0);
+    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    XCTAssertEqual([header count], 0);
+    [metrics endClientMetricsRecord:@"error"];
+    XCTAssertEqual([header count], 0);
+    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    XCTAssertEqual([header count], 4);
+}
+
 @end


### PR DESCRIPTION
In production environments where ADFS is used for on-prem and exchange servers are online the first login after install would cause the application to crash.

This crash was caused by the fact that the endpoint was not set properly on the first authentication in beginClientMetricsRecordEndpoint:::, this would cause endClientMetricsRecord: to set the isPending flag and the next request would call beginClientMetricsRecordForEndpoint and crash when building the dictionary.

Added one test to cover this scenario.