### PR TITLE
Generate NTLM Dialog by Code for Mac

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -282,12 +282,12 @@ static ADAuthenticationRequest* s_modalRequest = nil;
                     // Request failure
                     NSString* body = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
                     NSString* errorData = [NSString stringWithFormat:@"Full response: %@", body];
-                    SAFE_ARC_RELEASE(body);
                     AD_LOG_WARN(([NSString stringWithFormat:@"HTTP Error %ld", (long)webResponse.statusCode]), _correlationId, errorData);
                     
                     ADAuthenticationError* adError = [ADAuthenticationError HTTPErrorCode:webResponse.statusCode
                                                                                      body:body
                                                                             correlationId:_correlationId];
+                    SAFE_ARC_RELEASE(body);
                     
                     //Now add the information to the dictionary, so that the parser can extract it:
                     [response setObject:adError

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -136,9 +136,9 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
 
 - (void)dispatchCompletionBlock:(ADAuthenticationError *)error URL:(NSURL *)url
 {
-    // NOTE: It is possible that race between a successful completion
+    // NOTE: It is possible that competition between a successful completion
     //       and the user cancelling the authentication dialog can
-    //       occur causing this method to be called twice. The race
+    //       occur causing this method to be called twice. The competition
     //       cannot be blocked at its root, and so this method must
     //       be resilient to this condition and should not generate
     //       two callbacks.

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -39,6 +39,7 @@
         //Generate the NTLM input dialog by code for Mac
         //usename field
         _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 36, 73, 17)];
+        SAFE_ARC_AUTORELEASE(_usernameLabel);
         [_usernameLabel setStringValue:@"User Name"];
         [_usernameLabel setBezeled:NO];
         [_usernameLabel setDrawsBackground:NO];
@@ -46,9 +47,11 @@
         [_usernameLabel setSelectable:NO];
         
         _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(85, 36,210, 22)];
+        SAFE_ARC_AUTORELEASE(_usernameField);
         
         //password field
         _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 6, 72, 17)];
+        SAFE_ARC_AUTORELEASE(_passwordLabel);
         [_passwordLabel setStringValue:@"Password"];
         [_passwordLabel setBezeled:NO];
         [_passwordLabel setDrawsBackground:NO];
@@ -56,9 +59,11 @@
         [_passwordLabel setSelectable:NO];
         
         _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(85, 6,210, 22)];
+        SAFE_ARC_AUTORELEASE(_passwordField);
         
         //add labels and fileds to view
         _customView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 306, 63)];
+        SAFE_ARC_AUTORELEASE(_customView);
         [_customView addSubview:_usernameLabel];
         [_customView addSubview:_usernameField];
         [_customView addSubview:_passwordLabel];

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -23,6 +23,31 @@
 
 #import "ADCredentialCollectionController.h"
 
+// UI position values for the input dialog
+const CGFloat USERNAME_LABEL_X = 7;
+const CGFloat USERNAME_LABEL_Y = 36;
+const CGFloat USERNAME_LABEL_WIDTH = 73;
+const CGFloat USERNAME_LABEL_HEIGHT = 17;
+const CGFloat USERNAME_FIELD_X = 85;
+const CGFloat USERNAME_FIELD_Y = 36;
+const CGFloat USERNAME_FIELD_WIDTH = 210;
+const CGFloat USERNAME_FIELD_HEIGHT = 22;
+
+const CGFloat PASSWORD_LABEL_X = 7;
+const CGFloat PASSWORD_LABEL_Y = 6;
+const CGFloat PASSWORD_LABEL_WIDTH = 72;
+const CGFloat PASSWORD_LABEL_HEIGHT = 17;
+const CGFloat PASSWORD_FIELD_X = 85;
+const CGFloat PASSWORD_FIELD_Y = 6;
+const CGFloat PASSWORD_FIELD_WIDTH = 210;
+const CGFloat PASSWORD_FIELD_HEIGHT = 22;
+
+const CGFloat CUSTOM_VIEW_X = 0;
+const CGFloat CUSTOM_VIEW_Y = 0;
+const CGFloat CUSTOM_VIEW_WIDTH = 306;
+const CGFloat CUSTOM_VIEW_HEIGHT = 63;
+
+
 @implementation ADCredentialCollectionController
 
 @synthesize customView = _customView;
@@ -38,7 +63,7 @@
     {
         //Generate the NTLM input dialog by code for Mac
         //usename field
-        _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 36, 73, 17)];
+        _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(USERNAME_LABEL_X, USERNAME_LABEL_Y, USERNAME_LABEL_WIDTH, USERNAME_LABEL_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_usernameLabel);
         [_usernameLabel setStringValue:@"User Name"];
         [_usernameLabel setBezeled:NO];
@@ -46,11 +71,11 @@
         [_usernameLabel setEditable:NO];
         [_usernameLabel setSelectable:NO];
         
-        _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(85, 36,210, 22)];
+        _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(USERNAME_FIELD_X, USERNAME_FIELD_Y, USERNAME_FIELD_WIDTH, USERNAME_FIELD_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_usernameField);
         
         //password field
-        _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 6, 72, 17)];
+        _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(PASSWORD_LABEL_X, PASSWORD_LABEL_Y, PASSWORD_LABEL_WIDTH, PASSWORD_LABEL_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_passwordLabel);
         [_passwordLabel setStringValue:@"Password"];
         [_passwordLabel setBezeled:NO];
@@ -58,11 +83,11 @@
         [_passwordLabel setEditable:NO];
         [_passwordLabel setSelectable:NO];
         
-        _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(85, 6,210, 22)];
+        _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(PASSWORD_FIELD_X, PASSWORD_FIELD_Y, PASSWORD_FIELD_WIDTH, PASSWORD_FIELD_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_passwordField);
         
         //add labels and fileds to view
-        _customView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 306, 63)];
+        _customView = [[NSView alloc] initWithFrame:NSMakeRect(CUSTOM_VIEW_X, CUSTOM_VIEW_Y, CUSTOM_VIEW_WIDTH, CUSTOM_VIEW_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_customView);
         [_customView addSubview:_usernameLabel];
         [_customView addSubview:_usernameField];

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -39,7 +39,7 @@
         //Generate the NTLM input dialog by code for Mac
         //usename field
         _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 36, 73, 17)];
-        //SAFE_ARC_AUTORELEASE(_usernameLabel);
+        SAFE_ARC_AUTORELEASE(_usernameLabel);
         [_usernameLabel setStringValue:@"User Name"];
         [_usernameLabel setBezeled:NO];
         [_usernameLabel setDrawsBackground:NO];
@@ -47,11 +47,11 @@
         [_usernameLabel setSelectable:NO];
         
         _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(85, 36,210, 22)];
-        //SAFE_ARC_AUTORELEASE(_usernameField);
+        SAFE_ARC_AUTORELEASE(_usernameField);
         
         //password field
         _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 6, 72, 17)];
-        //SAFE_ARC_AUTORELEASE(_passwordLabel);
+        SAFE_ARC_AUTORELEASE(_passwordLabel);
         [_passwordLabel setStringValue:@"Password"];
         [_passwordLabel setBezeled:NO];
         [_passwordLabel setDrawsBackground:NO];
@@ -59,11 +59,11 @@
         [_passwordLabel setSelectable:NO];
         
         _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(85, 6,210, 22)];
-        //SAFE_ARC_AUTORELEASE(_passwordField);
+        SAFE_ARC_AUTORELEASE(_passwordField);
         
         //add labels and fileds to view
         _customView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 306, 63)];
-        //SAFE_ARC_AUTORELEASE(_customView);
+        SAFE_ARC_AUTORELEASE(_customView);
         [_customView addSubview:_usernameLabel];
         [_customView addSubview:_usernameField];
         [_customView addSubview:_passwordLabel];

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -65,7 +65,7 @@ const CGFloat CUSTOM_VIEW_HEIGHT = 63;
         //usename field
         _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(USERNAME_LABEL_X, USERNAME_LABEL_Y, USERNAME_LABEL_WIDTH, USERNAME_LABEL_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_usernameLabel);
-        [_usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
+        [_usernameLabel setStringValue:NSLocalizedString(@"Username", nil)];
         [_usernameLabel setBezeled:NO];
         [_usernameLabel setDrawsBackground:NO];
         [_usernameLabel setEditable:NO];

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -36,11 +36,33 @@
     self = [super init];
     if(self)
     {
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
-        [NSBundle loadNibNamed:@"ADCredentialViewController" owner:self];
-#pragma clang diagnostic pop
-//        loaded = [[NSBundle mainBundle] loadNibNamed:@"ADCredentialViewController" owner:self topLevelObjects:nil];
+        //Generate the NTLM input dialog by code for Mac
+        //usename field
+        _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 36, 73, 17)];
+        [_usernameLabel setStringValue:@"User Name"];
+        [_usernameLabel setBezeled:NO];
+        [_usernameLabel setDrawsBackground:NO];
+        [_usernameLabel setEditable:NO];
+        [_usernameLabel setSelectable:NO];
+        
+        _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(85, 36,210, 22)];
+        
+        //password field
+        _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 6, 72, 17)];
+        [_passwordLabel setStringValue:@"Password"];
+        [_passwordLabel setBezeled:NO];
+        [_passwordLabel setDrawsBackground:NO];
+        [_passwordLabel setEditable:NO];
+        [_passwordLabel setSelectable:NO];
+        
+        _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(85, 6,210, 22)];
+        
+        //add labels and fileds to view
+        _customView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 306, 63)];
+        [_customView addSubview:_usernameLabel];
+        [_customView addSubview:_usernameField];
+        [_customView addSubview:_passwordLabel];
+        [_customView addSubview:_passwordField];
     }
     
     return self;

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -65,7 +65,7 @@ const CGFloat CUSTOM_VIEW_HEIGHT = 63;
         //usename field
         _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(USERNAME_LABEL_X, USERNAME_LABEL_Y, USERNAME_LABEL_WIDTH, USERNAME_LABEL_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_usernameLabel);
-        [_usernameLabel setStringValue:@"User Name"];
+        [_usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
         [_usernameLabel setBezeled:NO];
         [_usernameLabel setDrawsBackground:NO];
         [_usernameLabel setEditable:NO];
@@ -77,7 +77,7 @@ const CGFloat CUSTOM_VIEW_HEIGHT = 63;
         //password field
         _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(PASSWORD_LABEL_X, PASSWORD_LABEL_Y, PASSWORD_LABEL_WIDTH, PASSWORD_LABEL_HEIGHT)];
         SAFE_ARC_AUTORELEASE(_passwordLabel);
-        [_passwordLabel setStringValue:@"Password"];
+        [_passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
         [_passwordLabel setBezeled:NO];
         [_passwordLabel setDrawsBackground:NO];
         [_passwordLabel setEditable:NO];

--- a/ADAL/src/ui/mac/ADCredentialCollectionController.m
+++ b/ADAL/src/ui/mac/ADCredentialCollectionController.m
@@ -39,7 +39,7 @@
         //Generate the NTLM input dialog by code for Mac
         //usename field
         _usernameLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 36, 73, 17)];
-        SAFE_ARC_AUTORELEASE(_usernameLabel);
+        //SAFE_ARC_AUTORELEASE(_usernameLabel);
         [_usernameLabel setStringValue:@"User Name"];
         [_usernameLabel setBezeled:NO];
         [_usernameLabel setDrawsBackground:NO];
@@ -47,11 +47,11 @@
         [_usernameLabel setSelectable:NO];
         
         _usernameField = [[NSTextField alloc] initWithFrame:NSMakeRect(85, 36,210, 22)];
-        SAFE_ARC_AUTORELEASE(_usernameField);
+        //SAFE_ARC_AUTORELEASE(_usernameField);
         
         //password field
         _passwordLabel = [[NSTextField alloc] initWithFrame:NSMakeRect(7, 6, 72, 17)];
-        SAFE_ARC_AUTORELEASE(_passwordLabel);
+        //SAFE_ARC_AUTORELEASE(_passwordLabel);
         [_passwordLabel setStringValue:@"Password"];
         [_passwordLabel setBezeled:NO];
         [_passwordLabel setDrawsBackground:NO];
@@ -59,11 +59,11 @@
         [_passwordLabel setSelectable:NO];
         
         _passwordField = [[NSSecureTextField alloc] initWithFrame:NSMakeRect(85, 6,210, 22)];
-        SAFE_ARC_AUTORELEASE(_passwordField);
+        //SAFE_ARC_AUTORELEASE(_passwordField);
         
         //add labels and fileds to view
         _customView = [[NSView alloc] initWithFrame:NSMakeRect(0, 0, 306, 63)];
-        SAFE_ARC_AUTORELEASE(_customView);
+        //SAFE_ARC_AUTORELEASE(_customView);
         [_customView addSubview:_usernameLabel];
         [_customView addSubview:_usernameField];
         [_customView addSubview:_passwordLabel];

--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -42,7 +42,7 @@
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
     
     ADCredentialCollectionController* view = [ADCredentialCollectionController new];
-    SAFE_ARC_AUTORELEASE(view);
+    //SAFE_ARC_AUTORELEASE(view);
     [view.usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
     [view.passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
     [alert setAccessoryView:view.customView];

--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -48,7 +48,7 @@
     
     [alert beginSheetModalForWindow:[NSApp keyWindow] completionHandler:^(NSModalResponse returnCode)
     {
-        if (returnCode == 1)
+        if (returnCode == 1000)
         {
             NSString* username = [view.usernameField stringValue];
             NSString* password = [view.passwordField stringValue];

--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -43,7 +43,7 @@
     
     ADCredentialCollectionController* view = [ADCredentialCollectionController new];
     SAFE_ARC_AUTORELEASE(view);
-    [view.usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
+    [view.usernameLabel setStringValue:NSLocalizedString(@"Username", nil)];
     [view.passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
     [alert setAccessoryView:view.customView];
     

--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -42,7 +42,7 @@
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
     
     ADCredentialCollectionController* view = [ADCredentialCollectionController new];
-    //SAFE_ARC_AUTORELEASE(view);
+    SAFE_ARC_AUTORELEASE(view);
     [view.usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
     [view.passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
     [alert setAccessoryView:view.customView];

--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -42,6 +42,7 @@
     [alert addButtonWithTitle:NSLocalizedString(@"Cancel", nil)];
     
     ADCredentialCollectionController* view = [ADCredentialCollectionController new];
+    SAFE_ARC_AUTORELEASE(view);
     [view.usernameLabel setStringValue:NSLocalizedString(@"User Name", nil)];
     [view.passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
     [alert setAccessoryView:view.customView];

--- a/ADAL/tests/ADAuthenticationParametersTests.m
+++ b/ADAL/tests/ADAuthenticationParametersTests.m
@@ -262,7 +262,7 @@
     //HTTP headers are case-insensitive. This test validates that the underlying code is aware:
     NSURL *url = [NSURL URLWithString:@"http://www.example.com"];
     NSDictionary* headerFields1 = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
-                                                              forKey:@"WWW-AUTHENTICATE"];//Capital
+                                                              forKey:@"WWW-AUTHENTICATE"];//Uppercase
     NSHTTPURLResponse* response1 = [[NSHTTPURLResponse alloc] initWithURL:url
                                                                statusCode:401
                                                               HTTPVersion:@"1.1"
@@ -275,7 +275,7 @@
     [self verifyWithAuthority:@"https://www.example.com"];
     
     NSDictionary* headerFields2 = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
-                                                              forKey:@"www-AUTHEnticate"];//Capital
+                                                              forKey:@"www-AUTHEnticate"];//Partially uppercase
     NSHTTPURLResponse* response2 = [[NSHTTPURLResponse alloc] initWithURL:url
                                                                statusCode:401
                                                               HTTPVersion:@"1.1"
@@ -356,12 +356,12 @@
 
 -(void) testInternalInit
 {
-    [self validateExtractChallenge:@"Bearerauthorization_uri=\"abc\", resource_id=\"foo\"" authority:nil resource:nil line:__LINE__];
-    [self validateExtractChallenge:@"Bearer foo" authority:nil resource:nil line:__LINE__];
-    [self validateExtractChallenge:@"Bearer foo=bar" authority:nil resource:nil line:__LINE__];
-    [self validateExtractChallenge:@"Bearer foo=\"bar\"" authority:nil resource:nil line:__LINE__];
-    [self validateExtractChallenge:@"Bearer foo=\"bar" authority:nil resource:nil line:__LINE__];//Missing second quote
-    [self validateExtractChallenge:@"Bearer foo=\"bar\"," authority:nil resource:nil line:__LINE__];
+    [self validateExtractChallenge:@"Bearerauthorization_uri=\"abc\", resource_id=\"something\"" authority:nil resource:nil line:__LINE__];
+    [self validateExtractChallenge:@"Bearer something" authority:nil resource:nil line:__LINE__];
+    [self validateExtractChallenge:@"Bearer something=bar" authority:nil resource:nil line:__LINE__];
+    [self validateExtractChallenge:@"Bearer something=\"bar\"" authority:nil resource:nil line:__LINE__];
+    [self validateExtractChallenge:@"Bearer something=\"bar" authority:nil resource:nil line:__LINE__];//Missing second quote
+    [self validateExtractChallenge:@"Bearer something=\"bar\"," authority:nil resource:nil line:__LINE__];
     [self validateExtractChallenge:@"Bearer   authorization_uri=\"https://login.windows.net/common\""
                                 authority:@"https://login.windows.net/common" resource:nil line:__LINE__];
     //More commas:
@@ -369,16 +369,16 @@
                          authority:@"https://login.windows.net/common"
                           resource:nil
                               line:__LINE__];
-    [self validateExtractChallenge:@"Bearer authorization_uri=\"https://login.windows.net/common\",resource_id=\"foo\""
+    [self validateExtractChallenge:@"Bearer authorization_uri=\"https://login.windows.net/common\",resource_id=\"something\""
                          authority:@"https://login.windows.net/common"
-                          resource:@"foo"
+                          resource:@"something"
                               line:__LINE__];
-    [self validateExtractChallenge:@"Bearer authorization_uri=\"\",resource_id=\"foo\"" authority:nil resource:@"foo" line:__LINE__];
+    [self validateExtractChallenge:@"Bearer authorization_uri=\"\",resource_id=\"something\"" authority:nil resource:@"something" line:__LINE__];
 
     //Pass an attribute, whose value contains commas:
-    [self validateExtractChallenge:@"Bearer  error_descritpion=\"Make sure, that you handle commas, inside the text\",authorization_uri=\"https://login.windows.net/common\",resource_id=\"foo\""
+    [self validateExtractChallenge:@"Bearer  error_descritpion=\"Make sure, that you handle commas, inside the text\",authorization_uri=\"https://login.windows.net/common\",resource_id=\"something\""
                          authority:@"https://login.windows.net/common"
-                          resource:@"foo"
+                          resource:@"something"
                               line:__LINE__];
 }
 
@@ -394,7 +394,7 @@
 
 -(void) testParametersFromResponseAuthenticateHeaderInvalid
 {
-    [self validateFactoryForBadHeader:@"Bearer foo=bar" line:__LINE__];
+    [self validateFactoryForBadHeader:@"Bearer something=bar" line:__LINE__];
     [self validateFactoryForBadHeader:@"Bearer = , = , "  line:__LINE__];
     [self validateFactoryForBadHeader:@"Bearer =,=,=" line:__LINE__];
 }
@@ -403,7 +403,7 @@
 {
     [self adSetLogTolerance:ADAL_LOG_LEVEL_INFO];
     ADAuthenticationError* error = nil;
-    ADAuthenticationParameters* params = [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:@"Bearer authorization_uri=\"https://login.windows.net/common\", resource_uri=\"foo.com\", anotherParam=\"Indeed, another param=5\" "
+    ADAuthenticationParameters* params = [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:@"Bearer authorization_uri=\"https://login.windows.net/common\", resource_uri=\"something.com\", anotherParam=\"Indeed, another param=5\" "
                                                                             error:&error];
     XCTAssertNotNil(params);
     XCTAssertNil(error);

--- a/ADAL/tests/ADInstanceDiscoveryTests.m
+++ b/ADAL/tests/ADInstanceDiscoveryTests.m
@@ -184,24 +184,24 @@ static NSString* const sAlwaysTrusted = @"https://login.windows.net";
     
     //Invalid URL
     XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"&-23425 5345g"]);
-    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"https:///login.windows.Net/foo"], "Bad URL. Three slashes");
+    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"https:///login.windows.Net/something"], "Bad URL. Three slashes");
     XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"https:////"]);
     
     //Non-ssl:
-    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"foo"]);
-    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"http://foo"]);
+    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"something"]);
+    XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"http://something"]);
     XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"http://www.microsoft.com"]);
     XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"abcde://login.windows.net/common"]);
     
     //Canonicalization to the supported extent:
-    NSString* authority = @"    https://www.microsoft.com/foo.com/";
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:authority], @"https://www.microsoft.com/foo.com");
+    NSString* authority = @"    https://www.microsoft.com/something.com/";
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:authority], @"https://www.microsoft.com/something.com");
     
-    authority = @"https://www.microsoft.com/foo.com";
+    authority = @"https://www.microsoft.com/something.com";
     //Without the trailing "/":
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://www.microsoft.com/foo.com"], authority);
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://www.microsoft.com/something.com"], authority);
     //Ending with non-white characters:
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://www.microsoft.com/foo.com   "], authority);
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://www.microsoft.com/something.com   "], authority);
     
     authority = @"https://login.windows.net/msopentechbv.onmicrosoft.com";
     //Test canonicalizing the endpoints:
@@ -212,11 +212,11 @@ static NSString* const sAlwaysTrusted = @"https://login.windows.net";
     XCTAssertNil([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/"], "No tenant");
     
     //Trimming beyond the tenant:
-    authority = @"https://login.windows.net/foo.com";
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/foo.com/bar"], authority);
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/foo.com"], authority);
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/foo.com/"], authority);
-    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/foo.com#bar"], authority);
+    authority = @"https://login.windows.net/something.com";
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/something.com/bar"], authority);
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/something.com"], authority);
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/something.com/"], authority);
+    ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.Net/something.com#bar"], authority);
     authority = @"https://login.windows.net/common";//Use "common" for a change
     ADAssertStringEquals([ADInstanceDiscovery canonicalizeAuthority:@"https://login.windows.net/common?abc=123&vc=3"], authority);
 }

--- a/ADAL/tests/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/ios/ADKeychainTokenCacheTests.m
@@ -60,7 +60,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
 
 - (void)tearDown
 {
-    [mStore testRemoveAll:nil];//Attempt to clear the junk from the keychain
+    [mStore testRemoveAll:nil];//Attempt to clear all things from the keychain
     mStore = nil;
     
     [self adTestEnd];


### PR DESCRIPTION
(For #474)
NTLM input dialog for Mac is now generated by code rather than nib file.

Besides, also removed the usage of words "junk", "foo", "capital" and "race".