### PR TITLE
Check Broker RedirectURI in -acquireToken:

### DIFF
--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -30,7 +30,7 @@ NSString* const ADCredentialsNeeded = @"The user credentials are need to obtain 
 NSString* const ADInteractionNotSupportedInExtension = @"Interaction is not supported in an app extension.";
 NSString* const ADServerError = @"The authentication server returned an error: %@.";
 NSString* const ADBrokerAppIdentifier = @"com.microsoft.azureadauthenticator";
-NSString* const ADRedirectUriInvalidError = @"Redirect URI cannot be used to invoke the application. Update your redirect URI to be of  <app-scheme>://<bundle-id> format";
+NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is configured to allow brokered authentication but your redirect URI is not setup properly. Make sure your redirect URI is in the form of <app-scheme>://<bundle-id> (e.g. \"x-adal-broker-testapp://com.microsoft.adal.testapp\") and that the \"app-scheme\" you choose is registered in your application's info.plist.";
 
 @implementation ADAuthenticationContext (Internal)
 

--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -30,7 +30,7 @@ NSString* const ADCredentialsNeeded = @"The user credentials are need to obtain 
 NSString* const ADInteractionNotSupportedInExtension = @"Interaction is not supported in an app extension.";
 NSString* const ADServerError = @"The authentication server returned an error: %@.";
 NSString* const ADBrokerAppIdentifier = @"com.microsoft.azureadauthenticator";
-NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is configured to allow brokered authentication but your redirect URI is not setup properly. Make sure your redirect URI is in the form of <app-scheme>://<bundle-id> (e.g. \"x-adal-broker-testapp://com.microsoft.adal.testapp\") and that the \"app-scheme\" you choose is registered in your application's info.plist.";
+NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is configured to allow brokered authentication but your redirect URI is not setup properly. Make sure your redirect URI is in the form of <app-scheme>://<bundle-id> (e.g. \"x-msauth-testapp://com.microsoft.adal.testapp\") and that the \"app-scheme\" you choose is registered in your application's info.plist.";
 
 @implementation ADAuthenticationContext (Internal)
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -56,6 +56,17 @@
         return;
     }
     
+    if (!_silent && _context.credentialsType == AD_CREDENTIALS_AUTO && ![ADAuthenticationRequest validBrokerRedirectUri:_redirectUri])
+    {
+        ADAuthenticationError* error =
+        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI
+                                               protocolCode:nil
+                                               errorDetails:ADRedirectUriInvalidError
+                                              correlationId:_correlationId];
+        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+        return;
+    }
+    
     if (!_context.validateAuthority)
     {
         [self validatedAcquireToken:completionBlock];

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.h
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.h
@@ -27,6 +27,8 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
 + (void)internalHandleBrokerResponse:(NSURL*)response;
 
++ (BOOL)validBrokerRedirectUri:(NSString*)url;
+
 - (BOOL)canUseBroker;
 
 - (void)callBroker:(ADAuthenticationCallback)completionBlock;

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -55,7 +55,8 @@
     }
     
     NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
-    if (![[redirectURI path] isEqualToString:bundleId])
+    NSString* host = [redirectURI host];
+    if (![host isEqualToString:bundleId])
     {
         return NO;
     }

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -42,12 +42,20 @@
 
 @implementation ADAuthenticationRequest (Broker)
 
-+ (BOOL)respondsToUrl:(NSString*)url
++ (BOOL)validBrokerRedirectUri:(NSString*)url
 {
     NSArray* urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
     
-    NSString* scheme = [[NSURL URLWithString:url] scheme];
+    NSURL* redirectURI = [NSURL URLWithString:url];
+    
+    NSString* scheme = redirectURI.scheme;
     if (!scheme)
+    {
+        return NO;
+    }
+    
+    NSString* bundleId = [[NSBundle mainBundle] bundleIdentifier];
+    if (![[redirectURI path] isEqualToString:bundleId])
     {
         return NO;
     }
@@ -182,7 +190,7 @@
     CHECK_FOR_NIL(_correlationId);
     
     ADAuthenticationError* error = nil;
-    if(![ADAuthenticationRequest respondsToUrl:_redirectUri])
+    if(![ADAuthenticationRequest validBrokerRedirectUri:_redirectUri])
     {
         error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI
                                                        protocolCode:nil
@@ -248,7 +256,7 @@
     CHECK_FOR_NIL(_resource);
     
     ADAuthenticationError* error = nil;
-    if(![ADAuthenticationRequest respondsToUrl:_redirectUri])
+    if(![ADAuthenticationRequest validBrokerRedirectUri:_redirectUri])
     {
         error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI
                                                        protocolCode:nil

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -166,6 +166,27 @@ const int sAsyncContextTimeout = 10;
     TEST_WAIT;
 }
 
+- (void)testInvalidBrokerRedirectURI
+{
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    
+    [context setCredentialsType:AD_CREDENTIALS_AUTO];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:[NSURL URLWithString:@"urn:ietf:wg:oauth:2.0:oob"]
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI);
+         
+         TEST_SIGNAL;
+     }];
+    
+    TEST_WAIT;
+}
+
 - (void)testAssertionBadAssertion
 {
     ADAuthenticationContext* context = [self getTestAuthenticationContext];

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
@@ -51,7 +51,7 @@ NSString* ADTestAppCacheChangeNotification = @"ADTestAppCacheChangeNotification"
                                      // NOTE: The settings below should come from your registered application on
                                      //       the azure management portal.
                                      @"clientId" : @"b92e0ba5-f86e-4411-8e18-6b5f928d968a",
-                                     @"redirectUri" : @"urn:ietf:wg:oauth:2.0:oob",
+                                     @"redirectUri" : @"x-msauth-adaltestapp-210://com.microsoft.adal.2.1.0.TestApp",
                                      };
     
     [defaults registerDefaults:defaultValues];

--- a/Samples/MyTestiOSApp/MyTestiOSApp/MyTestiOSApp-Info.plist
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/MyTestiOSApp-Info.plist
@@ -20,19 +20,19 @@
 	<string>2.1.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
-	<key>CFBundleURLTypes</key>
-	<array>
-		<dict>
-			<key>CFBundleTypeRole</key>
-			<string>Editor</string>
-			<key>CFBundleURLName</key>
-			<string>com.MSOpenTech.MyTestiOSApp</string>
-			<key>CFBundleURLSchemes</key>
-			<array>
-				<string>MyTestiOSApp</string>
-			</array>
-		</dict>
-	</array>
+    <key>CFBundleURLTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeRole</key>
+            <string>Editor</string>
+            <key>CFBundleURLName</key>
+            <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+            <key>CFBundleURLSchemes</key>
+            <array>
+                <string>x-msauth-adaltestapp-210</string>
+            </array>
+        </dict>
+    </array>
 	<key>CFBundleVersion</key>
 	<string>1.0</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
If the authentication context is set up to use broker then we want to fail really early on an invalid redirect URI, before we check for the broker being installed. This way we don't surprise developers if their code doesn't work when the Authenticator is installed.