### PR TITLE
Issues/dev/age out tombstones

### DIFF
--- a/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationContext+TokenCaching.m
@@ -156,10 +156,11 @@
     
     for (ADTokenCacheItem* item in items)
     {
-        if (![NSString adIsStringNilOrBlank:item.familyId] &&
+        if (![item tombstone] &&
+            ![NSString adIsStringNilOrBlank:item.familyId] &&
             ![NSString adIsStringNilOrBlank:item.refreshToken])
         {
-            // Return the first item we see with a family ID and a RT
+            // Return the first non-tombstone item we see with a family ID and a RT
             return item;
         }
     }

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -356,9 +356,27 @@
         {
             [itemsKept addObject:item];
         }
+        else
+        {
+            //tombstone will be deleted from cache store if it is too old
+            [self deleteTombstoneIfTooOld:item];
+        }
     }
     SAFE_ARC_AUTORELEASE(itemsKept);
     return itemsKept;
+}
+
+- (void)deleteTombstoneIfTooOld:(ADTokenCacheItem *)item
+{
+    if (!item)
+    {
+        return;
+    }
+    
+    if ([[item expiresOn] compare:[NSDate date]] == NSOrderedAscending)
+    {
+        [self removeItem:item error:nil];
+    }
 }
 
 @end

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -221,6 +221,9 @@
     
     //wipe out the refresh token
     _refreshToken = @"<tombstone>";
+    SAFE_ARC_RELEASE(_expiresOn);
+    _expiresOn = [NSDate dateWithTimeIntervalSinceNow:60*60*24*30];//tombstones should be removed after 30 days
+    SAFE_ARC_RETAIN(_expiresOn);
     _tombstone = tombstoneDictionary;
 
 }

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -34,6 +34,7 @@
 @implementation ADTokenCacheItem (Internal)
 
 #define CHECK_ERROR(_CHECK, _ERR) { if (_CHECK) { if (error) {*error = _ERR;} return; } }
+#define THIRTY_DAYS_IN_SECONDS 2592000
 
 - (void)checkCorrelationId:(NSDictionary*)response
       requestCorrelationId:(NSUUID*)requestCorrelationId
@@ -222,7 +223,7 @@
     //wipe out the refresh token
     _refreshToken = @"<tombstone>";
     SAFE_ARC_RELEASE(_expiresOn);
-    _expiresOn = [NSDate dateWithTimeIntervalSinceNow:60*60*24*30];//tombstones should be removed after 30 days
+    _expiresOn = [NSDate dateWithTimeIntervalSinceNow:THIRTY_DAYS_IN_SECONDS];//tombstones should be removed after 30 days
     SAFE_ARC_RETAIN(_expiresOn);
     _tombstone = tombstoneDictionary;
 

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -285,9 +285,27 @@ static NSString* const s_libraryString = @"MSOpenTech.ADAL." TOSTRING(KEYCHAIN_V
         {
             [itemsKept addObject:item];
         }
+        else
+        {
+            //tombstone will be deleted from cache store if it is too old
+            [self deleteTombstoneIfTooOld:item];
+        }
     }
     SAFE_ARC_AUTORELEASE(itemsKept);
     return itemsKept;
+}
+
+- (void)deleteTombstoneIfTooOld:(ADTokenCacheItem *)item
+{
+    if (!item)
+    {
+        return;
+    }
+    
+    if ([[item expiresOn] compare:[NSDate date]] == NSOrderedAscending)
+    {
+        [self deleteItem:item error:nil];
+    }
 }
 
 - (BOOL)removeAllForClientId:(NSString * __nonnull)clientId

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -69,12 +69,12 @@
 @property (retain) ADUserInformation* userInformation;
 
 /*!
- The item is a tombstone if this property if not nil;
+ The item is a tombstone if this property is not nil;
  The dictionary contains the following pairs:
  @"bundleId":Bundle ID of the app which tombstones the token.
  @"correlationId":correlation ID of the request that we got the error from.
  @"protocolCode":error code returned by the server for the rejected RT
-  @"errorDetails":error details of the rejected RT
+ @"errorDetails":error details of the rejected RT
  */
 - (NSDictionary*)tombstone;
 

--- a/ADAL/tests/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/ios/ADKeychainTokenCacheTests.m
@@ -457,37 +457,39 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
 //test the case where a tombstone is too old to stay in cache store
 - (void)testTombstoneAgingOut
 {
-    XCTAssertTrue([self count] == 0, "Start empty.");
+    XCTAssertTrue([self count] == 0, "There should be no token item in cache at start.");
+    XCTAssertTrue([self tombstoneCount] == 0, "There should be no tombstone item in cache at start.");
     
     ADAuthenticationError* error;
     XCTAssertNotNil([mStore allItems:&error]);
     ADAssertNoError;
     
-    //add a tombstone which is old enough
+    //add a tombstone
     ADTokenCacheItem* item1 = [self adCreateCacheItem:@"eric@contoso.com"];
     [item1 makeTombstone:nil];
-    [item1 setExpiresOn:[NSDate date]];// set the tombstone expire date as now
+    [item1 setExpiresOn:[NSDate dateWithTimeIntervalSinceNow:3600]];// set the tombstone's expire date as 1 hour later
     [mStore addOrUpdateItem:item1 correlationId:nil error:&error];
+    //the tombstone should remain in cache as it is not too old
     XCTAssertEqual([self tombstoneCount], 1);
+    XCTAssertEqual([self count], 0);
     
-    //deletion of old-enough tombstones is done on the back of the filtering function
-    //any method involving filtering tombstones will have the effect of deleting old tombstones
-    //E.g., [allitems:] will filter out tombstones and therefore old tombstones are deleted.
-    NSArray* all = [mStore allItems:nil];
-    (void) all;
-    XCTAssertEqual([self tombstoneCount], 0);
+    //add a tombstone which is old enough
+    ADTokenCacheItem* item2 = [self adCreateCacheItem:@"jack@contoso.com"];
+    [item2 makeTombstone:nil];
+    [item2 setExpiresOn:[NSDate date]];// set the tombstone expire date as now
+    [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
+    //the tombstone is too old and deleted. It won't be returned. Therefore there is still one tombstone in cache store.
+    XCTAssertEqual([self tombstoneCount], 1);
+    XCTAssertEqual([self count], 0);
     
     //add another item
-    ADTokenCacheItem* item2 = [self adCreateCacheItem:@"stan@contoso.com"];
-    [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
-    //make item2 a tombstone. It will expire after 30 days by default.
-    [mStore removeItem:item2 error:&error];
+    ADTokenCacheItem* item3 = [self adCreateCacheItem:@"stan@contoso.com"];
+    [mStore addOrUpdateItem:item3 correlationId:nil error:&error];
+    //make item3 a tombstone. It will expire after 30 days by default.
+    [mStore removeItem:item3 error:&error];
     ADAssertNoError;
-    XCTAssertEqual([self tombstoneCount], 1);
-    
-    //after calling [allItems:], tombstone for item2 should still remain in cache store as it is new.
-    [mStore allItems:nil];
-    XCTAssertEqual([self tombstoneCount], 1);
+    XCTAssertEqual([self tombstoneCount], 2);
+    XCTAssertEqual([self count], 0);
 }
 
 @end


### PR DESCRIPTION
addressing #523 

1. Changes are made to delete tombstones which are more than 30-day old.
Deletion of out-of-date tombstones is done on the back of the filtering function. Any method involving filtering tombstones will have the effect of deleting old tombstones. 
E.g., [ADKeychainTokenCache allitems: error:] will filter out tombstones and therefore old tombstones are deleted.

2. Unit test for tombstone aging out is added.

3. Fixed the issue that method [ADAuthenticationContext findFamilyItemForUser:] will return tombstone items.