### PR TITLE
Move TokenCaching category into AuthenticationRequest

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -67,7 +67,7 @@
 		9453C3441C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33D1C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m */; };
 		9453C3451C57FC2A006B9E79 /* ADTokenCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */; };
 		9453C34A1C5800E1006B9E79 /* ADPkeyAuthHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3491C5800E1006B9E79 /* ADPkeyAuthHelper.m */; };
-		9453C3551C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m */; };
+		9453C3551C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */; };
 		9453C35B1C580143006B9E79 /* ADRegistrationInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3561C580143006B9E79 /* ADRegistrationInformation.m */; };
 		9453C35C1C580143006B9E79 /* ADWorkPlaceJoin.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3571C580143006B9E79 /* ADWorkPlaceJoin.m */; };
 		9453C35D1C580143006B9E79 /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C35A1C580143006B9E79 /* ADWorkPlaceJoinUtil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -139,8 +139,8 @@
 		9453C41B1C586456006B9E79 /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
 		9453C41C1C586456006B9E79 /* ADClientMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A522511A1A89C4001D77CE /* ADClientMetrics.h */; };
 		9453C41D1C586456006B9E79 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
-		9453C41E1C586462006B9E79 /* ADAuthenticationContext+TokenCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3531C580123006B9E79 /* ADAuthenticationContext+TokenCaching.h */; };
-		9453C41F1C586462006B9E79 /* ADAuthenticationContext+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m */; };
+		9453C41E1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */; };
+		9453C41F1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */; };
 		9453C4201C586462006B9E79 /* ADTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3371C57FC2A006B9E79 /* ADTokenCache.m */; };
 		9453C4211C586462006B9E79 /* ADTokenCache+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3381C57FC2A006B9E79 /* ADTokenCache+Internal.h */; };
 		9453C4221C586462006B9E79 /* ADTokenCacheAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3391C57FC2A006B9E79 /* ADTokenCacheAccessor.h */; };
@@ -371,8 +371,8 @@
 		9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheKey.m; sourceTree = "<group>"; };
 		9453C3481C5800E1006B9E79 /* ADPkeyAuthHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADPkeyAuthHelper.h; sourceTree = "<group>"; };
 		9453C3491C5800E1006B9E79 /* ADPkeyAuthHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADPkeyAuthHelper.m; sourceTree = "<group>"; };
-		9453C3531C580123006B9E79 /* ADAuthenticationContext+TokenCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+TokenCaching.h"; sourceTree = "<group>"; };
-		9453C3541C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationContext+TokenCaching.m"; sourceTree = "<group>"; };
+		9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationRequest+TokenCaching.h"; sourceTree = "<group>"; };
+		9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationRequest+TokenCaching.m"; sourceTree = "<group>"; };
 		9453C3561C580143006B9E79 /* ADRegistrationInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADRegistrationInformation.m; sourceTree = "<group>"; };
 		9453C3571C580143006B9E79 /* ADWorkPlaceJoin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoin.m; sourceTree = "<group>"; };
 		9453C3581C580143006B9E79 /* ADWorkPlaceJoinConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWorkPlaceJoinConstants.h; sourceTree = "<group>"; };
@@ -720,8 +720,8 @@
 		9453C3181C57FB91006B9E79 /* cache */ = {
 			isa = PBXGroup;
 			children = (
-				9453C3531C580123006B9E79 /* ADAuthenticationContext+TokenCaching.h */,
-				9453C3541C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m */,
+				9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */,
+				9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */,
 				9453C3371C57FC2A006B9E79 /* ADTokenCache.m */,
 				9453C3381C57FC2A006B9E79 /* ADTokenCache+Internal.h */,
 				9453C3391C57FC2A006B9E79 /* ADTokenCacheAccessor.h */,
@@ -1006,7 +1006,7 @@
 				9453C43C1C58647E006B9E79 /* ADALFrameworkUtils.h in Headers */,
 				9453C4341C58646D006B9E79 /* ADWebResponse.h in Headers */,
 				94DD18D61C5AC8DE00F80C62 /* ADLogger.h in Headers */,
-				9453C41E1C586462006B9E79 /* ADAuthenticationContext+TokenCaching.h in Headers */,
+				9453C41E1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.h in Headers */,
 				94DD18D71C5AC8DE00F80C62 /* ADTokenCacheItem.h in Headers */,
 				9453C4321C58646D006B9E79 /* ADWebRequest.h in Headers */,
 				9453C4301C58646D006B9E79 /* ADAuthenticationRequest+WebRequest.h in Headers */,
@@ -1232,7 +1232,7 @@
 				9453C39E1C5826F2006B9E79 /* ADURLProtocol.m in Sources */,
 				9453C35D1C580143006B9E79 /* ADWorkPlaceJoinUtil.m in Sources */,
 				9453C46D1C5872AD006B9E79 /* ADJwtHelper.m in Sources */,
-				9453C3551C580123006B9E79 /* ADAuthenticationContext+TokenCaching.m in Sources */,
+				9453C3551C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */,
 				9453C39D1C5826F2006B9E79 /* ADNTLMHandler.m in Sources */,
 				9453C3911C5820E3006B9E79 /* ADAuthenticationRequest+Broker.m in Sources */,
 				9453C3441C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m in Sources */,
@@ -1336,7 +1336,7 @@
 				9453C40A1C586456006B9E79 /* ADAuthenticationError.m in Sources */,
 				9453C4451C58647E006B9E79 /* NSString+ADHelperMethods.m in Sources */,
 				9453C46E1C5872B0006B9E79 /* ADJwtHelper.m in Sources */,
-				9453C41F1C586462006B9E79 /* ADAuthenticationContext+TokenCaching.m in Sources */,
+				9453C41F1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */,
 				9453C4471C58647E006B9E79 /* NSURL+ADExtensions.m in Sources */,
 				9453C4111C586456006B9E79 /* ADAuthenticationSettings.m in Sources */,
 				9453C4651C58707B006B9E79 /* ADCredentialCollectionController.m in Sources */,

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -34,8 +34,8 @@
 // Framework versions only support high and low for the double value, sadly.
 #define ADAL_VERSION_NUMBER 2.1
 
-#define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH "-beta.2"
-#define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH "-beta.2"
+#define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH "-beta.3"
+#define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH "-beta.3"
 
 #import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"

--- a/ADAL/src/ADAuthenticationContext+Internal.h
+++ b/ADAL/src/ADAuthenticationContext+Internal.h
@@ -39,7 +39,6 @@
 @class ADUserIdentifier;
 
 #import "ADAuthenticationContext.h"
-#import "ADAuthenticationContext+TokenCaching.h"
 #import "ADAuthenticationResult+Internal.h"
 #import "ADOAuth2Constants.h"
 #import "ADTokenCacheAccessor.h"

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -62,7 +62,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 @synthesize validateAuthority = _validateAuthority;
 @synthesize correlationId = _correlationId;
 @synthesize credentialsType = _credentialsType;
-@synthesize component = _component;
+@synthesize logComponent = _logComponent;
 @synthesize webView = _webView;
 
 - (id)init
@@ -272,12 +272,12 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 #define REQUEST_WITH_REDIRECT_STRING(_redirect, _clientId, _resource) \
     ADAuthenticationRequest* request = [self requestWithRedirectString:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
-    [request setComponent:_component];
+    [request setLogComponent:_logComponent];
 
 #define REQUEST_WITH_REDIRECT_URL(_redirect, _clientId, _resource) \
     ADAuthenticationRequest* request = [self requestWithRedirectUrl:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
-    [request setComponent:_component];
+    [request setLogComponent:_logComponent];
 
 - (void)acquireTokenForAssertion:(NSString*)assertion
                    assertionType:(ADAssertionType)assertionType

--- a/ADAL/src/ADAuthenticationError.m
+++ b/ADAL/src/ADAuthenticationError.m
@@ -93,7 +93,7 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
     
     if (!quiet)
     {
-        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code:%lu ProtocolCode: \"%@\" Details: \"%@\"", domain, (long)code, protocolCode, details];
+        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code: %lu ProtocolCode: \"%@\" Details: \"%@\"", domain, (long)code, protocolCode, details];
         NSDictionary* logDict = nil;
         if (correlationId)
         {

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -29,11 +29,9 @@
 //Checks the multi-resource refresh tokens too.
 - (ADTokenCacheItem*)findCacheItemWithKey:(ADTokenCacheKey *)key
                                    userId:(ADUserIdentifier *)userId
-                            correlationId:(NSUUID *)correlationId
                                     error:(ADAuthenticationError * __autoreleasing *)error;
 
 - (ADTokenCacheItem *)findFamilyItemForUser:(ADUserIdentifier *)userIdentifier
-                              correlationId:(NSUUID *)correlationId
                                       error:(ADAuthenticationError * __autoreleasing *)error;
 
 /*!
@@ -43,12 +41,12 @@
     @param result       The result to update the cache to
     @param refreshToken The refresh token (if anything) that was used to get this authentication result
  */
-- (void)updateCacheToResult:(ADAuthenticationResult*)result
-               refreshToken:(NSString*)refreshToken;
+- (void)updateCacheToResult:(ADAuthenticationResult *)result
+                  cacheItem:(ADTokenCacheItem *)cacheItem
+               refreshToken:(NSString *)refreshToken;
 
 - (ADTokenCacheItem *)extractCacheItemWithKey:(ADTokenCacheKey *)key
                                        userId:(ADUserIdentifier *)userId
-                                correlationId:(NSUUID *)correlationId
                                         error:(ADAuthenticationError * __autoreleasing *)error;
 
 @end

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -36,17 +36,15 @@
                               correlationId:(NSUUID *)correlationId
                                       error:(ADAuthenticationError * __autoreleasing *)error;
 
-//Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
-//the item to be stored.
+/*!
+    Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
+    the item to be stored.
+ 
+    @param result       The result to update the cache to
+    @param refreshToken The refresh token (if anything) that was used to get this authentication result
+ */
 - (void)updateCacheToResult:(ADAuthenticationResult*)result
-                  cacheItem:(ADTokenCacheItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken
-       requestCorrelationId:(NSUUID*)requestCorrelationId;
-- (void)updateCacheToResult:(ADAuthenticationResult*)result
-              cacheInstance:(id<ADTokenCacheAccessor>)tokenCacheStoreInstance
-                  cacheItem:(ADTokenCacheItem*)cacheItem
-           withRefreshToken:(NSString*)refreshToken
-       requestCorrelationId:(NSUUID*)requestCorrelationId;
+               refreshToken:(NSString*)refreshToken;
 
 - (ADTokenCacheItem *)extractCacheItemWithKey:(ADTokenCacheKey *)key
                                        userId:(ADUserIdentifier *)userId

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -23,7 +23,7 @@
 
 #import "ADTokenCacheAccessor.h"
 
-@interface ADAuthenticationContext (TokenCaching)
+@interface ADAuthenticationRequest (TokenCaching)
 
 //Checks the cache for item that can be used to get directly or indirectly an access token.
 //Checks the multi-resource refresh tokens too.

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
@@ -29,7 +29,7 @@
 #import "ADTokenCacheKey.h"
 #import "ADUserInformation.h"
 
-@implementation ADAuthenticationContext (TokenCaching)
+@implementation ADAuthenticationRequest (TokenCaching)
 
 //Gets an item from the cache, where userId may be nil. Raises error, if items for multiple users
 //are present and user id is not specified.

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -120,7 +120,7 @@ typedef enum
     NSString* _authority;
     BOOL _validateAuthority;
     ADCredentialsType _credentialsType;
-    NSString* _component;
+    NSString* _logComponent;
     NSUUID* _correlationId;
     __weak WebViewType* _webView;
 }
@@ -253,7 +253,7 @@ typedef enum
 
 /*! The name of the component using this authentication context. Used in some logging and telemetry
     for clarification purposes. */
-@property (retain) NSString* component;
+@property (retain) NSString* logComponent;
 
 #if TARGET_OS_IPHONE
 /*! The parent view controller for the authentication view controller UI. This property will be used only if

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
@@ -83,10 +83,9 @@
     if ([_context hasCacheStore])
     {
         //Cache should be used in this case:
-        ADTokenCacheItem* cacheItem = [_context findCacheItemWithKey:key
-                                                              userId:_identifier
-                                                       correlationId:_correlationId
-                                                               error:&error];
+        ADTokenCacheItem* cacheItem = [self findCacheItemWithKey:key
+                                                          userId:_identifier
+                                                           error:&error];
         if (error)
         {
             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -110,7 +109,7 @@
     {
         if (result.status == AD_SUCCEEDED)
         {
-            [_context updateCacheToResult:result cacheItem:nil withRefreshToken:nil requestCorrelationId:_correlationId];
+            [self updateCacheToResult:result cacheItem: nil refreshToken:nil];
         }
         
         completionBlock(result);
@@ -167,7 +166,7 @@
              if (broadKey)
              {
                  ADAuthenticationError* error = nil;
-                 ADTokenCacheItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier correlationId:_correlationId error:&error];
+                 ADTokenCacheItem* broadItem = [self findCacheItemWithKey:broadKey userId:_identifier error:&error];
                  if (error)
                  {
                      completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -202,7 +201,7 @@
           {
               if (result.status == AD_SUCCEEDED)
               {
-                  [_context updateCacheToResult:result cacheItem:nil withRefreshToken:nil requestCorrelationId:_correlationId];
+                  [self updateCacheToResult:result cacheItem:nil refreshToken:nil];
               }
               
               completionBlock(result);

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -86,10 +86,9 @@
     if (![ADAuthenticationContext isForcedAuthorization:_promptBehavior] && [_context hasCacheStore])
     {
         //Cache should be used in this case:
-        ADTokenCacheItem* cacheItem = [_context findCacheItemWithKey:key
-                                                              userId:_identifier
-                                                       correlationId:_correlationId
-                                                               error:&error];
+        ADTokenCacheItem* cacheItem = [self findCacheItemWithKey:key
+                                                          userId:_identifier
+                                                           error:&error];
         if (!cacheItem && error)
         {
             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -103,7 +102,7 @@
             return; //The tryRefreshingFromCacheItem has taken care of the token obtaining
         }
         
-        ADTokenCacheItem* familyItem = [_context findFamilyItemForUser:_identifier correlationId:_correlationId error:&error];
+        ADTokenCacheItem* familyItem = [self findFamilyItemForUser:_identifier error:&error];
         if (familyItem)
         {
             [self attemptToUseCacheItem:familyItem completionBlock:completionBlock];
@@ -163,7 +162,7 @@
              if (broadKey)
              {
                  ADAuthenticationError* error;
-                 ADTokenCacheItem* broadItem = [_context findCacheItemWithKey:broadKey userId:_identifier correlationId:_correlationId error:&error];
+                 ADTokenCacheItem* broadItem = [self findCacheItemWithKey:broadKey userId:_identifier error:&error];
                  if (!broadItem && error)
                  {
                      completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
@@ -254,7 +253,7 @@
                   {
                       if (AD_SUCCEEDED == result.status)
                       {
-                          [_context updateCacheToResult:result cacheItem:nil withRefreshToken:nil requestCorrelationId:_correlationId];
+                          [self updateCacheToResult:result cacheItem:nil refreshToken:nil];
                           result = [ADAuthenticationContext updateResult:result toUser:_identifier];
                       }
                       completionBlock(result);
@@ -359,10 +358,9 @@
          ADAuthenticationResult *result = [resultItem processTokenResponse:response fromRefresh:YES requestCorrelationId:_correlationId];
          if (cacheItem)//The request came from the cache item, update it:
          {
-             [_context updateCacheToResult:result
-                                 cacheItem:resultItem
-                          withRefreshToken:refreshToken
-                      requestCorrelationId:_correlationId];
+             [self updateCacheToResult:result
+                             cacheItem:resultItem
+                          refreshToken:refreshToken];
          }
          result = [ADAuthenticationContext updateResult:result toUser:_identifier];//Verify the user (just in case)
          //

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -142,14 +142,9 @@
     
     if (AD_SUCCEEDED == result.status)
     {
-        ADAuthenticationContext* ctx = [ADAuthenticationContext
-                                        authenticationContextWithAuthority:result.tokenCacheItem.authority
-                                        error:nil];
+        ADAuthenticationRequest* req = [ADAuthenticationRequest requestWithAuthority:result.tokenCacheItem.authority];
         
-        [ctx updateCacheToResult:result
-                       cacheItem:nil
-                withRefreshToken:nil
-            requestCorrelationId:nil];
+        [req updateCacheToResult:result cacheItem:nil refreshToken:nil];
         
         NSString* userId = [[[result tokenCacheItem] userInformation] userId];
         [ADAuthenticationContext updateResult:result

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -65,12 +65,17 @@
     BOOL _allowSilent;
     
     NSUUID* _correlationId;
-    NSString* _component;
+    NSString* _logComponet;
     
     BOOL _requestStarted;
 }
 
-@property (retain) NSString* component;
+@property (retain) NSString* logComponent;
+
+// These constructors exists *solely* to be used when trying to use some of the caching logic.
+// You can't actually send requests with it. They will fail.
++ (ADAuthenticationRequest *)requestWithAuthority:(NSString *)authority;
++ (ADAuthenticationRequest *)requestWithContext:(ADAuthenticationContext *)context;
 
 // The default constructor. All of the parameters are mandatory
 + (ADAuthenticationRequest*)requestWithContext:(ADAuthenticationContext*)context
@@ -105,3 +110,4 @@
 #import "ADAuthenticationRequest+AcquireToken.h"
 #import "ADAuthenticationRequest+Broker.h"
 #import "ADAuthenticationRequest+WebRequest.h"
+#import "ADAuthenticationRequest+TokenCaching.h"

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -65,7 +65,7 @@
     BOOL _allowSilent;
     
     NSUUID* _correlationId;
-    NSString* _logComponet;
+    NSString* _logComponent;
     
     BOOL _requestStarted;
 }

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -38,7 +38,7 @@
 
 @implementation ADAuthenticationRequest
 
-@synthesize component = _component;
+@synthesize logComponent = _logComponent;
 
 #define RETURN_IF_NIL(_X) { if (!_X) { AD_LOG_ERROR(@#_X " must not be nil!", AD_FAILED, nil, nil); SAFE_ARC_RELEASE(self); return nil; } }
 #define ERROR_RETURN_IF_NIL(_X) { \
@@ -50,6 +50,26 @@
     } \
 }
 
++ (ADAuthenticationRequest *)requestWithAuthority:(NSString *)authority
+{
+    ADAuthenticationContext* context = [[ADAuthenticationContext alloc] initWithAuthority:authority validateAuthority:NO error:nil];
+    
+    return [self requestWithContext:context];
+}
+
++ (ADAuthenticationRequest *)requestWithContext:(ADAuthenticationContext *)context
+{
+    ADAuthenticationRequest* request = [[ADAuthenticationRequest alloc] init];
+    if (!request)
+    {
+        return nil;
+    }
+    SAFE_ARC_AUTORELEASE(request);
+    
+    request->_context = context;
+    
+    return request;
+}
 
 + (ADAuthenticationRequest*)requestWithContext:(ADAuthenticationContext*)context
                                    redirectUri:(NSString*)redirectUri

--- a/ADAL/tests/ADAuthenticationContextTests.m
+++ b/ADAL/tests/ADAuthenticationContextTests.m
@@ -28,6 +28,7 @@
 #import "ADTokenCache+Internal.h"
 #import "ADTokenCacheItem+Internal.h"
 #import "ADUserIdentifier.h"
+#import "ADAuthenticationRequest.h"
 
 #define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
 
@@ -180,7 +181,9 @@
     XCTAssertTrue([[context tokenCacheStore] addOrUpdateItem:familyItem correlationId:nil error:&error]);
     XCTAssertNil(error);
     
-    ADTokenCacheItem* foundItem = [context findFamilyItemForUser:[ADUserIdentifier identifierWithId:TEST_USER_ID] correlationId:nil error:&error];
+    ADAuthenticationRequest* req = [ADAuthenticationRequest requestWithContext:context];
+    
+    ADTokenCacheItem* foundItem = [req findFamilyItemForUser:[ADUserIdentifier identifierWithId:TEST_USER_ID] error:&error];
     XCTAssertNotNil(foundItem);
     XCTAssertEqualObjects(familyItem, foundItem);
 }

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestMainViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestMainViewController.m
@@ -186,7 +186,7 @@ static NSString* _StringForLevel(ADAL_LOG_LEVEL level)
                                                         validateAuthority:mAADInstance.validateAuthority
                                                                     error:&error];
     [context setCredentialsType:AD_CREDENTIALS_AUTO];
-    [context setComponent:@"end-to-end"];
+    [context setLogComponent:@"end-to-end"];
     if (!context)
     {
         [self appendToResults:error.errorDetails];


### PR DESCRIPTION
When I created ADAuthenticationRequest I did it almost entirely off of categories that I had separated out from ADAuthenticationContext and then switched the classes of. I had left TokenCaching alone at the time because it appeared to dip into properties of the authentication context too much. Now with some of the logging changes I want to make, and some of the changes we've already made regarding correlation IDs, it makes sense to move it into ADAuthenticationRequest as well.