### PR TITLE
Removed Client ID from scope in request.

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -164,11 +164,9 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
     
     RETURN_IF_NOT_NIL([self validateScopes:lowercaseScopes additional:NO]);
     
-    if (![lowercaseScopes containsObject:_clientId])
-    {
-        [lowercaseScopes addObject:@"openid"];
-        [lowercaseScopes addObject:@"offline_access"];
-    }
+    [lowercaseScopes removeObject:_clientId];
+    [lowercaseScopes addObject:@"openid"];
+    [lowercaseScopes addObject:@"offline_access"];
     
     _scopes = [NSSet setWithArray:lowercaseScopes];
     


### PR DESCRIPTION
(Fix for #543)

Previously, If client ID is in the scope, we keep it in scope and won't add "openid"/"offline_access".

Now we change it:
Client ID will always removed from scope (if any); "openid" and "offline_access" will be added to scope.