### PR TITLE
Fix a case where we were passing in a NSString where we needed a NSUUID

### DIFF
--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -98,7 +98,7 @@
         BOOL isMrrt = [self fillItemWithResponse:response];
         return [ADAuthenticationResult resultFromTokenCacheItem:self
                                            multiResourceRefreshToken:isMrrt
-                                                       correlationId:[response objectForKey:OAUTH2_CORRELATION_ID_RESPONSE]];
+                                                       correlationId:requestCorrelationId];
     }
     else
     {

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -255,7 +255,7 @@ const int sAsyncContextTimeout = 10;
          XCTAssertNotNil(result.tokenCacheItem);
          XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, broadRefreshToken);
          XCTAssertEqualObjects(result.accessToken, anotherAccessToken);
-         XCTAssertEqualObjects(result.correlationId, correlationId.UUIDString);
+         XCTAssertEqualObjects(result.correlationId, correlationId);
          
          TEST_SIGNAL;
      }];
@@ -566,6 +566,7 @@ const int sAsyncContextTimeout = 10;
          XCTAssertNotNil(result);
          XCTAssertEqual(result.status, AD_SUCCEEDED);
          XCTAssertNotNil(result.tokenCacheItem);
+         XCTAssertTrue([result.correlationId isKindOfClass:[NSUUID class]]);
          XCTAssertEqualObjects(result.accessToken, @"new access token");
          
          TEST_SIGNAL;


### PR DESCRIPTION
Add a check on an acquireToken test, and fix a test that erroneously was checking EqualObjects with a string.