### PR TITLE
Disable tests that fail with no network connection

### DIFF
--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -1048,6 +1048,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil([mProtocolContext findCacheItemWithKey:key userId:item.userInformation.userId useAccessToken:&useAccessToken error:&error]);
 }
 
+#if TEST_HITS_NETWORK
 -(void) testBadAuthorityWithValidation
 {
     mAuthority = @"https://MyFakeAuthority.microsoft.com/MSOpenTechBV.OnMicrosoft.com";
@@ -1061,6 +1062,7 @@ const int sAsyncContextTimeout = 10;
     ADAssertLongEquals(AD_FAILED, mResult.status);
     ADAssertLongEquals(AD_ERROR_AUTHORITY_VALIDATION, mError.code);
 }
+#endif // TEST_HITS_NETWORK
 
 //Used when the framework needs to display an UI and cannot, raising an error
 -(void) validateUIError
@@ -1100,7 +1102,8 @@ const int sAsyncContextTimeout = 10;
     mPromptBehavior = AD_PROMPT_ALWAYS;
     [self validateUIError];
 }
- 
+
+#if TEST_HITS_NETWORK
 -(void) testBadRefreshToken
 {
     //Create a normal authority (not a test one):
@@ -1131,6 +1134,7 @@ const int sAsyncContextTimeout = 10;
     acquireTokenAsync;//Will attempt to use the broad refresh token and fail.
     ADAssertLongEquals(0, [self cacheCount]);
 }
+#endif // TEST_HITS_NETWORK
 
 //Creates the context with
 -(void) testUnreachableAuthority
@@ -1340,6 +1344,7 @@ const int sAsyncContextTimeout = 10;
 }
 
 //Hits a the cloud with either a bad server or a bad refresh token:
+#if TEST_HITS_NETWORK
 -(void) testRefreshingTokenWithServerErrors
 {
     [ADAuthenticationSettings sharedInstance].requestTimeOut = 5;
@@ -1366,5 +1371,6 @@ const int sAsyncContextTimeout = 10;
     ADAssertStringEquals(mResult.error.protocolCode, @"invalid_grant");
     XCTAssertTrue([mResult.error.errorDetails.lowercaseString adContainsString:@"refresh token"]);
 }
+#endif // TEST_HITS_NETWORK
 
 @end

--- a/ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m
+++ b/ADALiOS/ADALiOSTests/ADInstanceDiscoveryTests.m
@@ -394,6 +394,7 @@ const int sAsyncTimeout = 10;//in seconds
     ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.net/common?abc=123&vc=3"], authority);
 }
 
+#if TEST_HITS_NETWORK
 //Tests a real authority
 -(void) testNormalFlow
 {
@@ -419,7 +420,9 @@ const int sAsyncTimeout = 10;//in seconds
     XCTAssertTrue([mValidatedAuthorities containsObject:@"https://login.windows-ppe.net"]);
     settings.dispatchQueue = savedQueue;//Restore for the rest of the tests
 }
+#endif // TEST_HITS_NETWORK
 
+#if TEST_HITS_NETWORK
 //Ensures that an invalid authority is not approved
 -(void) testNonValidatedAuthority
 {
@@ -430,7 +433,9 @@ const int sAsyncTimeout = 10;//in seconds
     XCTAssertNotNil(mError);
     ADAssertLongEquals(AD_ERROR_AUTHORITY_VALIDATION, mError.code);
 }
+#endif // TEST_HITS_NETWORK
 
+#if TEST_HITS_NETWORK
 -(void) testUnreachableServer
 {
     [self adSetLogTolerance:ADAL_LOG_LEVEL_ERROR];
@@ -452,5 +457,6 @@ const int sAsyncTimeout = 10;//in seconds
     XCTAssertFalse(mValidated);
     XCTAssertNotNil(mError);
 }
+#endif // TEST_HITS_NETWORK
 
 @end


### PR DESCRIPTION
Randomly failing tests suck. It's better to not run them at all then be comfortable with a test failure not really being a test failure.