### PR TITLE
Memory management in manual setter implementations

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -430,6 +430,10 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
 - (void)setTokenCacheStore:(id<ADTokenCacheAccessor>)tokenCacheStore
 {
+    if (_tokenCacheStore == tokenCacheStore)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_tokenCacheStore);
     _tokenCacheStore = tokenCacheStore;
     SAFE_ARC_RETAIN(_tokenCacheStore);

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -71,6 +71,10 @@
 
 - (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate
 {
+    if (_delegate == delegate)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_delegate);
     _delegate = delegate;
     SAFE_ARC_RETAIN(_delegate);

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -235,6 +235,10 @@
 
 - (void)setClientId:(NSString *)clientId
 {
+    if (_clientId == clientId)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_clientId);
     _clientId = clientId;
     SAFE_ARC_RETAIN(_clientId);
@@ -248,6 +252,10 @@
 
 - (void)setUserInformation:(ADUserInformation *)userInformation
 {
+    if (_userInformation == userInformation)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_userInformation);
     _userInformation = userInformation;
     SAFE_ARC_RETAIN(_userInformation);
@@ -261,6 +269,10 @@
 
 - (void)setResource:(NSString *)resource
 {
+    if (_resource == resource)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_resource);
     _resource = resource;
     SAFE_ARC_RETAIN(_resource);
@@ -274,6 +286,10 @@
 
 - (void)setAuthority:(NSString *)authority
 {
+    if (_authority == authority)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_authority);
     _authority = authority;
     SAFE_ARC_RETAIN(_authority);

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -240,8 +240,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_clientId);
-    _clientId = clientId;
-    SAFE_ARC_RETAIN(_clientId);
+    _clientId = [clientId copy];
     [self calculateHash];
 }
 
@@ -274,8 +273,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_resource);
-    _resource = resource;
-    SAFE_ARC_RETAIN(_resource);
+    _resource = [resource copy];
     [self calculateHash];
 }
 
@@ -291,8 +289,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_authority);
-    _authority = authority;
-    SAFE_ARC_RETAIN(_authority);
+    _authority = [authority copy];
     [self calculateHash];
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -142,8 +142,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_scope);
-    _scope = scope;
-    SAFE_ARC_RETAIN(_scope);
+    _scope = [scope copy];
 }
 
 - (void)setExtraQueryParameters:(NSString *)queryParams
@@ -154,8 +153,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_queryParams);
-    _queryParams = queryParams;
-    SAFE_ARC_RETAIN(_queryParams);
+    _queryParams = [queryParams copy];
 }
 
 - (void)setUserIdentifier:(ADUserIdentifier *)identifier
@@ -216,8 +214,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_redirectUri);
-    _redirectUri = redirectUri;
-    SAFE_ARC_RETAIN(_redirectUri);
+    _redirectUri = [redirectUri copy];
 }
 
 - (void)setAllowSilentRequests:(BOOL)allowSilent
@@ -234,8 +231,7 @@
         return;
     }
     SAFE_ARC_RELEASE(_refreshTokenCredential);
-    _refreshTokenCredential = refreshTokenCredential;
-    SAFE_ARC_RETAIN(_refreshTokenCredential);
+    _refreshTokenCredential = [refreshTokenCredential copy];
 }
 #endif
 

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -137,6 +137,10 @@
 - (void)setScope:(NSString *)scope
 {
     CHECK_REQUEST_STARTED;
+    if (_scope == scope)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_scope);
     _scope = scope;
     SAFE_ARC_RETAIN(_scope);
@@ -145,6 +149,10 @@
 - (void)setExtraQueryParameters:(NSString *)queryParams
 {
     CHECK_REQUEST_STARTED;
+    if (_queryParams == queryParams)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_queryParams);
     _queryParams = queryParams;
     SAFE_ARC_RETAIN(_queryParams);
@@ -153,6 +161,10 @@
 - (void)setUserIdentifier:(ADUserIdentifier *)identifier
 {
     CHECK_REQUEST_STARTED;
+    if (_identifier == identifier)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_identifier);
     _identifier = identifier;
     SAFE_ARC_RETAIN(_identifier);
@@ -161,9 +173,7 @@
 - (void)setUserId:(NSString *)userId
 {
     CHECK_REQUEST_STARTED;
-    SAFE_ARC_RELEASE(_identifier);
-    _identifier = [ADUserIdentifier identifierWithId:userId];
-    SAFE_ARC_RETAIN(_identifier);
+    [self setUserIdentifier:[ADUserIdentifier identifierWithId:userId]];
 }
 
 - (void)setPromptBehavior:(ADPromptBehavior)promptBehavior
@@ -181,6 +191,10 @@
 - (void)setCorrelationId:(NSUUID*)correlationId
 {
     CHECK_REQUEST_STARTED;
+    if (_correlationId == correlationId)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_correlationId);
     _correlationId = correlationId;
     SAFE_ARC_RETAIN(_correlationId);
@@ -197,6 +211,10 @@
 {
     // We knowingly do this mid-request when we have to change auth types
     // Thus no CHECK_REQUEST_STARTED
+    if (_redirectUri == redirectUri)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_redirectUri);
     _redirectUri = redirectUri;
     SAFE_ARC_RETAIN(_redirectUri);
@@ -211,6 +229,10 @@
 - (void)setRefreshTokenCredential:(NSString*)refreshTokenCredential
 {
     CHECK_REQUEST_STARTED;
+    if (_refreshTokenCredential == refreshTokenCredential)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_refreshTokenCredential);
     _refreshTokenCredential = refreshTokenCredential;
     SAFE_ARC_RETAIN(_refreshTokenCredential);

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -71,8 +71,7 @@ NSString *const HTTPPost = @"POST";
             return;
         }
         SAFE_ARC_RELEASE(_requestData);
-        _requestData   = body;
-        SAFE_ARC_RETAIN(_requestData);
+        _requestData = [body copy];
         
         // Add default HTTP Headers to the request: Expect
         // Note that we don't bother with Expect because iOS does not support it

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -65,6 +65,11 @@ NSString *const HTTPPost = @"POST";
         SAFE_ARC_RELEASE(_requestMethod);
         _requestMethod = HTTPPost;
         SAFE_ARC_RETAIN(_requestMethod);
+        
+        if (_requestData == body)
+        {
+            return;
+        }
         SAFE_ARC_RELEASE(_requestData);
         _requestData   = body;
         SAFE_ARC_RETAIN(_requestData);

--- a/ADAL/src/urlprotocol/ADNTLMHandler.m
+++ b/ADAL/src/urlprotocol/ADNTLMHandler.m
@@ -45,7 +45,12 @@ static NSURLConnection *_conn = nil;
 
 + (void)setCancellationUrl:(NSString*) url
 {
-    _cancellationUrl = url;
+    if (_cancellationUrl == url)
+    {
+        return;
+    }
+    SAFE_ARC_RELEASE(_cancellationUrl);
+    _cancellationUrl = [url copy];
 }
 
 + (BOOL)isChallengeCancelled

--- a/ADAL/src/utils/ADALFrameworkUtils.m
+++ b/ADAL/src/utils/ADALFrameworkUtils.m
@@ -39,7 +39,12 @@ static NSString *_resourcePath = nil;
 
 + (void)setResourcePath:(NSString *)resourcePath
 {
-    _resourcePath = resourcePath;
+    if (_resourcePath == resourcePath)
+    {
+        return;
+    }
+    SAFE_ARC_RELEASE(_resourcePath)
+    _resourcePath = [resourcePath copy];
 }
 
 // Retrive the bundle containing the resources for the library. May return nil, if the bundle

--- a/ADAL/tests/ADTestURLConnection.m
+++ b/ADAL/tests/ADTestURLConnection.m
@@ -187,6 +187,10 @@
                                                              HTTPVersion:@"1.1"
                                                             headerFields:headerFields];
     
+    if (_response == response)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_response);
     _response = response;
     SAFE_ARC_RETAIN(_response);
@@ -442,6 +446,10 @@ static NSMutableArray* s_responses = nil;
 
 - (void)setDelegateQueue:(NSOperationQueue*)queue
 {
+    if (_delegateQueue == queue)
+    {
+        return;
+    }
     SAFE_ARC_RELEASE(_delegateQueue);
     _delegateQueue = queue;
     SAFE_ARC_RETAIN(_delegateQueue);

--- a/ADAL/tests/ADTestURLConnection.m
+++ b/ADAL/tests/ADTestURLConnection.m
@@ -199,17 +199,28 @@
 - (void)setJSONResponse:(id)jsonResponse
 {
     NSError* error = nil;
-    _responseData = [NSJSONSerialization dataWithJSONObject:jsonResponse options:0 error:&error];
+    NSData* responseData = [NSJSONSerialization dataWithJSONObject:jsonResponse options:0 error:&error];
+    if (_responseData == responseData)
+    {
+        return;
+    }
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData = responseData;
     SAFE_ARC_RETAIN(_responseData);
     
     NSAssert(_responseData, @"Invalid JSON object set for test response! %@", error);
 }
 
-- (void)setRequestURL:(NSURL*)url
+- (void)setRequestURL:(NSURL*)requestURL
 {
-    _requestURL = url;
+    if (_requestURL == requestURL)
+    {
+        return;
+    }
+    SAFE_ARC_RELEASE(_requestURL);
+    _requestURL = requestURL;
     SAFE_ARC_RETAIN(_requestURL);
-    NSString* query = [url query];
+    NSString* query = [requestURL query];
     SAFE_ARC_RELEASE(_QPs);
     if (![NSString adIsStringNilOrBlank:query])
     {


### PR DESCRIPTION
Added checks that the new object is not the same as the existing before releasing it (protecting against a potential over release).

Change to copy new objects that have mutable counterparts (protecting against a potential mutation after a value has been set).

Implement memory management (according to the above) in setters where it was missing.