### PR TITLE
Changes made to age out tombstone.

### DIFF
--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -34,7 +34,7 @@
 @implementation ADTokenCacheItem (Internal)
 
 #define CHECK_ERROR(_CHECK, _ERR) { if (_CHECK) { if (error) {*error = _ERR;} return; } }
-#define THIRTY_DAYS_IN_SECONDS 2592000
+#define THIRTY_DAYS_IN_SECONDS (30*24*60*60)
 
 - (void)checkCorrelationId:(NSDictionary*)response
       requestCorrelationId:(NSUUID*)requestCorrelationId

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -34,6 +34,7 @@
 @implementation ADTokenCacheItem (Internal)
 
 #define CHECK_ERROR(_CHECK, _ERR) { if (_CHECK) { if (error) {*error = _ERR;} return; } }
+#define THIRTY_DAYS_IN_SECONDS 2592000
 
 - (void)checkCorrelationId:(NSDictionary*)response
       requestCorrelationId:(NSUUID*)requestCorrelationId
@@ -222,6 +223,9 @@
     //wipe out the refresh token
     _refreshToken = @"<tombstone>";
     _tombstone = tombstoneDictionary;
+    SAFE_ARC_RELEASE(_expiresOn);
+    _expiresOn = [NSDate dateWithTimeIntervalSinceNow:THIRTY_DAYS_IN_SECONDS];//tombstones should be removed after 30 days
+    SAFE_ARC_RETAIN(_expiresOn);
 
 }
 

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -42,7 +42,7 @@ static NSString* const s_delimiter = @"|";
 
 static NSString* const s_libraryString = @"MSOpenTech.ADAL." TOSTRING(KEYCHAIN_VERSION);
 
-static NSString* const s_keyForStoringTomestoneCleanTime = @"NEXT-TOMBSTONE-CLEAN-TIME";
+static NSString* const s_keyForStoringTomestoneCleanTime = @"ADAL-NEXT-TOMBSTONE-CLEAN-TIME";
 
 @implementation ADKeychainTokenCache
 {


### PR DESCRIPTION
(for #523)

Tombstones 30-day old will be deleted.
Clean frequency is set to be once a day. Cleaning necessity check is performed once per app launch, i.e. the checking code is put at the init function of ADKeychainTokenCache using dispatch_once.