### PR TITLE
Policy is now set before a cache item is stored.

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+WebRequest.m
@@ -52,6 +52,7 @@
          item.clientId = _clientId;
          NSArray* scopes = [[response objectForKey:@"scope"] componentsSeparatedByString:@" "];
          item.scopes = [NSSet setWithArray:scopes];
+         item.policy = _policy;
          completionBlock([_context processTokenResponse:response
                                                 forItem:item
                                             fromRefresh:NO

--- a/ADALiOS/ADALiOS/ADKeychainItem.m
+++ b/ADALiOS/ADALiOS/ADKeychainItem.m
@@ -352,6 +352,7 @@
                                       scopes:(NSSet*)scopes
 {
     ADTokenCacheStoreItem* item = [self tokenItem];
+    item.policy = policy;
     
     // If no token was found then this is a no-op. We still want to return an item as the
     // refresh token might still be usable.

--- a/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
+++ b/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
@@ -259,7 +259,11 @@ static void adkeychain_dispatch_if_needed(dispatch_block_t block)
     }
     
     ADKeychainQuery* writeQuery = [self createBaseQuery];
-    [writeQuery setUserId:userId ? userId : @""];
+    if (!userId || [userId isKindOfClass:[NSNull class]])
+    {
+        userId = @"";
+    }
+    [writeQuery setUserId:userId];
     
     const void * keys[] = { kSecAttrGeneric };
     const void * values[] = { data };

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -97,7 +97,7 @@
     }
     
     NSString* matchString = [identifier userIdMatchString:info];
-    if (!matchString || [matchString isEqualToString:identifier.userId])
+    if (!matchString || [matchString isKindOfClass:[NSNull class]] || [matchString isEqualToString:identifier.userId])
     {
         return YES;
     }

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -415,6 +415,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
                                   identifier:[ADUserIdentifier identifierWithId:_userId type:RequiredDisplayableId]
                                promptBehavior:_promptBehavior
                            extraQueryParameters:nil
+                                       policy:_policy
                                 completionBlock:callback];
          }
 
@@ -476,6 +477,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
     item.expiresOn = [NSDate dateWithTimeIntervalSinceNow:3600];
     item.authority = _authority;
     item.clientId = _clientId;
+    item.policy = _policy;
     if (userId)
     {
         item.profileInfo = [ADProfileInfo profileInfoWithUsername:userId
@@ -1027,7 +1029,49 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
     ADAssertLongEquals(0, [self cacheCount]);
 }
 
-//Creates the context with
+- (void)testExtractAndStoreTokenFromResponse
+{
+    //Create a normal authority (not a test one):
+    ADAuthenticationError* error;
+    _context = [ADAuthenticationContext authenticationContextWithAuthority:_authority error:&error];
+    XCTAssertNotNil(_context);
+    ADAssertNoError;
+    
+    //add refresh token:
+    NSString* oldRefreshToken = @"old refresh token";
+    _userId = nil;
+    _policy = @"sign_in";
+    ADD_AT_RT_TO_CACHE(nil, oldRefreshToken);
+    ADAssertLongEquals(1, [self cacheCount]);
+    
+    //new refresh token and id token in response
+    NSString* newRefreshToken = @"new refresh token";
+    NSString* newIdToken = @"new id token";
+    ADTestURLResponse* response = [ADTestURLResponse requestURLString:@"https://login.windows.net/msopentechbv.onmicrosoft.com/oauth2/v2.0/token?p=sign_in&x-client-Ver=" ADAL_VERSION_STRING
+                                                    responseURLString:@"https://login.windows.net/msopentechbv.onmicrosoft.com/oauth2/v2.0/token?x-client-Ver=" ADAL_VERSION_STRING
+                                                         responseCode:200
+                                                     httpHeaderFields:@{ }
+                                                     dictionaryAsJSON:@{ OAUTH2_TOKEN_TYPE : @"Bearer",
+                                                                         OAUTH2_REFRESH_TOKEN : newRefreshToken,
+                                                                         OAUTH2_ID_TOKEN : newIdToken,
+                                                                         OAUTH2_SCOPE : @"plantetarydefense.fire planetarydefense.target openid offline_access"
+                                                                         }];
+    [ADTestURLConnection addResponse:response];
+    
+    //call acquireToken
+    //AT and RT should be extracted from response and updated in cache
+    acquireTokenAsync;
+    ADAssertLongEquals(1, [self cacheCount]);
+    
+    //call acquireToken again, this time access token should be retrieved from cache
+    acquireTokenAsync;
+    XCTAssertEqual(_result.status, AD_SUCCEEDED);
+    XCTAssertEqualObjects(_result.accessToken, newIdToken);
+    XCTAssertEqualObjects(_result.tokenCacheStoreItem.refreshToken, newRefreshToken);
+    
+    
+}
+
 - (void)testUnreachableAuthority
 {
     //Create a normal authority (not a test one):


### PR DESCRIPTION
(For #582)

Policy value is used to look up for proper refresh token from cache but previously it was not set for each cache item.
Now policy value is set before a cache item is stored.

--------------

When adding the unit test, I found a few more bugs:
1) For [ADKeychainTokenCacheStore getItemWithKey:error:], policy value is not retrieved.

2) userId being NSNull should be treated the same as being nil. Otherwise it can cause ADAL to crash in one place, it can also cause cache to unwanted behaviour.