### PR TITLE
Change generic attr on tombstone timestamp

### DIFF
--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -49,6 +49,7 @@ static NSString* const s_tombstoneLibraryString = @"Microsoft.ADAL.Tombstone." T
 {
     NSString* _sharedGroup;
     NSDictionary* _default;
+    NSDictionary* _defaultTombstone;
 }
 
 // Shouldn't be called.
@@ -80,6 +81,18 @@ static NSString* const s_tombstoneLibraryString = @"Microsoft.ADAL.Tombstone." T
                  (id)kSecAttrGeneric : [s_libraryString dataUsingEncoding:NSUTF8StringEncoding]
                  };
     SAFE_ARC_RETAIN(_default);
+    
+    // Use a different generic attribute so that past versions of ADAL don't trip up on this entry
+    _defaultTombstone = @{
+                 (id)kSecClass : (id)kSecClassGenericPassword,
+                 //Apps are not signed on the simulator, so the shared group doesn't apply there.
+#if !(TARGET_IPHONE_SIMULATOR)
+                 (id)kSecAttrAccessGroup : (id)_sharedGroup,
+#endif
+                 (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding]
+                 };
+    SAFE_ARC_RETAIN(_default);
+
     
     static dispatch_once_t onceToken = 0;
     dispatch_once(&onceToken, ^{
@@ -406,12 +419,12 @@ static NSString* const s_tombstoneLibraryString = @"Microsoft.ADAL.Tombstone." T
 
 - (NSDate*)getTombstoneCleanTime
 {
-    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithDictionary:_default];
+    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithDictionary:_defaultTombstone];
+    
     [query addEntriesFromDictionary:@{ (id)kSecMatchLimit : (id)kSecMatchLimitOne,
                                        (id)kSecReturnData : @YES,
-                                       (id)kSecAttrService : s_keyForStoringTomestoneCleanTime,
-                                       (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding] }];
-
+                                       (id)kSecAttrService : s_keyForStoringTomestoneCleanTime }];
+    
     NSData* data = nil;
     OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, (CFTypeRef *)&data);
     if (status == errSecSuccess && data)
@@ -427,9 +440,8 @@ static NSString* const s_tombstoneLibraryString = @"Microsoft.ADAL.Tombstone." T
 
 - (void)storeTombstoneCleanTime:(NSDate *)cleanTime
 {
-    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithDictionary:_default];
-    [query addEntriesFromDictionary:@{ (id)kSecAttrService : s_keyForStoringTomestoneCleanTime,
-                                       (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding] }];
+    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithDictionary:_defaultTombstone];
+    [query setObject:s_keyForStoringTomestoneCleanTime forKey:(id)kSecAttrService];
     
     NSData* itemData = [NSKeyedArchiver archivedDataWithRootObject:cleanTime];
     if (!itemData)
@@ -671,6 +683,10 @@ static NSString* const s_tombstoneLibraryString = @"Microsoft.ADAL.Tombstone." T
         NSMutableDictionary* query = [self queryDictionaryForKey:nil userId:nil additional:nil];
         OSStatus status = SecItemDelete((CFDictionaryRef)query);
         [ADKeychainTokenCache checkStatus:status operation:@"remove all" correlationId:nil error:error];
+        
+        // Remove the tombstone timestamp as well;
+        status = SecItemDelete((CFDictionaryRef)_defaultTombstone);
+        [ADKeychainTokenCache checkStatus:status operation:@"remove tombstone timestamp" correlationId:nil error:nil];
     }
 }
 


### PR DESCRIPTION
The tombstone timestamp is tripping up old versions of ADAL and causing allItems to fail on 1.2.x. Change the generic on it so it doesn't show up in their keychain queries.