### PR TITLE
Fix method type handling

### DIFF
--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -147,27 +147,16 @@ AD_LOG_VERBOSE(__adalVersion, nil, __where); \
 }
 
 #if __has_feature(objc_arc)
-#   define SAFE_ARC_PROP_RETAIN strong
-#   define SAFE_ARC_RETAIN(x)
-#   define SAFE_ARC_RELEASE(x)
-#   define SAFE_ARC_AUTORELEASE(x)
-#   define SAFE_ARC_BLOCK_COPY(x)
-#   define SAFE_ARC_BLOCK_RELEASE(x)
-#   define SAFE_ARC_SUPER_DEALLOC()
-#   define SAFE_ARC_AUTORELEASE_POOL_START() @autoreleasepool {
-#   define SAFE_ARC_AUTORELEASE_POOL_END() }
-#   define SAFE_ARC_DISPATCH_RETAIN(x)
-#   define SAFE_ARC_DISPATCH_RELEASE(x)
-#else
-#   define SAFE_ARC_PROP_RETAIN retain
-#   define SAFE_ARC_RETAIN(x) ([(x) retain])
-#   define SAFE_ARC_RELEASE(x) { [(x) release]; }
-#   define SAFE_ARC_AUTORELEASE(x) ([(x) autorelease])
-#   define SAFE_ARC_BLOCK_COPY(x) (Block_copy(x))
-#   define SAFE_ARC_BLOCK_RELEASE(x) (Block_release(x))
-#   define SAFE_ARC_SUPER_DEALLOC() ([super dealloc])
-#   define SAFE_ARC_AUTORELEASE_POOL_START() NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-#   define SAFE_ARC_AUTORELEASE_POOL_END() [pool release];
-#   define SAFE_ARC_DISPATCH_RETAIN(x) dispatch_retain((x))
-#   define SAFE_ARC_DISPATCH_RELEASE(x) dispatch_release((x))
+#define __WEAK __weak
+#define SAFE_ARC_RETAIN(x)
+#define SAFE_ARC_RELEASE(x)
+#define SAFE_ARC_AUTORELEASE(x)
+#define SAFE_ARC_SUPER_DEALLOC()
+
+#else // ! __has_feature(objc_arc)
+#define __WEAK
+#define SAFE_ARC_RETAIN(x) ([(x) retain])
+#define SAFE_ARC_RELEASE(x) { [(x) release]; }
+#define SAFE_ARC_AUTORELEASE(x) ([(x) autorelease])
+#define SAFE_ARC_SUPER_DEALLOC() ([super dealloc])
 #endif

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -91,7 +91,7 @@
     }
 
     ADWebRequest* request = [[ADWebRequest alloc] initWithURL:resourceUrl correlationId:nil];
-    request.method = HTTPGet;
+    [request setMethodType:ADWebRequestGet];
     AD_LOG_VERBOSE_F(@"Starting authorization challenge request", nil, @"Resource: %@", resourceUrl);
     
     [request send:^(NSError * error, ADWebResponse *response) {

--- a/ADAL/src/ADInstanceDiscovery.m
+++ b/ADAL/src/ADInstanceDiscovery.m
@@ -293,7 +293,7 @@ static NSString* const sValidationServerError = @"The authority validation serve
     AD_LOG_VERBOSE(@"Authority Validation Request", correlationId, endPoint);
     ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:[NSURL URLWithString:endPoint] correlationId:correlationId];
     
-    webRequest.method = HTTPGet;
+    [webRequest setMethodType:ADWebRequestGet];
     [webRequest.headers setObject:@"application/json" forKey:@"Accept"];
     [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     __block NSDate* startTime = [NSDate new];

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -134,16 +134,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
     
     ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:[NSURL URLWithString:endPoint]
                                                    correlationId:_correlationId];
-    
-    if(isGetRequest)
-    {
-        webRequest.method = HTTPGet;
-    }
-    else
-    {
-        webRequest.method = HTTPPost;
-    }
-    
+    [webRequest setMethodType:isGetRequest ? ADWebRequestGet : ADWebRequestPost];
     [webRequest.headers setObject:@"application/json" forKey:@"Accept"];
     [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     [webRequest.headers setObject:pKeyAuthHeaderVersion forKey:pKeyAuthHeader];

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -24,15 +24,19 @@
 @class ADWebRequest;
 @class ADWebResponse;
 
-extern NSString *const HTTPGet;
-extern NSString *const HTTPPost;
+
+typedef enum
+{
+    ADWebRequestGet,
+    ADWebRequestPost,
+} ADWebRequestMethodType;
 
 @interface ADWebRequest : NSObject <NSURLConnectionDelegate>
 {
     NSURLConnection * _connection;
     
     NSURL * _requestURL;
-    NSString* _requestMethod;
+    __WEAK NSString* _requestMethod;
     NSMutableDictionary* _requestHeaders;
     NSData * _requestData;
     
@@ -49,7 +53,7 @@ extern NSString *const HTTPPost;
 }
 
 @property (strong, readonly, nonatomic) NSURL               *URL;
-@property (strong)                      NSString            *method;
+@property (weak, readonly)              NSString            *method;
 @property (strong, readonly, nonatomic) NSMutableDictionary *headers;
 @property (strong)                      NSData              *body;
 @property (nonatomic)           NSUInteger           timeout;
@@ -58,6 +62,8 @@ extern NSString *const HTTPPost;
     correlationId: (NSUUID*) correlationId;
 
 - (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
+
+- (void)setMethodType:(ADWebRequestMethodType)methodType;
 
 @end
 

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -33,8 +33,8 @@
 #import "ADLogger+Internal.h"
 #import "ADURLProtocol.h"
 
-NSString *const HTTPGet  = @"GET";
-NSString *const HTTPPost = @"POST";
+static NSString *const HTTPGet  = @"GET";
+static NSString *const HTTPPost = @"POST";
 
 @interface ADWebRequest () <NSURLConnectionDelegate>
 
@@ -62,9 +62,7 @@ NSString *const HTTPPost = @"POST";
 {
     if ( body != nil )
     {
-        SAFE_ARC_RELEASE(_requestMethod);
         _requestMethod = HTTPPost;
-        SAFE_ARC_RETAIN(_requestMethod);
         
         if (_requestData == body)
         {
@@ -76,6 +74,15 @@ NSString *const HTTPPost = @"POST";
         // Add default HTTP Headers to the request: Expect
         // Note that we don't bother with Expect because iOS does not support it
         //[_requestHeaders setValue:@"100-continue" forKey:@"Expect"];
+    }
+}
+
+- (void)setMethodType:(ADWebRequestMethodType)methodType
+{
+    switch (methodType)
+    {
+        case ADWebRequestGet: _requestMethod = HTTPGet; break;
+        case ADWebRequestPost: _requestMethod = HTTPPost; break;
     }
 }
 
@@ -91,7 +98,6 @@ NSString *const HTTPPost = @"POST";
     
     _requestURL        = [requestURL copy];
     _requestMethod     = HTTPGet;
-    SAFE_ARC_RETAIN(_requestMethod);
     _requestHeaders    = [[NSMutableDictionary alloc] init];
     
     // Default timeout for ADWebRequest is 30 seconds
@@ -114,7 +120,7 @@ NSString *const HTTPPost = @"POST";
     
     SAFE_ARC_RELEASE(_requestURL);
     _requestURL = nil;
-    SAFE_ARC_RELEASE(_requestMethod);
+    
     _requestMethod = nil;
     SAFE_ARC_RELEASE(_requestHeaders);
     _requestHeaders = nil;
@@ -144,7 +150,7 @@ NSString *const HTTPPost = @"POST";
     // Cleanup
     SAFE_ARC_RELEASE(_requestURL);
     _requestURL     = nil;
-    SAFE_ARC_RELEASE(_requestMethod);
+    
     _requestMethod  = nil;
     SAFE_ARC_RELEASE(_requestHeaders);
     _requestHeaders = nil;

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -59,7 +59,7 @@ const int sAsyncContextTimeout = 10;
 - (void)tearDown
 {
 #if !__has_feature(objc_arc)
-    dispatch_semaphore_release(_dsem);
+    dispatch_release(_dsem);
 #endif
     _dsem = nil;
     

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -58,7 +58,9 @@ const int sAsyncContextTimeout = 10;
 
 - (void)tearDown
 {
-    SAFE_ARC_DISPATCH_RELEASE(_dsem);
+#if !__has_feature(objc_arc)
+    dispatch_semaphore_release(_dsem);
+#endif
     _dsem = nil;
     
     XCTAssertTrue([ADTestURLConnection noResponsesLeft]);

--- a/ADAL/tests/ADAuthenticationViewControllerTests.m
+++ b/ADAL/tests/ADAuthenticationViewControllerTests.m
@@ -42,7 +42,9 @@
 
 - (void)tearDown
 {
-    SAFE_ARC_DISPATCH_RELEASE(_dsem);
+#if !__has_feature(objc_arc)
+    dispatch_semaphore_release(_dsem);
+#endif
     _dsem = nil;
     [super tearDown];
 }

--- a/ADAL/tests/ADAuthenticationViewControllerTests.m
+++ b/ADAL/tests/ADAuthenticationViewControllerTests.m
@@ -43,7 +43,7 @@
 - (void)tearDown
 {
 #if !__has_feature(objc_arc)
-    dispatch_semaphore_release(_dsem);
+    dispatch_release(_dsem);
 #endif
     _dsem = nil;
     [super tearDown];

--- a/ADAL/tests/ADInstanceDiscoveryTests.m
+++ b/ADAL/tests/ADInstanceDiscoveryTests.m
@@ -54,7 +54,9 @@ static NSString* const sAlwaysTrusted = @"https://login.windows.net";
 
 - (void)tearDown
 {
-    SAFE_ARC_DISPATCH_RELEASE(_dsem);
+#if !__has_feature(objc_arc)
+    dispatch_semaphore_release(_dsem);
+#endif
     _dsem = nil;
     
     [self adTestEnd];

--- a/ADAL/tests/ADInstanceDiscoveryTests.m
+++ b/ADAL/tests/ADInstanceDiscoveryTests.m
@@ -55,7 +55,7 @@ static NSString* const sAlwaysTrusted = @"https://login.windows.net";
 - (void)tearDown
 {
 #if !__has_feature(objc_arc)
-    dispatch_semaphore_release(_dsem);
+    dispatch_release(_dsem);
 #endif
     _dsem = nil;
     


### PR DESCRIPTION
The use of global variables was not in line with best practices, and the overall handling of that ivar was incorrect in some cases, but we were most likely getting away with it due to it only being set with constant compile time defined NSStrings. I'm cleaning up the interface a bit here to make it less likely this could cause issues.