### PR TITLE
Rework the ADClientMetrics API.

### DIFF
--- a/ADALiOS/ADALiOS/ADClientMetrics.h
+++ b/ADALiOS/ADALiOS/ADClientMetrics.h
@@ -38,10 +38,12 @@
 
 + (ADClientMetrics*) getInstance;
 
-- (void) beginClientMetricsRecordForEndpoint: (NSString*) endPoint
-                               correlationId: (NSString*) correlationId
-                               requestHeader: (NSMutableDictionary*) requestHeader;
+- (void)addClientMetrics:(NSMutableDictionary *)requestHeaders
+                endpoint:(NSString *)endPoint;
 
--(void) endClientMetricsRecord: (NSString*) error;
+- (void)endClientMetricsRecord:(NSString *)endpoint
+                     startTime:(NSDate *)startTime
+                 correlationId:(NSUUID *)correlationId
+                  errorDetails:(NSString *)errorDetails;
 
 @end

--- a/ADALiOS/ADALiOS/ADInstanceDiscovery.m
+++ b/ADALiOS/ADALiOS/ADInstanceDiscovery.m
@@ -235,7 +235,9 @@ NSString* const sValidationServerError = @"The authority validation server retur
     webRequest.method = HTTPGet;
     [webRequest.headers setObject:@"application/json" forKey:@"Accept"];
     [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
-    [[ADClientMetrics getInstance] beginClientMetricsRecordForEndpoint:endPoint correlationId:[correlationId UUIDString] requestHeader:webRequest.headers];
+    
+    __block NSDate* startTime = [NSDate new];
+    [[ADClientMetrics getInstance] addClientMetrics:webRequest.headers endpoint:endPoint];
     
     [webRequest send:^( NSError *error, ADWebResponse *webResponse )
      {
@@ -314,11 +316,17 @@ NSString* const sValidationServerError = @"The authority validation server retur
          
          if(adError)
          {
-             [[ADClientMetrics getInstance] endClientMetricsRecord:[adError description]];
+             [[ADClientMetrics getInstance] endClientMetricsRecord:endPoint
+                                                         startTime:startTime
+                                                     correlationId:correlationId
+                                                      errorDetails:[adError errorDetails]];
          }
          else
          {
-             [[ADClientMetrics getInstance] endClientMetricsRecord:nil];
+             [[ADClientMetrics getInstance] endClientMetricsRecord:endPoint
+                                                         startTime:startTime
+                                                     correlationId:correlationId
+                                                      errorDetails:nil];
          }
          
          completionBlock( verified, adError );

--- a/ADALiOS/ADALiOSTests/ADClientMetricsTests.m
+++ b/ADALiOS/ADALiOSTests/ADClientMetricsTests.m
@@ -39,26 +39,46 @@
     
     ADClientMetrics* metrics = [ADClientMetrics new];
     NSMutableDictionary* header = [NSMutableDictionary new];
-
-    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
-    [metrics endClientMetricsRecord:@"error"];
+    
+    NSDate* startTime = [NSDate new];
+    [metrics addClientMetrics:header
+                     endpoint:@"https://login.windows.net/common/oauth2/token"];
+    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
+                          startTime:startTime
+                      correlationId:[NSUUID UUID]
+                       errorDetails:@"error"];
     XCTAssertEqual([header count], 0);
-    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    
+    [metrics addClientMetrics:header
+                     endpoint:@"https://login.windows.net/common/oauth2/token"];
     XCTAssertEqual([header count], 4);
 }
 
--(void)testMetricsWithAdsfEndpointFollowedByNonAdsf {
+- (void)testMetricsWithADFSEndpointFollowedByNonADFS
+{
     ADClientMetrics* metrics = [ADClientMetrics new];
     NSMutableDictionary* header = [NSMutableDictionary new];
     
-    [metrics beginClientMetricsRecordForEndpoint:@"https://sts.concoso.com/adfs/oauth2/token" correlationId:@"correlationId" requestHeader:header];
-    [metrics endClientMetricsRecord:@"error"];
+    NSDate* startTime = [NSDate new];
+    [metrics addClientMetrics:header
+                     endpoint:@"https://sts.contoso.com/adfs/oauth2/token"];
     XCTAssertEqual([header count], 0);
-    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    [metrics endClientMetricsRecord:@"https://sts.contoso.com/adfs/oauth2/token"
+                          startTime:startTime
+                      correlationId:[NSUUID UUID]
+                       errorDetails:@"error"];
+    
+    [metrics addClientMetrics:header
+                     endpoint:@"https://login.windows.net/common/oauth2/token"];
     XCTAssertEqual([header count], 0);
-    [metrics endClientMetricsRecord:@"error"];
-    XCTAssertEqual([header count], 0);
-    [metrics beginClientMetricsRecordForEndpoint:@"https://login.windows.net/common/oauth2/token" correlationId:@"correlationId" requestHeader:header];
+    
+    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
+                          startTime:startTime
+                      correlationId:[NSUUID UUID]
+                       errorDetails:@"error"];
+    
+    [metrics addClientMetrics:header
+                     endpoint:@"https://login.windows.net/common/oauth2/token"];
     XCTAssertEqual([header count], 4);
 }
 


### PR DESCRIPTION
We don't want to split setting data for different operations between the begin and end calls, because if multiple ADAL operations are happening at the same time the odds that we'll end up misreporting metrics between endpoints are fairly high. In this change we only set the metris data at the very end of the opertation, so in effect begin grabs any metrics data and clears it out, end sets the metrics data. If end gets hit multiple times before a begin we'll still end up dropping data though.