### PR TITLE
Protect correlationId with synchronization directive

### DIFF
--- a/ADALiOS/ADALiOS/ADLogger.m
+++ b/ADALiOS/ADALiOS/ADLogger.m
@@ -187,12 +187,18 @@ additionalInformation: (NSString*) additionalInformation
 
 +(void) setCorrelationId: (NSUUID*) correlationId
 {
-    requestCorrelationId = correlationId;
+    @synchronized(self)
+    {
+        requestCorrelationId = correlationId;
+    }
 }
 
 +(NSUUID*) getCorrelationId
 {
-    return requestCorrelationId;
+    @synchronized(self)
+    {
+        return requestCorrelationId;
+    }
 }
 
 


### PR DESCRIPTION
Mitigation for #364. We have a better fix in 2.1, but those changes are far too wide ranging to bring down to 1.2.x