### PR TITLE
Only delete RTs when we get 'invalid_grant' from the server

### DIFF
--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -693,20 +693,17 @@ const int sAsyncContextTimeout = 10;
     // Set up the mock connection to simulate a no internet connection error
     [ADTestURLConnection addResponse:[self adDefaultBadRefreshTokenResponseError:@"unauthorized_client"]];
     
-    // Web UI should not attempt to launch when we fail to refresh the RT because there is no internet
-    // connection
-    [context acquireTokenWithResource:TEST_RESOURCE
-                             clientId:TEST_CLIENT_ID
-                          redirectUri:TEST_REDIRECT_URL
-                               userId:TEST_USER_ID
-                      completionBlock:^(ADAuthenticationResult *result)
-     {
-         XCTAssertNotNil(result);
-         XCTAssertEqual(result.status, AD_FAILED);
-         XCTAssertNotNil(result.error);
-         
-         TEST_SIGNAL;
-     }];
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                            completionBlock:^(ADAuthenticationResult *result)
+    {
+        XCTAssertNotNil(result);
+        XCTAssertEqual(result.status, AD_FAILED);
+        XCTAssertNotNil(result.error);
+        
+        TEST_SIGNAL;
+    }];
     
     TEST_WAIT;
     
@@ -715,8 +712,6 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNotNil(allItems);
     XCTAssertEqual(allItems.count, 1);
     XCTAssertEqualObjects(allItems[0], mrrtItem);
-    
-    
 }
 
 - (void)testRequestRetryOnUnusualHttpResponse

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -679,6 +679,46 @@ const int sAsyncContextTimeout = 10;
     XCTAssertEqualObjects(allItems[0], mrrtItem);
 }
 
+- (void)testMRRTUnauthorizedClient
+{
+    // Refresh tokens should only be deleted when the server returns a 'invalid_grant' error
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    
+    // Add an MRRT to the cache as well
+    ADTokenCacheItem* mrrtItem = [self adCreateMRRTCacheItem];
+    [[context tokenCacheStore] addOrUpdateItem:mrrtItem correlationId:nil error:&error];
+    XCTAssertNil(error);
+    
+    // Set up the mock connection to simulate a no internet connection error
+    [ADTestURLConnection addResponse:[self adDefaultBadRefreshTokenResponseError:@"unauthorized_client"]];
+    
+    // Web UI should not attempt to launch when we fail to refresh the RT because there is no internet
+    // connection
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:TEST_REDIRECT_URL
+                               userId:TEST_USER_ID
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         
+         TEST_SIGNAL;
+     }];
+    
+    TEST_WAIT;
+    
+    // The MRRT should still be in the cache
+    NSArray* allItems = [[context tokenCacheStore] allItems:&error];
+    XCTAssertNotNil(allItems);
+    XCTAssertEqual(allItems.count, 1);
+    XCTAssertEqualObjects(allItems[0], mrrtItem);
+    
+    
+}
+
 - (void)testRequestRetryOnUnusualHttpResponse
 {
     //Create a normal authority (not a test one):

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -71,6 +71,7 @@ typedef enum
                                         resource:(NSString *)resource
                                         clientId:(NSString *)clientId
                                    correlationId:(NSUUID *)correlationId;
+- (ADTestURLResponse *)adDefaultBadRefreshTokenResponseError:(NSString*)oauthError;
 - (ADTestURLResponse *)adDefaultBadRefreshTokenResponse;
 
 - (ADTestURLResponse *)adDefaultRefreshResponse:(NSString *)newRefreshToken

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -294,6 +294,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
                                        authority:(NSString *)authority
                                         resource:(NSString *)resource
                                         clientId:(NSString *)clientId
+                                      oauthError:(NSString *)oauthError
                                    correlationId:(NSUUID *)correlationId
 {
     NSString* requestUrlString = [NSString stringWithFormat:@"%@/oauth2/token?x-client-Ver=" ADAL_VERSION_STRING, authority];
@@ -314,19 +315,26 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
                       responseURLString:@"https://contoso.com"
                            responseCode:400
                        httpHeaderFields:@{}
-                       dictionaryAsJSON:@{ OAUTH2_ERROR : @"bad_refresh_token",
+                       dictionaryAsJSON:@{ OAUTH2_ERROR : oauthError,
                                            OAUTH2_ERROR_DESCRIPTION : @"oauth error description"}];
     
     return response;
 }
 
-- (ADTestURLResponse *)adDefaultBadRefreshTokenResponse
+- (ADTestURLResponse *)adDefaultBadRefreshTokenResponseError:(NSString*)oauthError
 {
     return [self adResponseBadRefreshToken:TEST_REFRESH_TOKEN
                                  authority:TEST_AUTHORITY
                                   resource:TEST_RESOURCE
                                   clientId:TEST_CLIENT_ID
+                                oauthError:oauthError
                              correlationId:TEST_CORRELATION_ID];
+
+}
+
+- (ADTestURLResponse *)adDefaultBadRefreshTokenResponse
+{
+    return [self adDefaultBadRefreshTokenResponseError:@"invalid_grant"];
 }
 
 - (ADTestURLResponse *)adDefaultRefreshResponse:(NSString *)newRefreshToken


### PR DESCRIPTION
MRRTs might still be good for other resources, so we want to limit the cases where we delete them. We still are working with the service to reduce the cases where they send us invalid_grant when another error is more appropriate.

#606 