### PR TITLE
Family of Client IDs support: Mk II

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ install:
 before_script:
 # Start by nuking any lingering codecov files. These can cause issues when the xcode version changes
   - find . -name "*.gcda" -print0 | xargs -0 rm
+  
+# Nuke the entire derived data folder while we're at it.
+  - rm -rf ~/Library/Developer/Xcode/DerivedData
 
 # Tell the shell to echo failure codes up the pipe so that Travis will properly fail the
 # build when the xcodebuild command fails

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -45,12 +45,14 @@
 #import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"
 #import "ADAuthenticationError+Internal.h"
+#import "ADAuthenticationResult+Internal.h"
 #import "NSString+ADHelperMethods.h"
 
 @class ADAuthenticationResult;
 
 /*! The completion block declaration. */
 typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
+
 
 #if TARGET_OS_IPHONE
 //iOS:
@@ -62,6 +64,7 @@ typedef UIWebView WebViewType;
 typedef WebView   WebViewType;
 #endif
 
+#import "ADAuthenticationRequest.h"
 
 //Helper macro to initialize a variable named __where string with place in file details:
 #define WHERE \

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -272,7 +272,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 #define CHECK_STRING_ARG_BLOCK(_arg) \
     if (!_arg || [NSString adIsStringNilOrBlank:_arg]) { \
-        ADAuthenticationError* error = [ADAuthenticationError invalidArgumentError:@#_arg " connot be nil" correlationId:_correlationId]; \
+        ADAuthenticationError* error = [ADAuthenticationError invalidArgumentError:@#_arg " cannot be nil" correlationId:_correlationId]; \
         completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]); \
         return; \
     }

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -21,36 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "ADAL_Internal.h"
-#import "ADAuthenticationContext.h"
-#import "ADAuthenticationResult.h"
-#import "ADAuthenticationResult+Internal.h"
-#import "ADOAuth2Constants.h"
-#import "ADWebAuthController.h"
 #import "ADAuthenticationSettings.h"
-#import "NSURL+ADExtensions.h"
-#import "NSDictionary+ADExtensions.h"
-#import "ADWebRequest.h"
-#import "ADWebResponse.h"
 #import "ADInstanceDiscovery.h"
-#import "ADTokenCacheItem.h"
-#import "ADTokenCacheKey.h"
-#import "ADUserInformation.h"
-#import "ADWorkPlaceJoin.h"
-#import "ADPkeyAuthHelper.h"
-#import "ADWorkPlaceJoinConstants.h"
-#import "ADBrokerKeyHelper.h"
-#import "ADClientMetrics.h"
-#import "NSString+ADHelperMethods.h"
-#import "ADHelpers.h"
-#import "ADBrokerNotificationManager.h"
-#import "ADOAuth2Constants.h"
-#import "ADAuthenticationRequest.h"
 #import "ADTokenCache+Internal.h"
 #if TARGET_OS_IPHONE
 #import "ADKeychainTokenCache+Internal.h"
 #endif 
-#import "ADTokenCacheAccessor.h"
 
 #import "ADAuthenticationContext+Internal.h"
 
@@ -283,6 +259,8 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 }
 
 #define REQUEST_WITH_REDIRECT_STRING(_redirect, _clientId, _resource) \
+    THROW_ON_NIL_ARGUMENT(completionBlock) \
+    CHECK_STRING_ARG_BLOCK(clientId) \
     ADAuthenticationRequest* request = [self requestWithRedirectString:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
     [request setLogComponent:_logComponent];
@@ -291,6 +269,13 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     ADAuthenticationRequest* request = [self requestWithRedirectUrl:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
     [request setLogComponent:_logComponent];
+
+#define CHECK_STRING_ARG_BLOCK(_arg) \
+    if (!_arg || [NSString adIsStringNilOrBlank:_arg]) { \
+        ADAuthenticationError* error = [ADAuthenticationError invalidArgumentError:@#_arg " connot be nil" correlationId:_correlationId]; \
+        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]); \
+        return; \
+    }
 
 - (void)acquireTokenForAssertion:(NSString*)assertion
                    assertionType:(ADAssertionType)assertionType
@@ -301,11 +286,14 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 {
     API_ENTRY;
     REQUEST_WITH_REDIRECT_STRING(nil, clientId, resource);
-    [request setUserId:userId];
+    CHECK_STRING_ARG_BLOCK(assertion);
+    CHECK_STRING_ARG_BLOCK(resource);
     
-    [request acquireTokenForAssertion:assertion
-                        assertionType:assertionType
-                      completionBlock:completionBlock];
+    [request setUserId:userId];
+    [request setSamlAssertion:assertion];
+    [request setAssertionType:assertionType];
+    
+    [request acquireToken:completionBlock];
     
 }
 

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -25,6 +25,8 @@
 
 @interface ADAuthenticationRequest (TokenCaching)
 
++ (NSString*)fociClientId:(NSString*)familyID;
+
 /*!
     Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
     the item to be stored.

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -25,7 +25,7 @@
 
 @interface ADAuthenticationRequest (TokenCaching)
 
-+ (NSString*)fociClientId:(NSString*)familyID;
++ (NSString*)familyClientId:(NSString*)familyID;
 
 /*!
     Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.h
@@ -25,12 +25,6 @@
 
 @interface ADAuthenticationRequest (TokenCaching)
 
-//Checks the cache for item that can be used to get directly or indirectly an access token.
-//Checks the multi-resource refresh tokens too.
-- (ADTokenCacheItem*)findCacheItemWithKey:(ADTokenCacheKey *)key
-                                   userId:(ADUserIdentifier *)userId
-                                    error:(ADAuthenticationError * __autoreleasing *)error;
-
 /*!
     Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
     the item to be stored.
@@ -42,8 +36,11 @@
                   cacheItem:(ADTokenCacheItem *)cacheItem
                refreshToken:(NSString *)refreshToken;
 
-- (ADTokenCacheItem *)extractCacheItemWithKey:(ADTokenCacheKey *)key
-                                       userId:(ADUserIdentifier *)userId
-                                        error:(ADAuthenticationError * __autoreleasing *)error;
+
+- (ADTokenCacheItem *)getItemForResource:(NSString*)resource
+                                clientId:(NSString*)clientId
+                                   error:(ADAuthenticationError * __autoreleasing *)error;
+
+- (ADTokenCacheItem*)getUnkownUserADFSToken:(ADAuthenticationError * __autoreleasing *)error;
 
 @end

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
@@ -32,7 +32,7 @@
 
 @implementation ADAuthenticationRequest (TokenCaching)
 
-+ (NSString*)fociClientId:(NSString*)familyID
++ (NSString*)familyClientId:(NSString*)familyID
 {
     if (!familyID)
     {
@@ -159,7 +159,7 @@
         if (familyId)
         {
             ADTokenCacheItem* frtItem = [multiRefreshTokenItem copy];
-            NSString* fociClientId = [ADAuthenticationRequest fociClientId:familyId];
+            NSString* fociClientId = [ADAuthenticationRequest familyClientId:familyId];
             frtItem.clientId = fociClientId;
             [tokenCacheStore addOrUpdateItem:frtItem correlationId:_correlationId error:nil];
             SAFE_ARC_RELEASE(frtItem);

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
@@ -152,7 +152,6 @@
         multiRefreshTokenItem.resource = nil;
         multiRefreshTokenItem.expiresOn = nil;
         [tokenCacheStore addOrUpdateItem:multiRefreshTokenItem correlationId:_correlationId error:nil];
-        SAFE_ARC_RELEASE(multiRefreshTokenItem);
         
         // If the item is also a Family Refesh Token (FRT) we update the FRT
         // as well so we have a guaranteed spot to look for the most recent FRT.
@@ -165,7 +164,7 @@
             [tokenCacheStore addOrUpdateItem:frtItem correlationId:_correlationId error:nil];
             SAFE_ARC_RELEASE(frtItem);
         }
-        
+        SAFE_ARC_RELEASE(multiRefreshTokenItem);
     }
     
     AD_LOG_VERBOSE_F(@"Token cache store", _correlationId, @"Storing access token for resource: %@", cacheItem.resource);

--- a/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
+++ b/ADAL/src/cache/ADAuthenticationRequest+TokenCaching.m
@@ -32,104 +32,43 @@
 
 @implementation ADAuthenticationRequest (TokenCaching)
 
-//Gets an item from the cache, where userId may be nil. Raises error, if items for multiple users
-//are present and user id is not specified.
-- (ADTokenCacheItem*)extractCacheItemWithKey:(ADTokenCacheKey *)key
-                                      userId:(ADUserIdentifier *)userId
-                                       error:(ADAuthenticationError* __autoreleasing*)error
+- (ADTokenCacheItem *)getItemForResource:(NSString*)resource
+                                clientId:(NSString*)clientId
+                                   error:(ADAuthenticationError * __autoreleasing *)error
 {
-    id<ADTokenCacheAccessor> tokenCacheStore = [_context tokenCacheStore];
-    if (!key || !tokenCacheStore)
+    ADTokenCacheKey* key = [ADTokenCacheKey keyWithAuthority:_context.authority
+                                                    resource:resource
+                                                    clientId:clientId
+                                                       error:error];
+    if (!key)
     {
-        return nil;//Nothing to return
-    }
-    
-    ADAuthenticationError* localError = nil;
-    ADTokenCacheItem* item = [tokenCacheStore getItemWithKey:key userId:userId.userId correlationId:_correlationId error:&localError];
-    if (!item && !localError && userId)
-    {
-        //ADFS fix, where the userId is not received by the server, but can be passed to the API:
-        //We didn't find element with the userId, try finding an item with a blank userId:
-        item = [tokenCacheStore getItemWithKey:key userId:@"" correlationId:_correlationId error:&localError];
-    }
-    if (error && localError)
-    {
-        *error = localError;
-    }
-    return item;
-}
-
-//Checks the cache for item that can be used to get directly or indirectly an access token.
-//Checks the multi-resource refresh tokens too.
-- (ADTokenCacheItem *)findCacheItemWithKey:(ADTokenCacheKey *) key
-                                    userId:(ADUserIdentifier *)userId
-                                     error:(ADAuthenticationError * __autoreleasing *)error
-{
-    if (error)
-    {
-        *error = nil;
-    }
-    
-    id<ADTokenCacheAccessor> tokenCacheStore = [_context tokenCacheStore];
-    
-    if (!key || !tokenCacheStore)
-    {
-        return nil;//Nothing to return
-    }
-    ADAuthenticationError* localError = nil;
-    ADTokenCacheItem* item = [self extractCacheItemWithKey:key
-                                                    userId:userId
-                                                     error:&localError];
-    if (localError)
-    {
-        if (error)
-        {
-            *error = localError;
-        }
         return nil;
     }
     
-    if (item.accessToken && !item.isExpired)
-    {
-        return item;
-    }
-    
-    if (![NSString adIsStringNilOrBlank:item.refreshToken])
-    {
-        // Suitable direct refresh token found.
-        return item;
-    }
-    
-    // We have a cache item that cannot be used anymore, remove it from the cache:
-    [tokenCacheStore removeItem:item error:nil];
-    
-    if (![NSString adIsStringNilOrBlank:key.resource])
-    {
-        //The request came for specific resource. Try returning a multi-resource refresh token:
-        ADTokenCacheKey* broadKey = [ADTokenCacheKey keyWithAuthority:_context.authority
-                                                                       resource:nil
-                                                                       clientId:key.clientId
-                                                                          error:&localError];
-        if (!broadKey)
-        {
-            AD_LOG_WARN(@"Unexpected error", _correlationId, localError.errorDetails);
-            return nil;//Recover
-        }
-        ADTokenCacheItem* broadItem = [self extractCacheItemWithKey:broadKey
-                                                             userId:userId
-                                                              error:&localError];
-        if (localError)
-        {
-            if (error)
-            {
-                *error = localError;
-            }
-            return nil;
-        }
-        return broadItem;
-    }
-    return nil;//Nothing suitable
+    return [[_context tokenCacheStore] getItemWithKey:key
+                                               userId:_identifier.userId
+                                        correlationId:_correlationId
+                                                error:error];
 }
+
+- (ADTokenCacheItem*)getUnkownUserADFSToken:(ADAuthenticationError * __autoreleasing *)error
+{
+    // ADFS fix: When talking to ADFS directly we can get ATs and RTs (but not MRRTs or FRTs) without
+    // id tokens. In those cases we do not know who they belong to and cache them with a blank userId
+    // (@"").
+    
+    ADTokenCacheKey* key = [ADTokenCacheKey keyWithAuthority:_context.authority
+                                                    resource:_resource
+                                                    clientId:_clientId
+                                                       error:error];
+    if (!key)
+    {
+        return nil;
+    }
+    
+    return [[_context tokenCacheStore] getItemWithKey:key userId:@"" correlationId:_correlationId error:error];
+}
+
 
 //Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
 //the item to be stored.

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.h
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.h
@@ -23,20 +23,7 @@
 
 @interface ADAuthenticationRequest (AcquireAssertion)
 
-- (void)acquireTokenForAssertion:(NSString*)samlAssertion
-                   assertionType:(ADAssertionType)assertionType
-                 completionBlock:(ADAuthenticationCallback)completionBlock;
-
-/*Attemps to use the cache. Returns YES if an attempt was successful or if an
- internal asynchronous call will proceed the processing. */
-- (void)attemptToUseCacheItem:(ADTokenCacheItem*)item
-                samlAssertion:(NSString*)samlAssertion
-                assertionType:(ADAssertionType)assertionType
-              completionBlock:(ADAuthenticationCallback)completionBlock;
-
 // Generic OAuth2 Authorization Request, obtains a token from a SAML assertion.
-- (void)requestTokenByAssertion:(NSString *)samlAssertion
-                  assertionType:(ADAssertionType)assertionType
-                     completion:(ADAuthenticationCallback)completionBlock;
+- (void)requestTokenByAssertion:(ADAuthenticationCallback)completionBlock;
 
 @end

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
@@ -30,192 +30,15 @@
 
 @implementation ADAuthenticationRequest (AcquireAssertion)
 
-- (void)acquireTokenForAssertion:(NSString*)samlAssertion
-                   assertionType:(ADAssertionType)assertionType
-                 completionBlock:(ADAuthenticationCallback)completionBlock
+- (NSString*)assertionTypeString
 {
-    
-    THROW_ON_NIL_ARGUMENT(completionBlock);
-    AD_REQUEST_CHECK_PROPERTY(_resource);
-    AD_REQUEST_CHECK_ARGUMENT(samlAssertion);
-    [self ensureRequest];
-
-    [[ADInstanceDiscovery sharedInstance] validateAuthority:_context.authority
-                                              correlationId:_correlationId
-                                            completionBlock:^(BOOL validated, ADAuthenticationError *error)
-     {
-         //Error should always be raised if the authority cannot be validated
-#pragma unused(validated)
-         if (error)
-         {
-             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-         }
-         else
-         {
-             [self validatedAcquireTokenForAssertion:samlAssertion
-                                       assertionType:assertionType
-                                     completionBlock:completionBlock];
-         }
-     }];
-    return;//The asynchronous handler above will do the work.
-}
-
-- (void)validatedAcquireTokenForAssertion:(NSString*)samlAssertion
-                            assertionType:(ADAssertionType)assertionType
-                          completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    [self ensureRequest];
-    //Check the cache:
-    ADAuthenticationError* error = nil;
-    //We are explicitly creating a key first to ensure indirectly that all of the required arguments are correct.
-    //This is the safest way to guarantee it, it will raise an error, if the the any argument is not correct:
-    ADTokenCacheKey* key = [ADTokenCacheKey keyWithAuthority:_context.authority
-                                                              resource:_resource
-                                                              clientId:_clientId error:&error];
-    if (!key)
+    if(_assertionType == AD_SAML1_1)
     {
-        //If the key cannot be extracted, call the callback with the information:
-        ADAuthenticationResult* result = [ADAuthenticationResult resultFromError:error correlationId:_correlationId];
-        completionBlock(result);
-        return;
-    }
-    
-    if ([_context hasCacheStore])
-    {
-        //Cache should be used in this case:
-        ADTokenCacheItem* cacheItem = [self findCacheItemWithKey:key
-                                                          userId:_identifier
-                                                           error:&error];
-        if (error)
-        {
-            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-            return;
-        }
-        
-        if (cacheItem)
-        {
-            //Found a promising item in the cache, try using it:
-            [self attemptToUseCacheItem:cacheItem
-                          samlAssertion:samlAssertion
-                          assertionType:assertionType
-                        completionBlock:completionBlock];
-            return; //The tryRefreshingFromCacheItem has taken care of the token obtaining
-        }
-    }
-    
-    [self requestTokenByAssertion:samlAssertion
-                    assertionType:assertionType
-                       completion:^(ADAuthenticationResult* result)
-    {
-        if (result.status == AD_SUCCEEDED)
-        {
-            [self updateCacheToResult:result cacheItem: nil refreshToken:nil];
-        }
-        
-        completionBlock(result);
-    }];
-}
-
-/*Attemps to use the cache. Returns YES if an attempt was successful or if an
- internal asynchronous call will proceed the processing. */
-- (void)attemptToUseCacheItem:(ADTokenCacheItem*)item
-                samlAssertion:(NSString*)samlAssertion
-                assertionType:(ADAssertionType)assertionType
-              completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    //All of these should be set before calling this method:
-    THROW_ON_NIL_ARGUMENT(completionBlock);
-    HANDLE_ARGUMENT(item, _correlationId);
-    AD_REQUEST_CHECK_PROPERTY(_resource);
-    AD_REQUEST_CHECK_PROPERTY(_clientId);
-    [self ensureRequest];
-    
-    if (item.accessToken && !item.isExpired)
-    {
-        //Access token is good, just use it:
-        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
-        ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheItem:item multiResourceRefreshToken:NO correlationId:_correlationId];
-        completionBlock(result);
-        return;
-    }
-    
-    if ([NSString adIsStringNilOrBlank:item.refreshToken])
-    {
-        completionBlock([ADAuthenticationResult resultFromError:[ADAuthenticationError unexpectedInternalError:@"Attempting to use an item without refresh token." correlationId:_correlationId]
-                                                  correlationId:_correlationId]);
-        return;
-    }
-    
-    //Now attempt to use the refresh token of the passed cache item:
-    BOOL isMultiresourceRefreshToken = [item isMultiResourceRefreshToken];
-    [self acquireTokenByRefreshToken:item.refreshToken
-                           cacheItem:item
-                     completionBlock:^(ADAuthenticationResult *result)
-     {
-         //Asynchronous block:
-         if ([ADAuthenticationContext isFinalResult:result])
-         {
-             completionBlock(result);
-             return;
-         }
-         
-         //Try other means of getting access token result:
-         if (!isMultiresourceRefreshToken)//Try multi-resource refresh token if not currently trying it
-         {
-             ADTokenCacheKey* broadKey = [ADTokenCacheKey keyWithAuthority:_context.authority resource:nil clientId:_clientId error:nil];
-             if (broadKey)
-             {
-                 ADAuthenticationError* error = nil;
-                 ADTokenCacheItem* broadItem = [self findCacheItemWithKey:broadKey userId:_identifier error:&error];
-                 if (error)
-                 {
-                     completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-                     return;
-                 }
-                 
-                 if (broadItem)
-                 {
-                     if (![broadItem isMultiResourceRefreshToken])
-                     {
-                         AD_LOG_WARN(@"Unexpected", _correlationId, @"Multi-resource refresh token expected here.");
-                         //Recover (avoid infinite recursion):
-                         completionBlock(result);
-                         return;
-                     }
-                     
-                     //Call recursively with the cache item containing a multi-resource refresh token:
-                     [self attemptToUseCacheItem:broadItem
-                                   samlAssertion:samlAssertion
-                                   assertionType:assertionType
-                                 completionBlock:completionBlock];
-                     return;//The call above takes over, no more processing
-                 }//broad item
-             }//key
-         }//!item.multiResourceRefreshToken
-         
-         //The refresh token attempt failed and no other suitable refresh token found
-         //call acquireToken
-         [self requestTokenByAssertion:samlAssertion
-                         assertionType:assertionType
-                            completion:^(ADAuthenticationResult *result)
-          {
-              if (result.status == AD_SUCCEEDED)
-              {
-                  [self updateCacheToResult:result cacheItem:nil refreshToken:nil];
-              }
-              
-              completionBlock(result);
-          }];
-     }];//End of the refreshing token completion block, executed asynchronously.
-}
-
-- (NSString*) getAssertionTypeGrantValue:(ADAssertionType) assertionType
-{
-    if(assertionType == AD_SAML1_1){
         return OAUTH2_SAML11_BEARER_VALUE;
     }
     
-    if(assertionType == AD_SAML2){
+    if(_assertionType == AD_SAML2)
+    {
         return OAUTH2_SAML2_BEARER_VALUE;
     }
     
@@ -223,19 +46,25 @@
 }
 
 // Generic OAuth2 Authorization Request, obtains a token from a SAML assertion.
-- (void)requestTokenByAssertion:(NSString *)samlAssertion
-                  assertionType:(ADAssertionType)assertionType
-                     completion:(ADAuthenticationCallback)completionBlock
+- (void)requestTokenByAssertion:(ADAuthenticationCallback)completionBlock
 {
     [self ensureRequest];
-    AD_LOG_VERBOSE_F(@"Requesting token from authorization code.", _correlationId, @"Requesting token by authorization code for resource: %@", _resource);
+    AD_LOG_INFO_F(@"Requesting token from SAML Assertion", _correlationId, @"resource: %@, clientId: %@", _resource, _clientId);
     
-    //samlAssertion = [NSString samlAssertion adBase64];
-    NSData *encodeData = [samlAssertion dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *encodeData = [_samlAssertion dataUsingEncoding:NSUTF8StringEncoding];
     NSString *base64String = [encodeData base64EncodedStringWithOptions:0];
-    //Fill the data for the token refreshing:
+
+    NSString* assertionType = [self assertionTypeString];
+    if (!assertionType)
+    {
+        ADAuthenticationError* error = [ADAuthenticationError invalidArgumentError:@"Unrecognized assertion type."
+                                                                     correlationId:_correlationId];
+        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+        return;
+    }
+    
     NSMutableDictionary *request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                                         [self getAssertionTypeGrantValue:assertionType], OAUTH2_GRANT_TYPE,
+                                         assertionType, OAUTH2_GRANT_TYPE,
                                          base64String, OAUTH2_ASSERTION,
                                          _clientId, OAUTH2_CLIENT_ID,
                                          _resource, OAUTH2_RESOURCE,

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -164,10 +164,12 @@
             return;
         }
         
-        if (item)
+        if (!item)
         {
-            fADFSUser = YES;
+            [self tryMRRT:completionBlock];
+            return;
         }
+        fADFSUser = YES;
     }
     
     // If we have a good (non-expired) access token then return it right away

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -273,7 +273,7 @@
     _attemptedFRT = YES;
     
     ADAuthenticationError* error = nil;
-    NSString* fociClientId = [NSString stringWithFormat:@"foci-%@", foci ? foci : @"1"];
+    NSString* fociClientId = [ADAuthenticationRequest fociClientId:foci];
     
     ADTokenCacheItem* frtItem = [self getItemForResource:nil clientId:fociClientId error:&error];
     if (!frtItem && error)

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -68,6 +68,9 @@
     NSString* _logComponent;
     
     BOOL _requestStarted;
+    BOOL _attemptedFRT;
+    
+    ADTokenCacheItem* _mrrtItem;
     
     ADAuthenticationError* _underlyingError;
 }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -61,6 +61,9 @@
     
     NSString* _refreshTokenCredential;
     
+    NSString* _samlAssertion;
+    ADAssertionType _assertionType;
+    
     BOOL _silent;
     BOOL _allowSilent;
     
@@ -111,6 +114,8 @@
 - (void)setAllowSilentRequests:(BOOL)allowSilent;
 - (void)setRefreshTokenCredential:(NSString*)refreshTokenCredential;
 #endif
+- (void)setSamlAssertion:(NSString*)samlAssertion;
+- (void)setAssertionType:(ADAssertionType)assertionType;
 
 @end
 

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -247,6 +247,25 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
 }
 #endif
 
+- (void)setSamlAssertion:(NSString *)samlAssertion
+{
+    CHECK_REQUEST_STARTED;
+    if (_samlAssertion == samlAssertion)
+    {
+        return;
+    }
+    
+    SAFE_ARC_RELEASE(_samlAssertion);
+    _samlAssertion = [samlAssertion copy];
+}
+
+- (void)setAssertionType:(ADAssertionType)assertionType
+{
+    CHECK_REQUEST_STARTED;
+    
+    _assertionType = assertionType;
+}
+
 - (void)ensureRequest
 {
     if (_requestStarted)

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -835,12 +835,12 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue([cache addOrUpdateItem:[self adCreateFRTCacheItem] correlationId:nil error:&error]);
     XCTAssertNil(error);
     
-    ADTestURLResponse* response = [self adResponseRefreshToken:TEST_REFRESH_TOKEN
+    ADTestURLResponse* response = [self adResponseRefreshToken:@"family refresh token"
                                                      authority:TEST_AUTHORITY
                                                       resource:TEST_RESOURCE
                                                       clientId:TEST_CLIENT_ID
                                                  correlationId:TEST_CORRELATION_ID
-                                               newRefreshToken:TEST_REFRESH_TOKEN
+                                               newRefreshToken:@"new family refresh token"
                                                 newAccessToken:TEST_ACCESS_TOKEN
                                               additionalFields:@{ ADAL_CLIENT_FAMILY_ID : @"1"}];
     
@@ -856,6 +856,7 @@ const int sAsyncContextTimeout = 10;
          XCTAssertEqual(result.status, AD_SUCCEEDED);
          XCTAssertNotNil(result.tokenCacheItem);
          XCTAssertEqualObjects(result.accessToken, TEST_ACCESS_TOKEN);
+         XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, @"new family refresh token");
          XCTAssertEqualObjects(result.tokenCacheItem.familyId, @"1");
          TEST_SIGNAL;
      }];

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -202,7 +202,7 @@ const int sAsyncContextTimeout = 10;
          XCTAssertEqual(result.status, AD_FAILED);
          XCTAssertNotNil(result.error);
          XCTAssertEqual(result.error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
-         ADTAssertContains(result.error.errorDetails, @"samlAssertion");
+         ADTAssertContains(result.error.errorDetails, @"assertion");
          
          TEST_SIGNAL;
      }];

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -70,6 +70,7 @@ typedef enum
                                        authority:(NSString *)authority
                                         resource:(NSString *)resource
                                         clientId:(NSString *)clientId
+                                      oauthError:(NSString *)oauthError
                                    correlationId:(NSUUID *)correlationId;
 - (ADTestURLResponse *)adDefaultBadRefreshTokenResponseError:(NSString*)oauthError;
 - (ADTestURLResponse *)adDefaultBadRefreshTokenResponse;

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -119,6 +119,11 @@ typedef enum
                                    userId:(NSString *)userId;
 - (ADTokenCacheItem *)adCreateMRRTCacheItem;
 - (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId;
+- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
+                                   familyId:(NSString *)familyId;
+- (ADTokenCacheItem *)adCreateFRTCacheItem;
+- (ADTokenCacheItem *)adCreateFRTCacheItem:(NSString *)familyId
+                                    userId:(NSString *)userId;
 - (ADTokenCacheKey *)adCreateCacheKey;
 
 //Creates a sample user information object

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -209,16 +209,48 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
 
 - (ADTokenCacheItem *)adCreateMRRTCacheItem
 {
-    return [self adCreateMRRTCacheItem:TEST_USER_ID];
+    return [self adCreateMRRTCacheItem:TEST_USER_ID familyId:nil];
 }
 
 - (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
+{
+    return [self adCreateMRRTCacheItem:userId familyId:nil];
+}
+
+- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
+                                   familyId:(NSString *)foci
 {
     // A MRRT item is just a refresh token, it doesn't have a specified resource
     // an expiration time (that we know about) and covers multiple ATs.
     ADTokenCacheItem* item = [[ADTokenCacheItem alloc] init];
     item.authority = TEST_AUTHORITY;
     item.clientId = TEST_CLIENT_ID;
+    item.refreshToken = TEST_REFRESH_TOKEN;
+    item.familyId = foci;
+    if (![NSString adIsStringNilOrBlank:userId])
+    {
+        item.userInformation = [self adCreateUserInformation:userId];
+    }
+    
+    SAFE_ARC_AUTORELEASE(item);
+    
+    return item;
+}
+
+- (ADTokenCacheItem *)adCreateFRTCacheItem
+{
+    return [self adCreateFRTCacheItem:@"1" userId:TEST_USER_ID];
+}
+
+- (ADTokenCacheItem *)adCreateFRTCacheItem:(NSString *)foci
+                                    userId:(NSString *)userId
+{
+    ADTokenCacheItem* item = [[ADTokenCacheItem alloc] init];
+    item.authority = TEST_AUTHORITY;
+    // This should match the implementation in +[ADAuthenticationRequest fociClientId:]
+    // think long and hard before changing this.
+    item.clientId = [NSString stringWithFormat:@"foci-%@", foci];
+    item.familyId = foci;
     item.refreshToken = TEST_REFRESH_TOKEN;
     if (![NSString adIsStringNilOrBlank:userId])
     {

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -251,7 +251,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     // think long and hard before changing this.
     item.clientId = [NSString stringWithFormat:@"foci-%@", foci];
     item.familyId = foci;
-    item.refreshToken = TEST_REFRESH_TOKEN;
+    item.refreshToken = @"family refresh token";
     if (![NSString adIsStringNilOrBlank:userId])
     {
         item.userInformation = [self adCreateUserInformation:userId];


### PR DESCRIPTION
Support for a singular one-true-FRT, and all of the caching changes that go with that.

* Rewrote the caching lookup and fallback code.
* ADAL will now use the following logic to determine which refresh token to use ('F' denotes a MRRT marked with a Family ID):

 | RT     | MRRT   | FRT    | Refresh Token Order (on failure)                  |
 | ------ | ------  | ------ | ------------------------------------------------- |
 | X      |         |        | RT -> interactive auth (all other tokens ignored) |
 |   |  X  |  | MRRT -> interactive auth |
 |  | X |  X | MRRT -> FRT -> interactive auth |
 |  |  F  |   | MRRT -> interactive auth |
 |  |  F | X | FRT -> MRRT -> interactive auth |
 |  |   | X | FRT -> interactive auth |

* Moved samlAssertion into the request object itself and pushed acquireTokenByAssertion into the normal acquireToken codepath, so we don't have duplicative cache lookup code in the library