### PR TITLE
Main thread checks.

### DIFF
--- a/ADAL/src/public/ADErrorCodes.h
+++ b/ADAL/src/public/ADErrorCodes.h
@@ -131,6 +131,9 @@ typedef enum
     /*! The user has cancelled the applicable UI prompts */
     AD_ERROR_UI_USER_CANCEL = 403,
     
+    /*! Interactive authentication requests must originate on the main thread. */
+    AD_ERROR_UI_NOT_ON_MAIN_THREAD = 404,
+    
     //
     // Token Broker Errors
     // These errors originate from being unable or failing to communicate with

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -40,6 +40,22 @@
     AD_REQUEST_CHECK_ARGUMENT(_resource);
     [self ensureRequest];
     
+    NSString* log = [NSString stringWithFormat:@"acquireToken (authority = %@, resource = %@, clientId = %@, idtype = %@)",
+                     _context.authority, _resource, _clientId, [_identifier typeAsString]];
+    AD_LOG_INFO_F(log, _correlationId, @"userId = %@", _identifier.userId);
+    
+    if (!_silent && ![NSThread isMainThread])
+    {
+        ADAuthenticationError* error =
+        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_UI_NOT_ON_MAIN_THREAD
+                                               protocolCode:nil
+                                               errorDetails:@"Interactive authentication requests must originate from the main thread"
+                                              correlationId:_correlationId];
+        
+        completionBlock([ADAuthenticationResult resultFromError:error]);
+        return;
+    }
+    
     if (!_context.validateAuthority)
     {
         [self validatedAcquireToken:completionBlock];

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -493,8 +493,27 @@ correlationId:(NSUUID *)correlationId
     THROW_ON_NIL_ARGUMENT(startURL);
     THROW_ON_NIL_ARGUMENT(endURL);
     THROW_ON_NIL_ARGUMENT(correlationId);
-    THROW_ON_NIL_ARGUMENT(completionBlock)
-    //AD_LOG_VERBOSE(@"Authorization", startURL.absoluteString);
+    THROW_ON_NIL_ARGUMENT(completionBlock);
+    
+    // If we're not on the main thread when trying to kick up the UI then
+    // dispatch over to the main thread.
+    if (![NSThread isMainThread])
+    {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self start:startURL
+                    end:endURL
+            refreshCred:refreshCred
+#if TARGET_OS_IPHONE
+                 parent:parent
+             fullScreen:fullScreen
+#endif
+                webView:webView
+          correlationId:correlationId
+             completion:completionBlock];
+        });
+        return;
+    }
+    
     
     _timeout = [[ADAuthenticationSettings sharedInstance] requestTimeOut];
     


### PR DESCRIPTION
Check in -acquireToken: to make sure we're on the main thread. In ADAL 2.1 we require interactive auth to be initiated on the main thread as the developer is requesting a UI operation. However it is still possible that we fail a RT attempt and end up on a network thread before popping UI so we still need to jump back to the main thread in that case.