### PR TITLE
Packed underlying errors to the error object when interaction needed.

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
@@ -32,8 +32,7 @@
 
 // Bypasses the cache and attempts to request a token from the server, generally called after
 // attempts to use cached tokens failed
-- (void)requestToken:(ADAuthenticationError*)previousError
-     completionBlock:(ADAuthenticationCallback)completionBlock;
+- (void)requestToken:(ADAuthenticationCallback)completionBlock;
 
 // Generic OAuth2 Authorization Request, obtains a token from an authorization code.
 - (void)requestTokenByCode:(NSString*)code

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
@@ -32,7 +32,8 @@
 
 // Bypasses the cache and attempts to request a token from the server, generally called after
 // attempts to use cached tokens failed
-- (void)requestToken:(ADAuthenticationCallback)completionBlock;
+- (void)requestToken:(ADAuthenticationError*)previousError
+     completionBlock:(ADAuthenticationCallback)completionBlock;
 
 // Generic OAuth2 Authorization Request, obtains a token from an authorization code.
 - (void)requestTokenByCode:(NSString*)code

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -230,7 +230,8 @@
         //so credentials are needed to get an access token, but the developer, requested
         //no UI to be shown:
         NSDictionary* underlyingError = _underlyingError ? @{NSUnderlyingErrorKey:_underlyingError} : nil;
-        ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
+        ADAuthenticationError* error =
+        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
                                                protocolCode:nil
                                                errorDetails:ADCredentialsNeeded
                                                    userInfo:underlyingError

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -229,16 +229,11 @@
         //The cache lookup and refresh token attempt have been unsuccessful,
         //so credentials are needed to get an access token, but the developer, requested
         //no UI to be shown:
-        ADAuthenticationError* error = _underlyingError ?
-        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
+        NSDictionary* underlyingError = _underlyingError ? @{NSUnderlyingErrorKey:_underlyingError} : nil;
+        ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
                                                protocolCode:nil
                                                errorDetails:ADCredentialsNeeded
-                                                   userInfo:@{NSUnderlyingErrorKey:_underlyingError}
-                                              correlationId:_correlationId]
-        :
-        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
-                                               protocolCode:nil
-                                               errorDetails:ADCredentialsNeeded
+                                                   userInfo:underlyingError
                                               correlationId:_correlationId];
         
         ADAuthenticationResult* result = [ADAuthenticationResult resultFromError:error correlationId:_correlationId];

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -130,7 +130,7 @@
         }
     }
     
-    [self requestToken:completionBlock];
+    [self requestToken:error completionBlock:completionBlock];
 }
 
 /*Attemps to use the cache. Returns YES if an attempt was successful or if an
@@ -214,11 +214,12 @@
          
          //The refresh token attempt failed and no other suitable refresh token found
          //call acquireToken
-         [self requestToken:completionBlock];
+         [self requestToken:[result error] completionBlock:completionBlock];
      }];//End of the refreshing token completion block, executed asynchronously.
 }
 
-- (void)requestToken:(ADAuthenticationCallback)completionBlock
+- (void)requestToken:(ADAuthenticationError*)previousError
+     completionBlock:(ADAuthenticationCallback)completionBlock
 {
     [self ensureRequest];
 
@@ -231,6 +232,7 @@
         [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
                                                protocolCode:nil
                                                errorDetails:ADCredentialsNeeded
+                                                   userInfo:@{NSUnderlyingErrorKey:(previousError?previousError:[NSNull null])}
                                               correlationId:_correlationId];
         ADAuthenticationResult* result = [ADAuthenticationResult resultFromError:error correlationId:_correlationId];
         completionBlock(result);
@@ -269,7 +271,7 @@
              if (silentRequest)
              {
                  _allowSilent = NO;
-                 [self requestToken:completionBlock];
+                 [self requestToken:error completionBlock:completionBlock];
                  return;
              }
              

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -68,6 +68,8 @@
     NSString* _logComponent;
     
     BOOL _requestStarted;
+    
+    ADAuthenticationError* _underlyingError;
 }
 
 @property (retain) NSString* logComponent;

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -133,6 +133,7 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     SAFE_ARC_RELEASE(_queryParams);
     SAFE_ARC_RELEASE(_refreshTokenCredential);
     SAFE_ARC_RELEASE(_correlationId);
+    SAFE_ARC_RELEASE(_underlyingError);
     
     SAFE_ARC_SUPER_DEALLOC();
 }


### PR DESCRIPTION
For #580

Underlying error is stored in the error object when AD_ERROR_SERVER_USER_INPUT_NEEDED error is returned.