### PR TITLE
Whitelist "about:blank" for allowed redirect URIs

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -24,8 +24,8 @@
 /* Begin PBXBuildFile section */
 		601BEE311C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */; };
 		601BEE321C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */; };
-		601BEE341C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE331C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m */; };
-		601BEE351C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE331C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m */; };
+		601BEE341C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */; };
+		601BEE351C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */; };
 		6071B5E41C14C0B0006F6CC2 /* ADTestURLConnection.m in Sources */ = {isa = PBXBuildFile; fileRef = 6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */; };
 		8B0965AE17F25770002BDFB8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B0965AD17F25770002BDFB8 /* Foundation.framework */; };
 		8B0965BC17F25770002BDFB8 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8B0965BB17F25770002BDFB8 /* XCTest.framework */; };
@@ -306,7 +306,7 @@
 /* Begin PBXFileReference section */
 		601BEE2F1C6D9CCE004AA8C1 /* ADTestAuthenticationViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTestAuthenticationViewController.h; sourceTree = "<group>"; };
 		601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestAuthenticationViewController.m; sourceTree = "<group>"; };
-		601BEE331C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewControllerTests.m; sourceTree = "<group>"; };
+		601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthControllerTests.m; sourceTree = "<group>"; };
 		6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLConnection.h; sourceTree = "<group>"; };
 		6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLConnection.m; sourceTree = "<group>"; };
 		8B0965AA17F25770002BDFB8 /* libADALiOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libADALiOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -633,7 +633,7 @@
 				94DD19091C5AD3B200F80C62 /* mac */,
 				601BEE2F1C6D9CCE004AA8C1 /* ADTestAuthenticationViewController.h */,
 				601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */,
-				601BEE331C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m */,
+				601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1282,7 +1282,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				601BEE341C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m in Sources */,
+				601BEE341C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */,
 				6071B5E41C14C0B0006F6CC2 /* ADTestURLConnection.m in Sources */,
 				8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */,
 				94DD19081C5AD3A600F80C62 /* ADKeychainTokenCacheTests.m in Sources */,
@@ -1379,7 +1379,7 @@
 				94DD18FD1C5ACFF900F80C62 /* NSURLExtensionsTests.m in Sources */,
 				94DD18FF1C5ACFF900F80C62 /* ADTokenCacheTests.m in Sources */,
 				94DD18FA1C5ACFF900F80C62 /* ADTokenCacheItemTests.m in Sources */,
-				601BEE351C6DCB0B004AA8C1 /* ADAuthenticationViewControllerTests.m in Sources */,
+				601BEE351C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */,
 				94DD18F91C5ACFF900F80C62 /* ADUserInformationTests.m in Sources */,
 				94DD18F71C5ACFF900F80C62 /* ADLoggerTests.m in Sources */,
 				94DD18F11C5ACFF000F80C62 /* ADAuthenticationParametersTests.m in Sources */,

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -304,6 +304,11 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
     }
     
     NSString *requestURL = [request.URL absoluteString];
+
+    if ([[requestURL lowercaseString] isEqualToString:@"about:blank"])
+    {
+        return NO;
+    }
     
     if ([[[request.URL scheme] lowercaseString] isEqualToString:@"browser"])
     {
@@ -354,7 +359,7 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
     }
     
     // redirecting to non-https url is not allowed
-    if (![requestURL hasPrefix: @"https"])
+    if (![[[request.URL scheme] lowercaseString] isEqualToString:@"https"])
     {
         AD_LOG_ERROR(@"Server is redirecting to a non-https url", AD_ERROR_SERVER_NON_HTTPS_REDIRECT, nil, nil);
         _complete = YES;

--- a/ADAL/tests/ADAuthenticationViewControllerTests.m
+++ b/ADAL/tests/ADAuthenticationViewControllerTests.m
@@ -73,9 +73,6 @@
     //Create a context with empty token cache
     ADAuthenticationContext* context = [self getTestAuthenticationContext];
     
-    //Add two delegate calls to the mocking ADTestAuthenticationViewController
-    //First one in https while the second one in http
-    [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:TEST_AUTHORITY]]];
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:TEST_REDIRECT_URL]];
     
@@ -85,12 +82,11 @@
                                userId:TEST_USER_ID
                       completionBlock:^(ADAuthenticationResult *result)
      {
-         //Should fail with AD_ERROR_NON_HTTPS_REDIRECT error
+         // we check for AD_ERROR_SERVER_AUTHORIZATION_CODE because the final url is redirect url that does not contain code QP.
+         // but the test validates that about:blank is whitelisted from non-https error.
          XCTAssertNotNil(result);
          XCTAssertEqual(result.status, AD_FAILED);
          XCTAssertNotNil(result.error);
-         // we check for AD_ERROR_SERVER_AUTHORIZATION_CODE because the final url is redirect url that does not contain code QP.
-         // but the test validates that about:blank is whitelisted from non-https error check.
          XCTAssertEqual(result.error.code, AD_ERROR_SERVER_AUTHORIZATION_CODE);
          
          dispatch_semaphore_signal(_dsem);

--- a/ADAL/tests/ADAuthenticationViewControllerTests.m
+++ b/ADAL/tests/ADAuthenticationViewControllerTests.m
@@ -67,6 +67,39 @@
     return context;
 }
 
+
+- (void)testAboutBlankWhitelistInWebView
+{
+    //Create a context with empty token cache
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    
+    //Add two delegate calls to the mocking ADTestAuthenticationViewController
+    //First one in https while the second one in http
+    [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:TEST_AUTHORITY]]];
+    [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
+    [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:TEST_REDIRECT_URL]];
+    
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:TEST_REDIRECT_URL
+                               userId:TEST_USER_ID
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         //Should fail with AD_ERROR_NON_HTTPS_REDIRECT error
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         // we check for AD_ERROR_SERVER_AUTHORIZATION_CODE because the final url is redirect url that does not contain code QP.
+         // but the test validates that about:blank is whitelisted from non-https error check.
+         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_AUTHORIZATION_CODE);
+         
+         dispatch_semaphore_signal(_dsem);
+     }];
+    
+    [self waitSemaphoreWithoutBlockingMainQueue:_dsem];
+    
+}
+
 - (void)testNonHttpsRedirectInWebView
 {
     //Create a context with empty token cache

--- a/ADAL/tests/ADTestAuthenticationViewController.h
+++ b/ADAL/tests/ADTestAuthenticationViewController.h
@@ -50,5 +50,6 @@
 + (void)addDelegateCallWebAuthShouldStartLoadRequest:(NSURLRequest*)request;
 + (void)addDelegateCallWebAuthDidCompleteWithURL:(NSURL *)endURL;
 + (void)addDelegateCallWebAuthDidFailWithError:(NSError *)error;
++ (void)clearDelegateCalls;
 
 @end

--- a/ADAL/tests/ADTestAuthenticationViewController.m
+++ b/ADAL/tests/ADTestAuthenticationViewController.m
@@ -236,4 +236,9 @@ static NSMutableArray<WebAuthDelegateCall*> * s_delegateCalls = nil;
     SAFE_ARC_RELEASE(call);
 }
 
++ (void)clearDelegateCalls
+{
+    [s_delegateCalls removeAllObjects];
+}
+
 @end

--- a/ADAL/tests/ADWebAuthControllerTests.m
+++ b/ADAL/tests/ADWebAuthControllerTests.m
@@ -23,8 +23,9 @@
 #import "ADAuthenticationContext+Internal.h"
 #import "XCTestCase+TestHelperMethods.h"
 #import "ADTokenCache+Internal.h"
+#import "ADWebAuthController+Internal.h"
 
-@interface ADAuthenticationViewControllerTests : XCTestCase
+@interface ADWebAuthControllerTests : XCTestCase
 {
 @private
     dispatch_semaphore_t _dsem;
@@ -32,7 +33,7 @@
 
 @end
 
-@implementation ADAuthenticationViewControllerTests
+@implementation ADWebAuthControllerTests
 
 - (void)setUp
 {
@@ -46,6 +47,7 @@
     dispatch_release(_dsem);
 #endif
     _dsem = nil;
+    [ADTestAuthenticationViewController clearDelegateCalls];
     [super tearDown];
 }
 
@@ -67,30 +69,31 @@
     return context;
 }
 
-
 - (void)testAboutBlankWhitelistInWebView
 {
-    //Create a context with empty token cache
-    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    ADWebAuthController* controller = [ADWebAuthController sharedInstance];
     
+    //add about:blank url in the middle to test that it does not fail as non-https redirect.
+    [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:TEST_AUTHORITY]]];
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"about:blank"]]];
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:TEST_REDIRECT_URL]];
-    
-    [context acquireTokenWithResource:TEST_RESOURCE
-                             clientId:TEST_CLIENT_ID
-                          redirectUri:TEST_REDIRECT_URL
-                               userId:TEST_USER_ID
-                      completionBlock:^(ADAuthenticationResult *result)
-     {
-         // we check for AD_ERROR_SERVER_AUTHORIZATION_CODE because the final url is redirect url that does not contain code QP.
-         // but the test validates that about:blank is whitelisted from non-https error.
-         XCTAssertNotNil(result);
-         XCTAssertEqual(result.status, AD_FAILED);
-         XCTAssertNotNil(result.error);
-         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_AUTHORIZATION_CODE);
-         
-         dispatch_semaphore_signal(_dsem);
-     }];
+
+    [controller start:[NSURL URLWithString:TEST_AUTHORITY]
+                  end:TEST_REDIRECT_URL
+          refreshCred:nil
+#if TARGET_OS_IPHONE
+               parent:nil
+           fullScreen:false
+#endif
+            webView:nil
+        correlationId:[NSUUID new]
+           completion:^(ADAuthenticationError *error, NSURL *url) {
+               
+               XCTAssertNil(error);
+               XCTAssertNotNil(url);
+               XCTAssertEqual(url.absoluteString, TEST_REDIRECT_URL.absoluteString);
+               dispatch_semaphore_signal(_dsem);
+    }];
     
     [self waitSemaphoreWithoutBlockingMainQueue:_dsem];
     
@@ -98,29 +101,32 @@
 
 - (void)testNonHttpsRedirectInWebView
 {
-    //Create a context with empty token cache
-    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    ADWebAuthController* controller = [ADWebAuthController sharedInstance];
     
     //Add two delegate calls to the mocking ADTestAuthenticationViewController
     //First one in https while the second one in http
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:TEST_AUTHORITY]]];
     [ADTestAuthenticationViewController addDelegateCallWebAuthShouldStartLoadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"http://abc.com"]]];
     
-    [context acquireTokenWithResource:TEST_RESOURCE
-                             clientId:TEST_CLIENT_ID
-                          redirectUri:TEST_REDIRECT_URL
-                               userId:TEST_USER_ID
-                      completionBlock:^(ADAuthenticationResult *result)
-     {
-         //Should fail with AD_ERROR_NON_HTTPS_REDIRECT error
-         XCTAssertNotNil(result);
-         XCTAssertEqual(result.status, AD_FAILED);
-         XCTAssertNotNil(result.error);
-         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_NON_HTTPS_REDIRECT);
-         
-         dispatch_semaphore_signal(_dsem);
-     }];
-    
+    [controller start:[NSURL URLWithString:TEST_AUTHORITY]
+                  end:TEST_REDIRECT_URL
+          refreshCred:nil
+#if TARGET_OS_IPHONE
+               parent:nil
+           fullScreen:false
+#endif
+              webView:nil
+        correlationId:[NSUUID new]
+           completion:^(ADAuthenticationError *error, NSURL *url) {
+               
+               //Should fail with AD_ERROR_NON_HTTPS_REDIRECT error
+               XCTAssertNil(url);
+               XCTAssertNotNil(error);
+               XCTAssertEqual(error.code, AD_ERROR_SERVER_NON_HTTPS_REDIRECT);
+               
+               dispatch_semaphore_signal(_dsem);
+           }];
+               
     [self waitSemaphoreWithoutBlockingMainQueue:_dsem];
     
 }


### PR DESCRIPTION
This fix whitelists about:blank as a URL for checks against non-https
redirects.