### PR TITLE
Removed invalid characters from the PRODUCT_BUNDLE_IDENTIFIER

### DIFF
--- a/ADAL/xcconfig/adal__mac__framework.xcconfig
+++ b/ADAL/xcconfig/adal__mac__framework.xcconfig
@@ -4,7 +4,7 @@
 
 #include "adal__mac__common.xcconfig"
 
-PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.ADAL";
+PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.ADAL;
 PRODUCT_NAME = ADAL;
 MODULEMAP_FILE = resources/mac/adal_mac.modulemap;
 DEFINES_MODULE = YES;


### PR DESCRIPTION
The PRODUCT_BUNDLE_IDENTIFIER was set to a value with quotes in the
xcconfig. This is not allowed by xcodebuild and will cause codesign to
fail as well.