### PR TITLE
Fix build errors when using Xcode 7.3 beta

### DIFF
--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -143,10 +143,10 @@ AD_LOG_VERBOSE(__adalVersion, nil, __where); \
 
 #if __has_feature(objc_arc)
 #   define SAFE_ARC_PROP_RETAIN strong
-#   define SAFE_ARC_RETAIN(x) (x)
+#   define SAFE_ARC_RETAIN(x)
 #   define SAFE_ARC_RELEASE(x)
-#   define SAFE_ARC_AUTORELEASE(x) (x)
-#   define SAFE_ARC_BLOCK_COPY(x) (x)
+#   define SAFE_ARC_AUTORELEASE(x)
+#   define SAFE_ARC_BLOCK_COPY(x)
 #   define SAFE_ARC_BLOCK_RELEASE(x)
 #   define SAFE_ARC_SUPER_DEALLOC()
 #   define SAFE_ARC_AUTORELEASE_POOL_START() @autoreleasepool {

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -148,8 +148,14 @@
     API_ENTRY;
     
     NSDictionary* params = [self extractChallengeParameters:authenticateHeader error:error];
-    return params ? SAFE_ARC_AUTORELEASE([[ADAuthenticationParameters alloc] initInternalWithParameters:params error:error])
-                  : nil;
+    if (!params)
+    {
+        return nil;
+    }
+    
+    ADAuthenticationParameters *parameters = [[ADAuthenticationParameters alloc] initInternalWithParameters:params error:error];
+    SAFE_ARC_AUTORELEASE(parameters);
+    return parameters;
 }
 
 

--- a/ADAL/src/ADInstanceDiscovery.m
+++ b/ADAL/src/ADInstanceDiscovery.m
@@ -216,7 +216,9 @@ static NSString* const sValidationServerError = @"The authority validation serve
     if (!(code == 200 || code == 400 || code == 401))
     {
         NSString* logMessage = [NSString stringWithFormat:@"Server HTTP Status %ld", (long)webResponse.statusCode];
-        NSString* errorData = [NSString stringWithFormat:@"Server HTTP Response %@", SAFE_ARC_AUTORELEASE([[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding])];
+        NSString* responseBodyString = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
+        SAFE_ARC_AUTORELEASE(responseBodyString);
+        NSString* errorData = [NSString stringWithFormat:@"Server HTTP Response %@", responseBodyString];
         AD_LOG_WARN(logMessage, correlationId, errorData);
         return [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_AUTHORITY_VALIDATION protocolCode:nil errorDetails:errorData correlationId:correlationId];
     }

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -122,7 +122,11 @@ typedef enum
     ADCredentialsType _credentialsType;
     NSString* _logComponent;
     NSUUID* _correlationId;
+#if __has_feature(objc_arc)
     __weak WebViewType* _webView;
+#else 
+    WebViewType* _webView;
+#endif
 }
 
 #if TARGET_OS_IPHONE

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -80,7 +80,9 @@
     ERROR_RETURN_IF_NIL(context);
     ERROR_RETURN_IF_NIL(clientId);
     
-    return SAFE_ARC_AUTORELEASE([[ADAuthenticationRequest alloc] initWithContext:context redirectUri:redirectUri clientId:clientId resource:resource]);
+    ADAuthenticationRequest *request = [[ADAuthenticationRequest alloc] initWithContext:context redirectUri:redirectUri clientId:clientId resource:resource];
+    SAFE_ARC_AUTORELEASE(request);
+    return request;
 }
 
 - (id)initWithContext:(ADAuthenticationContext*)context

--- a/ADAL/src/ui/ADAuthenticationViewController.h
+++ b/ADAL/src/ui/ADAuthenticationViewController.h
@@ -23,6 +23,12 @@
 
 @protocol ADWebAuthDelegate;
 
+#if __has_feature(objc_arc)
+#   define SAFE_ARC_IVAR_WEAK __weak
+#else
+#   define SAFE_ARC_IVAR_WEAK
+#endif
+
 @interface ADAuthenticationViewController :
 #if TARGET_OS_IPHONE
 UIViewController
@@ -31,9 +37,9 @@ NSWindowController
 {
     // In the legacy ObjC runtime (which is what we're stuck at for 32-bit Mac builds)
     // you can't define the ivars of a class in the implementation file.
-    __weak id<ADWebAuthDelegate> _delegate;
-    __weak WebViewType* _webView;
-    __weak NSProgressIndicator* _progressIndicator;
+    SAFE_ARC_IVAR_WEAK id<ADWebAuthDelegate> _delegate;
+    SAFE_ARC_IVAR_WEAK WebViewType* _webView;
+    SAFE_ARC_IVAR_WEAK NSProgressIndicator* _progressIndicator;
 }
 #endif
 

--- a/ADAL/src/utils/NSString+ADHelperMethods.m
+++ b/ADAL/src/utils/NSString+ADHelperMethods.m
@@ -167,7 +167,9 @@ BOOL validBase64Characters(const byte* data, const int size)
 {
     NSData *decodedData = [self.class Base64DecodeData:self];
     
-    return SAFE_ARC_AUTORELEASE([[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding]);
+    NSString *string = [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
+    SAFE_ARC_AUTORELEASE(string);
+    return string;
 }
 
 //Helper method to encode 3 bytes into a sequence of 4 bytes:

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -75,7 +75,9 @@ const int sAsyncContextTimeout = 10;
                                                      error:nil];
     
     NSAssert(context, @"If this is failing for whatever reason you should probably fix it before trying to run tests.");
-    [context setTokenCacheStore:SAFE_ARC_AUTORELEASE([ADTokenCache new])];
+    ADTokenCache *tokenCache = [ADTokenCache new];
+    SAFE_ARC_AUTORELEASE(tokenCache);
+    [context setTokenCacheStore:tokenCache];
     [context setCorrelationId:TEST_CORRELATION_ID];
     
     SAFE_ARC_AUTORELEASE(context);

--- a/ADAL/tests/ADAuthenticationViewControllerTests.m
+++ b/ADAL/tests/ADAuthenticationViewControllerTests.m
@@ -55,7 +55,9 @@
                                                  error:nil];
     
     NSAssert(context, @"If this is failing for whatever reason you should probably fix it before trying to run tests.");
-    [context setTokenCacheStore:SAFE_ARC_AUTORELEASE([ADTokenCache new])];
+    ADTokenCache *tokenCache = [ADTokenCache new];
+    SAFE_ARC_AUTORELEASE(tokenCache);
+    [context setTokenCacheStore:tokenCache];
     [context setCorrelationId:TEST_CORRELATION_ID];
     
     SAFE_ARC_AUTORELEASE(context);

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -35,7 +35,7 @@
 #define TEST_ACCESS_TOKEN @"access token"
 #define TEST_ACCESS_TOKEN_TYPE @"access token type"
 #define TEST_REFRESH_TOKEN @"refresh token"
-#define TEST_CORRELATION_ID SAFE_ARC_AUTORELEASE([[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"])
+#define TEST_CORRELATION_ID ({NSUUID *testID = [[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"]; SAFE_ARC_AUTORELEASE(testID); testID;})
 
 typedef enum
 {


### PR DESCRIPTION
The `SAFE_ARC_RETAIN` when called on its own line results in a warning that the result (of just `x`) is unused. This warning is treated as an error.

Since the case where these macros are used on their own line was more common then the usage where these macros (especially `SAFE_ARC_AUTORELEASE`) was used on the same line as the object being instantiated, I choose to favor the use-these-macros-on-their-own-line case, and rewrote the other cases to use these macros on their own line, so that it can become a real no-op.

There was also some usages of `__weak` for instance variables where ARC was disabled. In this case it followed the existing style and defined a macro that becomes `__weak` when ARC is available and nothing then ARC is not available. 