### PR TITLE
Exclusion lock is now grabbed before calling broker

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -356,11 +356,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
 //Attempts to release the lock. Logs warning if the lock was already released.
 -(void) releaseExclusionLock
 {
-    if ( ![self releaseUserInterationLock] )
-    {
-        AD_LOG_WARN(@"UI Locking", _correlationId, @"The UI lock has already been released.");
-    }
-    
+    [self releaseUserInterationLock];
     s_modalRequest = nil;
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -332,16 +332,13 @@ static ADAuthenticationRequest* s_modalRequest = nil;
     SAFE_ARC_RELEASE(webRequest);
 }
 
-//Used for the callback of obtaining the OAuth2 code:
-static volatile int sDialogInProgress = 0;
-
 //Ensures that a single UI login dialog can be requested at a time.
 //Returns true if successfully acquired the lock. If not, calls the callback with
 //the error and returns false.
 - (BOOL)takeExclusionLockWithCallback: (ADAuthorizationCodeCallback) completionBlock
 {
     THROW_ON_NIL_ARGUMENT(completionBlock);
-    if ( !OSAtomicCompareAndSwapInt( 0, 1, &sDialogInProgress) )
+    if ( ![self takeUserInterationLock] )
     {
         NSString* message = @"The user is currently prompted for credentials as result of another acquireToken request. Please retry the acquireToken call later.";
         ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_UI_MULTLIPLE_INTERACTIVE_REQUESTS
@@ -359,7 +356,7 @@ static volatile int sDialogInProgress = 0;
 //Attempts to release the lock. Logs warning if the lock was already released.
 -(void) releaseExclusionLock
 {
-    if ( !OSAtomicCompareAndSwapInt( 1, 0, &sDialogInProgress) )
+    if ( ![self releaseUserInterationLock] )
     {
         AD_LOG_WARN(@"UI Locking", _correlationId, @"The UI lock has already been released.");
     }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -43,6 +43,10 @@
     } \
 }
 
+// Used to make sure one interactive request is going on at a time,
+// either launching webview or broker
+static volatile int sInteractionInProgress = 0;
+
 @interface ADAuthenticationRequest : NSObject
 {
 @protected
@@ -87,6 +91,9 @@
 // This message is sent before any stage of processing is done, it marks all the fields as un-editable and grabs the
 // correlation ID from the logger
 - (void)ensureRequest;
+// This exclusion lock should be obtained before launching webview/broker for interaction
+- (BOOL)takeUserInterationLock;
+- (BOOL)releaseUserInterationLock;
 
 // These can only be set before the request gets sent out.
 - (void)setScope:(NSString*)scope;

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -43,10 +43,6 @@
     } \
 }
 
-// Used to make sure one interactive request is going on at a time,
-// either launching webview or broker
-static volatile int sInteractionInProgress = 0;
-
 @interface ADAuthenticationRequest : NSObject
 {
 @protected

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -38,7 +38,7 @@
 
 // Used to make sure one interactive request is going on at a time,
 // either launching webview or broker
-static volatile dispatch_semaphore_t sInteractionInProgress = nil;
+static dispatch_semaphore_t sInteractionInProgress = nil;
 
 @implementation ADAuthenticationRequest
 

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -54,6 +54,11 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     } \
 }
 
++ (void)initialize
+{
+    sInteractionInProgress = dispatch_semaphore_create(1);
+}
+
 + (ADAuthenticationRequest *)requestWithAuthority:(NSString *)authority
 {
     ADAuthenticationContext* context = [[ADAuthenticationContext alloc] initWithAuthority:authority validateAuthority:NO error:nil];
@@ -89,16 +94,6 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     return request;
 }
 
-- (id)init
-{
-    if (!(self = [super init]))
-        return nil;
-    
-    sInteractionInProgress = dispatch_semaphore_create(1);
-    
-    return self;
-}
-
 - (id)initWithContext:(ADAuthenticationContext*)context
           redirectUri:(NSString*)redirectUri
              clientId:(NSString*)clientId
@@ -109,8 +104,6 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     
     if (!(self = [super init]))
         return nil;
-    
-    sInteractionInProgress = dispatch_semaphore_create(1);
     
     SAFE_ARC_RETAIN(context);
     _context = context;
@@ -286,7 +279,7 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
 
 - (BOOL)takeUserInterationLock
 {
-    return !dispatch_semaphore_wait(sInteractionInProgress, DISPATCH_TIME_NOW);;
+    return !dispatch_semaphore_wait(sInteractionInProgress, DISPATCH_TIME_NOW);
 }
 
 - (BOOL)releaseUserInterationLock

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -268,4 +268,14 @@
     return _correlationId;
 }
 
+- (BOOL)takeUserInterationLock
+{
+    return OSAtomicCompareAndSwapInt( 0, 1, &sInteractionInProgress);
+}
+
+- (BOOL)releaseUserInterationLock
+{
+    return OSAtomicCompareAndSwapInt( 1, 0, &sInteractionInProgress);
+}
+
 @end


### PR DESCRIPTION
(for #550)
Before calling broker, an exclusion lock is grabbed.

The exclusion lock used for calling broker is the same as the one used for popping webview, as we want to make sure one interactive request is going on at a time.