### PR TITLE
Keychain Cache Helper APIs

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -84,7 +84,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     _validateAuthority = bValidate;
     _credentialsType = AD_CREDENTIALS_EMBEDDED;
     
-    _tokenCacheStore = [[ADKeychainTokenCache alloc] initWithGroup:sharedGroup];
+    _tokenCacheStore = [ADKeychainTokenCache keychainCacheForGroup:sharedGroup];
     
     return self;
 }

--- a/ADAL/src/ADAuthenticationSettings.m
+++ b/ADAL/src/ADAuthenticationSettings.m
@@ -23,6 +23,10 @@
 
 #import "ADAuthenticationSettings.h"
 
+#if TARGET_OS_IPHONE
+#import "ADKeychainTokenCache.h"
+#endif // TARGET_OS_IPHONE
+
 @implementation ADAuthenticationSettings
 
 @synthesize requestTimeOut = _requestTimeOut;
@@ -45,7 +49,6 @@
         self.expirationBuffer = 300;//in seconds, ensures catching of clock differences between the server and the device
 #if TARGET_OS_IPHONE
         self.enableFullScreen = YES;
-        self.defaultKeychainGroup = @"com.microsoft.adalcache";
 #endif
     }
     return self;
@@ -64,6 +67,18 @@
     }
     return instance;
 }
+
+#if TARGET_OS_IPHONE
+- (NSString*)defaultKeychainGroup
+{
+    return [ADKeychainTokenCache defaultKeychainGroup];
+}
+
+- (void)setDefaultKeychainGroup:(NSString*)keychainGroup
+{
+    [ADKeychainTokenCache setDefaultKeychainGroup:keychainGroup];
+}
+#endif
 
 @end
 

--- a/ADAL/src/public/ADAuthenticationSettings.h
+++ b/ADAL/src/public/ADAuthenticationSettings.h
@@ -59,6 +59,7 @@
 @property (copy) id<ADTokenCacheDelegate> defaultStorageDelegate;
 #endif
 
+#if TARGET_OS_IPHONE
 /*! The name of the keychain group to be used if sharing of cache between applications
  is desired. Can be nil. The property sets the appropriate value of defaultTokenCacheStore
  object. See apple's documentation for keychain groups: such groups require certain
@@ -73,5 +74,6 @@
  */
 - (NSString*)defaultKeychainGroup;
 - (void)setDefaultKeychainGroup:(NSString*)keychainGroup;
+#endif // TARGET_OS_IPHONE
 
 @end

--- a/ADAL/src/public/ADAuthenticationSettings.h
+++ b/ADAL/src/public/ADAuthenticationSettings.h
@@ -53,6 +53,11 @@
 #if TARGET_OS_IPHONE
 /*! Used for the webView. Default is YES.*/
 @property BOOL enableFullScreen;
+#endif //TARGET_OS_IPHONE
+
+#if !TARGET_OS_IPHONE
+@property (copy) id<ADTokenCacheDelegate> defaultStorageDelegate;
+#endif
 
 /*! The name of the keychain group to be used if sharing of cache between applications
  is desired. Can be nil. The property sets the appropriate value of defaultTokenCacheStore
@@ -60,12 +65,13 @@
  entitlements to be set by the applications. Additionally, access to the items in this group
  is only given to the applications from the same vendor. If this property is not set, the behavior
  will depend on the values in the entitlements file (if such exists) and may not result in token
- sharing. The property has no effect if other cache mechanisms are used (non-keychain). */
-@property (copy) NSString* defaultKeychainGroup;
-#endif //TARGET_OS_IPHONE
-
-#if !TARGET_OS_IPHONE
-@property (copy) id<ADTokenCacheDelegate> defaultStorageDelegate;
-#endif
+ sharing. The property has no effect if other cache mechanisms are used (non-keychain).
+ 
+ NOTE: Once an authentication context has been created with the default keychain
+ group, or +[ADKeychainTokenCache defaultKeychainCache] has been called then
+ this value cannot be changed. Doing so will throw an exception.
+ */
+- (NSString*)defaultKeychainGroup;
+- (void)setDefaultKeychainGroup:(NSString*)keychainGroup;
 
 @end

--- a/ADAL/src/public/ios/ADKeychainTokenCache.h
+++ b/ADAL/src/public/ios/ADKeychainTokenCache.h
@@ -29,6 +29,33 @@
 
 @property (readonly) NSString* __nonnull sharedGroup;
 
+/*! The name of the keychain group to be used if sharing of cache between applications
+ is desired. Can be nil. The property sets the appropriate value of defaultTokenCacheStore
+ object. See apple's documentation for keychain groups: such groups require certain
+ entitlements to be set by the applications. Additionally, access to the items in this group
+ is only given to the applications from the same vendor. If this property is not set, the behavior
+ will depend on the values in the entitlements file (if such exists) and may not result in token
+ sharing. The property has no effect if other cache mechanisms are used (non-keychain).
+ 
+ NOTE: Once an authentication context has been created with the default keychain
+ group, or +[ADKeychainTokenCache defaultKeychainCache] has been called then
+ this value cannot be changed. Doing so will throw an exception.
+ */
++ (nullable NSString*)defaultKeychainGroup;
++ (void)setDefaultKeychainGroup:(nullable NSString*)keychainGroup;
+
+
+/*!
+    @return A singleton instance of the ADKeychainTokenCache for the default keychain group.
+ */
++ (nonnull ADKeychainTokenCache*)defaultKeychainCache;
+
+/*!
+    @return An instance of ADKeychainTokenCache for the given group, or the defaultKeychainCache
+            singleton if the default keychain group is passed in.
+ */
++ (nonnull ADKeychainTokenCache*)keychainCacheForGroup:(nullable NSString*)group;
+
 /* Initializes the token cache store with default shared group value.
  */
 - (nullable instancetype)init;


### PR DESCRIPTION
Add convenience methods for grabbing the default keychain cache.
Add an exception when the default keychain group is changed improperly.