### PR TITLE
Bug fixed for ADAL crash when developers set their own UIWebView

### DIFF
--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -79,10 +79,14 @@ NSString* const ADRedirectUriInvalidError = @"Redirect URI cannot be used to inv
     {
         NSString* errorDetails = [dictionary objectForKey:OAUTH2_ERROR_DESCRIPTION];
         // Error response from the server
+        NSUUID* correlationId = [dictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE] ?
+                                [[NSUUID alloc] initWithUUIDString:[dictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE]]:
+                                nil;
+        SAFE_ARC_AUTORELEASE(correlationId);
         return [ADAuthenticationError errorFromAuthenticationError:errorCode
                                                       protocolCode:serverOAuth2Error
                                                       errorDetails:(errorDetails) ? errorDetails : [NSString stringWithFormat:ADServerError, serverOAuth2Error]
-                                                     correlationId:[dictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE]];
+                                                     correlationId:correlationId];
     }
     //In the case of more generic error, e.g. server unavailable, DNS error or no internet connection, the error object will be directly placed in the dictionary:
     return [dictionary objectForKey:AUTH_NON_PROTOCOL_ERROR];

--- a/ADAL/src/ui/ios/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/ios/ADAuthenticationViewController.m
@@ -108,6 +108,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 -(void)dealloc
 {
     [_webView setDelegate:nil];
+    _webView = nil;
 }
 
 #pragma mark - UIViewController Methods

--- a/ADAL/src/ui/ios/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/ios/ADAuthenticationViewController.m
@@ -103,6 +103,13 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
     return NO;
 }
 
+/*! set webview's delegate to nil when the view controller 
+    is deallocated, or it might crash ADAL. */
+-(void)dealloc
+{
+    [_webView setDelegate:nil];
+}
+
 #pragma mark - UIViewController Methods
 
 - (void)viewDidLoad
@@ -144,7 +151,16 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 
 - (void)stop:(void (^)(void))completion
 {
-    [_parentController dismissViewControllerAnimated:YES completion:completion];
+    //if webview is created by us, dismiss and then complete and return;
+    //otherwise just complete and return.
+    if (_parentController)
+    {
+        [_parentController dismissViewControllerAnimated:YES completion:completion];
+    }
+    else
+    {
+        completion();
+    }
     
     _parentController = nil;
     _delegate = nil;

--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -124,6 +124,15 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     return YES;
 }
 
+-(void)dealloc
+{
+    [_webView setFrameLoadDelegate:nil];
+    [_webView setResourceLoadDelegate:nil];
+    [_webView setPolicyDelegate:nil];
+    _webView = nil;
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
 #pragma mark - UIViewController Methods
 
 #pragma mark - Event Handlers


### PR DESCRIPTION
 Bug fixes for #539, #541 and #538 

1) ADAL crashes when developers set their own UIWebView because the webview's delegate property hasn't been nil out when webview controller is deallocated.

2) Fix has been made for the bug that developers' own UIWebView fails to return after completion.

3) Fixed a place where NSString* is passed in as CorrelationId but NSUUID* is expected.