### PR TITLE
Acquire Token Silent Flow Refactor

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF678518358544004E0F4D /* ADUserInformationTests.m */; };
 		8BBF6788183588EC004E0F4D /* ADTokenCacheItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF6787183588EC004E0F4D /* ADTokenCacheItemTests.m */; };
 		8BD14619182189C800796E79 /* ADAuthenticationParameters+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD14618182189C800796E79 /* ADAuthenticationParameters+Internal.m */; };
+		9424B6821CDD1B2B00729698 /* ADTokenCacheAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */; };
+		9424B6841CDD39E400729698 /* ADTokenCacheAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */; };
 		9430C3411C4631C200D6506D /* ADTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9430C3401C4631C200D6506D /* ADTokenCacheTests.m */; };
 		9430C34E1C54320400D6506D /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9430C34D1C54320400D6506D /* ADAuthenticationContextTests.m */; };
 		9430C34F1C54373E00D6506D /* ADAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8346A1807BE3F007F9F0D /* ADAcquireTokenTests.m */; };
@@ -66,7 +68,6 @@
 		9453C3441C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33D1C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m */; };
 		9453C3451C57FC2A006B9E79 /* ADTokenCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */; };
 		9453C34A1C5800E1006B9E79 /* ADPkeyAuthHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3491C5800E1006B9E79 /* ADPkeyAuthHelper.m */; };
-		9453C3551C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */; };
 		9453C35B1C580143006B9E79 /* ADRegistrationInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3561C580143006B9E79 /* ADRegistrationInformation.m */; };
 		9453C35C1C580143006B9E79 /* ADWorkPlaceJoin.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3571C580143006B9E79 /* ADWorkPlaceJoin.m */; };
 		9453C35D1C580143006B9E79 /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C35A1C580143006B9E79 /* ADWorkPlaceJoinUtil.m */; settings = {COMPILER_FLAGS = "-fno-objc-arc"; }; };
@@ -138,8 +139,6 @@
 		9453C41B1C586456006B9E79 /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
 		9453C41C1C586456006B9E79 /* ADClientMetrics.h in Headers */ = {isa = PBXBuildFile; fileRef = 97A522511A1A89C4001D77CE /* ADClientMetrics.h */; };
 		9453C41D1C586456006B9E79 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
-		9453C41E1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */; };
-		9453C41F1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */; };
 		9453C4201C586462006B9E79 /* ADTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3371C57FC2A006B9E79 /* ADTokenCache.m */; };
 		9453C4211C586462006B9E79 /* ADTokenCache+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3381C57FC2A006B9E79 /* ADTokenCache+Internal.h */; };
 		9453C4221C586462006B9E79 /* ADTokenCacheAccessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3391C57FC2A006B9E79 /* ADTokenCacheAccessor.h */; };
@@ -235,6 +234,12 @@
 		97A522491A1A752D001D77CE /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
 		97A522501A1A8999001D77CE /* ADClientMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */; };
 		D6E43A6A1B04026D000F5BE2 /* ADAuthenticationContext+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */; };
+		D6F095151CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */; };
+		D6F095161CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */; };
+		D6F095171CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */; };
+		D6F0951A1CDC2BC300D28FC2 /* ADWebAuthRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */; };
+		D6F0951B1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */; };
+		D6F0951C1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */; };
 		D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
 /* End PBXBuildFile section */
 
@@ -350,6 +355,8 @@
 		8BFEF067182DA57800122C0C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8BFEF069182DA57800122C0C /* ADALiOSBundle-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALiOSBundle-Prefix.pch"; sourceTree = "<group>"; };
 		941674431C9CCCAF00D8D52A /* ADAuthenticationError+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationError+Internal.h"; sourceTree = "<group>"; };
+		9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheAccessor.m; sourceTree = "<group>"; };
+		9424B6831CDD1B4600729698 /* ADTokenCacheDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTokenCacheDataSource.h; sourceTree = "<group>"; };
 		9430C3401C4631C200D6506D /* ADTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheTests.m; sourceTree = "<group>"; };
 		9430C34D1C54320400D6506D /* ADAuthenticationContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationContextTests.m; sourceTree = "<group>"; };
 		9430C3551C55862A00D6506D /* ADAuthorityValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthorityValidationTests.m; sourceTree = "<group>"; };
@@ -370,8 +377,6 @@
 		9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheKey.m; sourceTree = "<group>"; };
 		9453C3481C5800E1006B9E79 /* ADPkeyAuthHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADPkeyAuthHelper.h; sourceTree = "<group>"; };
 		9453C3491C5800E1006B9E79 /* ADPkeyAuthHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADPkeyAuthHelper.m; sourceTree = "<group>"; };
-		9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationRequest+TokenCaching.h"; sourceTree = "<group>"; };
-		9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationRequest+TokenCaching.m"; sourceTree = "<group>"; };
 		9453C3561C580143006B9E79 /* ADRegistrationInformation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADRegistrationInformation.m; sourceTree = "<group>"; };
 		9453C3571C580143006B9E79 /* ADWorkPlaceJoin.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoin.m; sourceTree = "<group>"; };
 		9453C3581C580143006B9E79 /* ADWorkPlaceJoinConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWorkPlaceJoinConstants.h; sourceTree = "<group>"; };
@@ -471,6 +476,10 @@
 		97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+Internal.h"; sourceTree = "<group>"; };
 		D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationContext+Internal.m"; sourceTree = "<group>"; };
+		D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAcquireTokenSilentHandler.h; sourceTree = "<group>"; };
+		D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenSilentHandler.m; sourceTree = "<group>"; };
+		D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthRequest.h; sourceTree = "<group>"; };
+		D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthRequest.m; sourceTree = "<group>"; };
 		D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADUserIdentifier.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -712,16 +721,16 @@
 		9453C3181C57FB91006B9E79 /* cache */ = {
 			isa = PBXGroup;
 			children = (
-				9453C3531C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.h */,
-				9453C3541C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m */,
 				9453C3371C57FC2A006B9E79 /* ADTokenCache.m */,
 				9453C3381C57FC2A006B9E79 /* ADTokenCache+Internal.h */,
 				9453C3391C57FC2A006B9E79 /* ADTokenCacheAccessor.h */,
+				9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */,
 				9453C33B1C57FC2A006B9E79 /* ADTokenCacheItem.m */,
 				9453C33C1C57FC2A006B9E79 /* ADTokenCacheItem+Internal.h */,
 				9453C33D1C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m */,
 				9453C33E1C57FC2A006B9E79 /* ADTokenCacheKey.h */,
 				9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */,
+				9424B6831CDD1B4600729698 /* ADTokenCacheDataSource.h */,
 				9453C3241C57FC03006B9E79 /* ios */,
 			);
 			path = cache;
@@ -810,8 +819,12 @@
 				9453C3871C5820E3006B9E79 /* ADAuthenticationRequest+Broker.m */,
 				9453C3881C5820E3006B9E79 /* ADAuthenticationRequest+WebRequest.h */,
 				9453C3891C5820E3006B9E79 /* ADAuthenticationRequest+WebRequest.m */,
+				D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */,
+				D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */,
 				9453C38A1C5820E3006B9E79 /* ADWebRequest.h */,
 				9453C38B1C5820E3006B9E79 /* ADWebRequest.m */,
+				D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */,
+				D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */,
 				9453C38C1C5820E3006B9E79 /* ADWebResponse.h */,
 				9453C38D1C5820E3006B9E79 /* ADWebResponse.m */,
 			);
@@ -968,6 +981,7 @@
 				9453C4461C58647E006B9E79 /* NSURL+ADExtensions.h in Headers */,
 				9453C40B1C586456006B9E79 /* ADAuthenticationParameters+Internal.h in Headers */,
 				94DD18D31C5AC8DE00F80C62 /* ADAuthenticationResult.h in Headers */,
+				D6F0951A1CDC2BC300D28FC2 /* ADWebAuthRequest.h in Headers */,
 				9453C40E1C586456006B9E79 /* ADAuthenticationResult+Internal.h in Headers */,
 				9453C4481C58647E006B9E79 /* NSUUID+ADExtensions.h in Headers */,
 				9453C42C1C58646D006B9E79 /* ADAuthenticationRequest+AcquireToken.h in Headers */,
@@ -997,8 +1011,8 @@
 				9453C4421C58647E006B9E79 /* NSDictionary+ADExtensions.h in Headers */,
 				9453C43C1C58647E006B9E79 /* ADALFrameworkUtils.h in Headers */,
 				9453C4341C58646D006B9E79 /* ADWebResponse.h in Headers */,
+				D6F095151CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h in Headers */,
 				94DD18D61C5AC8DE00F80C62 /* ADLogger.h in Headers */,
-				9453C41E1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.h in Headers */,
 				94DD18D71C5AC8DE00F80C62 /* ADTokenCacheItem.h in Headers */,
 				9453C4321C58646D006B9E79 /* ADWebRequest.h in Headers */,
 				9453C4301C58646D006B9E79 /* ADAuthenticationRequest+WebRequest.h in Headers */,
@@ -1190,6 +1204,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F0951B1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */,
 				9453C4691C58709D006B9E79 /* ADNTLMUIPrompt.m in Sources */,
 				8B7E6FC81856A1E8000DC3C8 /* ADOAuth2Constants.m in Sources */,
 				9453C3931C5820E3006B9E79 /* ADWebRequest.m in Sources */,
@@ -1198,7 +1213,6 @@
 				9453C39E1C5826F2006B9E79 /* ADURLProtocol.m in Sources */,
 				9453C35D1C580143006B9E79 /* ADWorkPlaceJoinUtil.m in Sources */,
 				9453C46D1C5872AD006B9E79 /* ADJwtHelper.m in Sources */,
-				9453C3551C580123006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */,
 				9453C39D1C5826F2006B9E79 /* ADNTLMHandler.m in Sources */,
 				9453C3911C5820E3006B9E79 /* ADAuthenticationRequest+Broker.m in Sources */,
 				9453C3441C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m in Sources */,
@@ -1219,9 +1233,11 @@
 				9453C3221C57FBCB006B9E79 /* UIAlertView+Additions.m in Sources */,
 				9453C37D1C5801CB006B9E79 /* ADBrokerKeyHelper.m in Sources */,
 				946818AA1C59B80800CA0378 /* ADAuthenticationViewController.m in Sources */,
+				D6F095161CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */,
 				9453C3711C580157006B9E79 /* NSURL+ADExtensions.m in Sources */,
 				D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */,
 				9453C3721C580157006B9E79 /* NSUUID+ADExtensions.m in Sources */,
+				9424B6821CDD1B2B00729698 /* ADTokenCacheAccessor.m in Sources */,
 				9453C3431C57FC2A006B9E79 /* ADTokenCacheItem.m in Sources */,
 				9453C3921C5820E3006B9E79 /* ADAuthenticationRequest+WebRequest.m in Sources */,
 				8B92DB70181B2335004AAB0E /* ADLogger.m in Sources */,
@@ -1295,7 +1311,6 @@
 				9453C40A1C586456006B9E79 /* ADAuthenticationError.m in Sources */,
 				9453C4451C58647E006B9E79 /* NSString+ADHelperMethods.m in Sources */,
 				9453C46E1C5872B0006B9E79 /* ADJwtHelper.m in Sources */,
-				9453C41F1C586462006B9E79 /* ADAuthenticationRequest+TokenCaching.m in Sources */,
 				9453C4471C58647E006B9E79 /* NSURL+ADExtensions.m in Sources */,
 				9453C4111C586456006B9E79 /* ADAuthenticationSettings.m in Sources */,
 				9453C4651C58707B006B9E79 /* ADCredentialCollectionController.m in Sources */,
@@ -1314,14 +1329,17 @@
 				9453C4431C58647E006B9E79 /* NSDictionary+ADExtensions.m in Sources */,
 				9453C4661C58707B006B9E79 /* ADNTLMUIPrompt.m in Sources */,
 				9453C40F1C586456006B9E79 /* ADAuthenticationResult+Internal.m in Sources */,
+				D6F095171CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */,
 				9453C42F1C58646D006B9E79 /* ADAuthenticationRequest+Broker.m in Sources */,
 				9453C4131C586456006B9E79 /* ADInstanceDiscovery.m in Sources */,
 				9453C4181C586456006B9E79 /* ADUserInformation.m in Sources */,
+				9424B6841CDD39E400729698 /* ADTokenCacheAccessor.m in Sources */,
 				9453C4331C58646D006B9E79 /* ADWebRequest.m in Sources */,
 				9453C4351C58646D006B9E79 /* ADWebResponse.m in Sources */,
 				9453C4171C586456006B9E79 /* ADOAuth2Constants.m in Sources */,
 				9453C4101C586456006B9E79 /* ADAuthenticationResult.m in Sources */,
 				9453C4091C586456006B9E79 /* ADAuthenticationContext+Internal.m in Sources */,
+				D6F0951C1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */,
 				9453C43F1C58647E006B9E79 /* ADHelpers.m in Sources */,
 				9453C4311C58646D006B9E79 /* ADAuthenticationRequest+WebRequest.m in Sources */,
 			);

--- a/ADAL/src/ADAuthenticationContext+Internal.h
+++ b/ADAL/src/ADAuthenticationContext+Internal.h
@@ -37,6 +37,8 @@
 #import "ADAL_Internal.h"
 
 @class ADUserIdentifier;
+@class ADTokenCacheAccessor;
+@protocol ADTokenCacheDataSource;
 
 #import "ADAuthenticationContext.h"
 #import "ADAuthenticationResult+Internal.h"
@@ -83,7 +85,7 @@ extern NSString* const ADRedirectUriInvalidError;
 
 @interface ADAuthenticationContext (CacheStorage)
 
-- (void)setTokenCacheStore:(id<ADTokenCacheAccessor>)tokenCacheStore;
-- (id<ADTokenCacheAccessor>)tokenCacheStore;
+- (void)setTokenCacheStore:(id<ADTokenCacheDataSource>)tokenCacheStore;
+- (ADTokenCacheAccessor *)tokenCacheStore;
 
 @end

--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -94,8 +94,26 @@ NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is conf
 //
 + (BOOL)isFinalResult:(ADAuthenticationResult*)result
 {
-    return (AD_SUCCEEDED == result.status) /* access token provided, no need to try anything else */
-    || (result.error && !result.error.protocolCode); //Connection is down, server is unreachable or DNS error. No need to try refresh tokens.
+    if (!result)
+    {
+        return NO;
+    }
+    
+    // Successful results are final results!
+    if (result.status == AD_SUCCEEDED)
+    {
+        return YES;
+    }
+    
+    // Protocol Code is used for OAuth errors (and should only be used for OAuth errors...). If we
+    // received an OAuth error that means that the server is up and responsive, just that something
+    // about the token was bad.
+    if (result.error && !result.error.protocolCode)
+    {
+        return YES;
+    }
+    
+    return NO;
 }
 
 //Translates the ADPromptBehavior into prompt query parameter. May return nil, if such

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -68,23 +68,12 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
                   error:(ADAuthenticationError* __autoreleasing *) error
 {
     API_ENTRY;
-    if (!(self = [super init]))
+    if (!(self = [self initWithAuthority:authority validateAuthority:bValidate error:error]))
     {
         return nil;
     }
     
-    NSString* extractedAuthority = [ADInstanceDiscovery canonicalizeAuthority:authority];
-    if (!extractedAuthority)
-    {
-        SAFE_ARC_RELEASE(self);
-        RETURN_ON_INVALID_ARGUMENT(!extractedAuthority, authority, nil);
-    }
-    
-    _authority = extractedAuthority;
-    _validateAuthority = bValidate;
-    _credentialsType = AD_CREDENTIALS_EMBEDDED;
-    
-    _tokenCacheStore = [ADKeychainTokenCache keychainCacheForGroup:sharedGroup];
+    [self setTokenCacheStore:[ADKeychainTokenCache keychainCacheForGroup:sharedGroup]];
     
     return self;
 }
@@ -92,7 +81,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 - (id)initWithAuthority:(NSString *)authority
       validateAuthority:(BOOL)validateAuthority
-             tokenCache:(ADTokenCache*)tokenCache
+             tokenCache:(id<ADTokenCacheDataSource>)tokenCache
                   error:(ADAuthenticationError *__autoreleasing *)error
 {
     API_ENTRY;
@@ -109,12 +98,9 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     }
     
     _authority = extractedAuthority;
-    SAFE_ARC_RETAIN(_authority);
     _validateAuthority = validateAuthority;
     _credentialsType = AD_CREDENTIALS_EMBEDDED;
-    _tokenCacheStore = tokenCache;
-    SAFE_ARC_RETAIN(_tokenCacheStore);
-    
+    [self setTokenCacheStore:tokenCache];
     return self;
 }
 
@@ -123,13 +109,16 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
           cacheDelegate:(id<ADTokenCacheDelegate>) delegate
                   error:(ADAuthenticationError * __autoreleasing *)error
 {
+    API_ENTRY;
+    if (!(self = [self initWithAuthority:authority validateAuthority:validateAuthority error:error]))
+    {
+        return nil;
+    }
+    
     ADTokenCache* cache = [ADTokenCache new];
     [cache setDelegate:delegate];
     
-    self = [self initWithAuthority:authority
-                 validateAuthority:validateAuthority
-                        tokenCache:cache
-                             error:error];
+    [self setTokenCacheStore:cache];
     SAFE_ARC_RELEASE(cache);
     return self;
 }
@@ -138,14 +127,19 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
       validateAuthority:(BOOL)validateAuthority
                   error:(ADAuthenticationError *__autoreleasing *)error
 {
+    id<ADTokenCacheDataSource> tokenCache = nil;
+
 #if TARGET_OS_IPHONE
+    tokenCache = [ADKeychainTokenCache defaultKeychainCache];
+#else
+    tokenCache = [ADTokenCache new];
+    [(ADTokenCache*)tokenCache setDelegate:[ADAuthenticationSettings sharedInstance].defaultStorageDelegate];
+#endif
+    
     return [self initWithAuthority:authority
                  validateAuthority:validateAuthority
-                       sharedGroup:[[ADAuthenticationSettings sharedInstance] defaultKeychainGroup]
+                        tokenCache:tokenCache
                              error:error];
-#else
-    return [self initWithAuthority:authority validateAuthority:validateAuthority cacheDelegate:[ADAuthenticationSettings sharedInstance].defaultStorageDelegate error:error];
-#endif
 }
 
 - (void)dealloc
@@ -260,18 +254,20 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 #define REQUEST_WITH_REDIRECT_STRING(_redirect, _clientId, _resource) \
     THROW_ON_NIL_ARGUMENT(completionBlock) \
-    CHECK_STRING_ARG_BLOCK(clientId) \
+    CHECK_STRING_ARG_BLOCK(_clientId) \
     ADAuthenticationRequest* request = [self requestWithRedirectString:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
     [request setLogComponent:_logComponent];
 
 #define REQUEST_WITH_REDIRECT_URL(_redirect, _clientId, _resource) \
+    THROW_ON_NIL_ARGUMENT(completionBlock) \
+    CHECK_STRING_ARG_BLOCK(_clientId) \
     ADAuthenticationRequest* request = [self requestWithRedirectUrl:_redirect clientId:_clientId resource:_resource completionBlock:completionBlock]; \
     if (!request) { return; } \
     [request setLogComponent:_logComponent];
 
 #define CHECK_STRING_ARG_BLOCK(_arg) \
-    if (!_arg || [NSString adIsStringNilOrBlank:_arg]) { \
+    if ([NSString adIsStringNilOrBlank:_arg]) { \
         ADAuthenticationError* error = [ADAuthenticationError invalidArgumentError:@#_arg " cannot be nil" correlationId:_correlationId]; \
         completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]); \
         return; \
@@ -381,33 +377,6 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:completionBlock];
 }
 
-- (void)acquireTokenByRefreshToken:(NSString*)refreshToken
-                          clientId:(NSString*)clientId
-                       redirectUri:(NSString*)redirectUri
-                   completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    API_ENTRY;
-    REQUEST_WITH_REDIRECT_STRING(redirectUri, clientId, nil);
-    
-    [request acquireTokenByRefreshToken:refreshToken
-                              cacheItem:nil
-                        completionBlock:completionBlock];
-}
-
-- (void)acquireTokenByRefreshToken:(NSString*)refreshToken
-                          clientId:(NSString*)clientId
-                       redirectUri:(NSString*)redirectUri
-                          resource:(NSString*)resource
-                   completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    API_ENTRY;
-    REQUEST_WITH_REDIRECT_STRING(redirectUri, clientId, resource);
-    
-    [request acquireTokenByRefreshToken:refreshToken
-                              cacheItem:nil
-                        completionBlock:completionBlock];
-}
-
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
                      redirectUri:(NSURL*)redirectUri
@@ -429,18 +398,18 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 @implementation ADAuthenticationContext (CacheStorage)
 
-- (void)setTokenCacheStore:(id<ADTokenCacheAccessor>)tokenCacheStore
+- (void)setTokenCacheStore:(id<ADTokenCacheDataSource>)dataSource
 {
-    if (_tokenCacheStore == tokenCacheStore)
+    if (_tokenCacheStore.dataSource == dataSource)
     {
         return;
     }
+    
     SAFE_ARC_RELEASE(_tokenCacheStore);
-    _tokenCacheStore = tokenCacheStore;
-    SAFE_ARC_RETAIN(_tokenCacheStore);
+    _tokenCacheStore = [[ADTokenCacheAccessor alloc] initWithDataSource:dataSource authority:_authority];
 }
 
-- (id<ADTokenCacheAccessor>)tokenCacheStore
+- (ADTokenCacheAccessor *)tokenCacheStore
 {
     return _tokenCacheStore;
 }

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -91,7 +91,7 @@
     }
 
     ADWebRequest* request = [[ADWebRequest alloc] initWithURL:resourceUrl correlationId:nil];
-    [request setMethodType:ADWebRequestGet];
+    [request setIsGetRequest:YES];
     AD_LOG_VERBOSE_F(@"Starting authorization challenge request", nil, @"Resource: %@", resourceUrl);
     
     [request send:^(NSError * error, ADWebResponse *response) {

--- a/ADAL/src/ADInstanceDiscovery.m
+++ b/ADAL/src/ADInstanceDiscovery.m
@@ -294,7 +294,7 @@ static NSString* const sValidationServerError = @"The authority validation serve
     AD_LOG_VERBOSE(@"Authority Validation Request", correlationId, endPoint);
     ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:[NSURL URLWithString:endPoint] correlationId:correlationId];
     
-    [webRequest setMethodType:ADWebRequestGet];
+    [webRequest setIsGetRequest:YES];
     [webRequest.headers setObject:@"application/json" forKey:@"Accept"];
     [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
     __block NSDate* startTime = [NSDate new];

--- a/ADAL/src/cache/ADTokenCache+Internal.h
+++ b/ADAL/src/cache/ADTokenCache+Internal.h
@@ -22,9 +22,9 @@
 // THE SOFTWARE.
 
 #import "ADTokenCache.h"
-#import "ADTokenCacheAccessor.h"
+#import "ADTokenCacheDataSource.h"
 
-@interface ADTokenCache (Internal) <ADTokenCacheAccessor>
+@interface ADTokenCache (Internal) <ADTokenCacheDataSource>
 
 - (BOOL)validateCache:(nullable NSDictionary *)dict
                 error:(ADAuthenticationError * __nullable  __autoreleasing * __nullable)error;

--- a/ADAL/src/cache/ADTokenCacheDataSource.h
+++ b/ADAL/src/cache/ADTokenCacheDataSource.h
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+@class ADTokenCacheKey;
+@class ADTokenCacheItem;
+@class ADAuthenticationError;
+
+@protocol ADTokenCacheDataSource <NSObject>
+
+/*!
+ @param key      The key of the item.
+ @param userId   The specific user whose item is needed. May be nil, in which
+ case the item for the first user in the cache will be returned.
+ @param error    Will be set only in case of ambiguity. E.g. if userId is nil
+ and we have tokens from multiple users. If the cache item is not
+ present, the error will not be set.
+ */
+- (nullable ADTokenCacheItem *)getItemWithKey:(nonnull ADTokenCacheKey *)key
+                                       userId:(nullable NSString *)userId
+                                correlationId:(nullable NSUUID *)correlationId
+                                        error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*!
+ @param key      The key of the item. May be nil, in which case all items that match
+ other parameters will be returned.
+ @param userId   The specific user whose item is needed. May be nil, in which
+ case the item for the first user in the cache will be returned.
+ @param error    Will be set only in case of ambiguity. E.g. if userId is nil
+ and we have tokens from multiple users. If the cache item is not
+ present, the error will not be set.
+ */
+- (nullable NSArray <ADTokenCacheItem *> *)getItemsWithKey:(nullable ADTokenCacheKey *)key
+                                                    userId:(nullable NSString *)userId
+                                             correlationId:(nullable NSUUID * )correlationId
+                                                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*!
+ Ensures the cache contains an item matching the passed in item, adding or updating the
+ item as necessary.
+ 
+ @param  item    The item to add to the cache, or update if an item matching the key and
+ userId already exists in the cache.
+ @param  error   (Optional) In the case of an error this will be filled with the
+ error details.
+ */
+- (BOOL)addOrUpdateItem:(nonnull ADTokenCacheItem *)item
+          correlationId:(nullable NSUUID *)correlationId
+                  error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*!
+ @param  item    The item to remove from the cache
+ @param  error   (Optional) In the case of an error this will be filled with the
+ error details.
+ 
+ @return YES if the item was successfully removed, or was not in the cache. If NO
+ look
+ */
+- (BOOL)removeItem:(nonnull ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+- (nullable NSArray*)allItems:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*! This internal method is only called in test code. */
+- (nullable NSArray<ADTokenCacheItem *> *)allTombstones:(ADAuthenticationError * __nullable __autoreleasing *__nullable)error;
+
+@end

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -103,9 +103,9 @@
 - (ADTokenCacheKey*)extractKey:(ADAuthenticationError* __autoreleasing *)error
 {
     return [ADTokenCacheKey keyWithAuthority:_authority
-                                         resource:_resource
-                                         clientId:_clientId
-                                            error:error];
+                                    resource:_resource
+                                    clientId:_clientId
+                                       error:error];
 }
 
 - (BOOL)isExpired

--- a/ADAL/src/cache/ADTokenCacheKey.m
+++ b/ADAL/src/cache/ADTokenCacheKey.m
@@ -79,9 +79,9 @@
                  error:(ADAuthenticationError * __autoreleasing *)error
 {
     API_ENTRY;
-    //Trimm first for faster nil or empty checks. Also lowercase and trimming is
-    //needed to ensure that the cache handles correctly same items with different
-    //character case:
+    // Trim first for faster nil or empty checks. Also lowercase and trimming is
+    // needed to ensure that the cache handles correctly same items with different
+    // character case:
     authority = [ADInstanceDiscovery canonicalizeAuthority:authority];
     resource = resource.adTrimmedString.lowercaseString;
     clientId = clientId.adTrimmedString.lowercaseString;

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -103,7 +103,7 @@ typedef enum
 } ADCredentialsType;
 
 @class ADAuthenticationResult;
-@protocol ADTokenCacheAccessor;
+@class ADTokenCacheAccessor;
 
 /*!
     @class ADAuthenticationContext
@@ -116,7 +116,7 @@ typedef enum
  */
 @interface ADAuthenticationContext : NSObject
 {
-    id <ADTokenCacheAccessor> _tokenCacheStore;
+    ADTokenCacheAccessor* _tokenCacheStore;
     NSString* _authority;
     BOOL _validateAuthority;
     ADCredentialsType _credentialsType;

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.h
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.h
@@ -21,28 +21,38 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "ADTokenCacheAccessor.h"
 
-@interface ADAuthenticationRequest (TokenCaching)
+#import <Foundation/Foundation.h>
 
-+ (NSString*)familyClientId:(NSString*)familyID;
+@class ADTokenCacheAccessor;
 
-/*!
-    Stores the result in the cache. cacheItem parameter may be nil, if the result is successfull and contains
-    the item to be stored.
- 
-    @param result       The result to update the cache to
-    @param refreshToken The refresh token (if anything) that was used to get this authentication result
- */
-- (void)updateCacheToResult:(ADAuthenticationResult *)result
-                  cacheItem:(ADTokenCacheItem *)cacheItem
-               refreshToken:(NSString *)refreshToken;
+@interface ADAcquireTokenSilentHandler : NSObject
+{
+    NSString* _authority;
+    NSString* _resource;
+    NSString* _clientId;
+    NSString* _redirectUri;
+    ADUserIdentifier* _identifier;
+    NSUUID* _correlationId;
+    ADTokenCacheAccessor* _tokenCache;
+    
+    ADTokenCacheItem* _mrrtItem;
+    
+    // We only return underlying errors from the MRRT Result, because the FRT is a
+    // "best attempt" method, which is not necessarily tied to the client ID we're
+    // trying, so the MRRT error will be more accurate.
+    ADAuthenticationResult* _mrrtResult;
+    
+    BOOL _attemptedFRT;
+}
 
-
-- (ADTokenCacheItem *)getItemForResource:(NSString*)resource
-                                clientId:(NSString*)clientId
-                                   error:(ADAuthenticationError * __autoreleasing *)error;
-
-- (ADTokenCacheItem*)getUnkownUserADFSToken:(ADAuthenticationError * __autoreleasing *)error;
++ (void)acquireTokenSilentForAuthority:(NSString *)authority
+                              resource:(NSString *)resource
+                              clientId:(NSString *)clientId
+                           redirectUri:(NSString *)redirectUri
+                            identifier:(ADUserIdentifier *)identifier
+                         correlationId:(NSUUID *)correlationId
+                            tokenCache:(ADTokenCacheAccessor *)tokenCache
+                       completionBlock:(ADAuthenticationCallback)completionBlock;
 
 @end

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -1,0 +1,444 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import "ADAcquireTokenSilentHandler.h"
+#import "ADTokenCacheKey.h"
+#import "ADTokenCacheItem+Internal.h"
+#import "ADUserIdentifier.h"
+#import "ADOAuth2Constants.h"
+#import "ADAuthenticationContext+Internal.h"
+#import "ADUserInformation.h"
+#import "ADWebAuthRequest.h"
+#import "ADHelpers.h"
+#import "ADTokenCacheAccessor.h"
+
+@implementation ADAcquireTokenSilentHandler
+
++ (void)acquireTokenSilentForAuthority:(NSString *)authority
+                              resource:(NSString *)resource
+                              clientId:(NSString *)clientId
+                           redirectUri:(NSString *)redirectUri
+                            identifier:(ADUserIdentifier *)identifier
+                         correlationId:(NSUUID *)correlationId
+                            tokenCache:(ADTokenCacheAccessor *)tokenCache
+                       completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    ADAcquireTokenSilentHandler* handler = [ADAcquireTokenSilentHandler new];
+    handler->_authority = authority;
+    handler->_resource = resource;
+    handler->_clientId = clientId;
+    handler->_redirectUri = redirectUri;
+    handler->_identifier = identifier;
+    handler->_tokenCache = tokenCache;
+    handler->_correlationId = correlationId;
+    
+    [handler getAccessToken:completionBlock];
+}
+
+- (void)dealloc
+{
+    SAFE_ARC_RELEASE(_authority);
+    _authority = nil;
+    
+    SAFE_ARC_RELEASE(_resource);
+    _resource = nil;
+    
+    SAFE_ARC_RELEASE(_clientId);
+    _clientId = nil;
+    
+    SAFE_ARC_RELEASE(_redirectUri);
+    _redirectUri = nil;
+    
+    SAFE_ARC_RELEASE(_identifier);
+    _identifier = nil;
+    
+    SAFE_ARC_RELEASE(_correlationId);
+    _correlationId = nil;
+    
+    SAFE_ARC_RELEASE(_tokenCache);
+    _tokenCache = nil;
+    
+    SAFE_ARC_RELEASE(_mrrtItem);
+    _mrrtItem = nil;
+    
+    SAFE_ARC_RELEASE(_mrrtResult);
+    _mrrtResult = nil;
+    
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+#pragma mark -
+#pragma mark Refresh Token Helper Methods
+
+//Obtains an access token from the passed refresh token. If "cacheItem" is passed, updates it with the additional
+//information and updates the cache:
+- (void)acquireTokenByRefreshToken:(NSString*)refreshToken
+                         cacheItem:(ADTokenCacheItem*)cacheItem
+                   completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    AD_LOG_VERBOSE_F(@"Attempting to acquire an access token from refresh token.", _correlationId, @"Resource: %@", _resource);
+
+    [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:_correlationId];
+    //Fill the data for the token refreshing:
+    NSMutableDictionary *request_data = nil;
+    
+    if(cacheItem.sessionKey)
+    {
+        NSString* jwtToken = [self createAccessTokenRequestJWTUsingRT:cacheItem];
+        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                        _redirectUri, @"redirect_uri",
+                        _clientId, @"client_id",
+                        @"2.0", @"windows_api_version",
+                        @"urn:ietf:params:oauth:grant-type:jwt-bearer", OAUTH2_GRANT_TYPE,
+                        jwtToken, @"request",
+                        nil];
+        
+    }
+    else
+    {
+        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
+                        OAUTH2_REFRESH_TOKEN, OAUTH2_GRANT_TYPE,
+                        refreshToken, OAUTH2_REFRESH_TOKEN,
+                        _clientId, OAUTH2_CLIENT_ID,
+                        nil];
+    }
+    
+    if (![NSString adIsStringNilOrBlank:_resource])
+    {
+        [request_data setObject:_resource forKey:OAUTH2_RESOURCE];
+    }
+    
+    ADWebAuthRequest* webReq =
+    [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:[_authority stringByAppendingString:OAUTH2_TOKEN_SUFFIX]]
+                            correlationId:_correlationId];
+    [webReq setRequestDictionary:request_data];
+    AD_LOG_INFO_F(@"Attempting to acquire an access token from refresh token", nil, @"clientId: '%@'; resource: '%@';", _clientId, _resource);
+    [webReq sendRequest:^(NSDictionary *response)
+     {
+         ADTokenCacheItem* resultItem = (cacheItem) ? cacheItem : [ADTokenCacheItem new];
+         
+         //Always ensure that the cache item has all of these set, especially in the broad token case, where the passed item
+         //may have empty "resource" property:
+         resultItem.resource = _resource;
+         resultItem.clientId = _clientId;
+         resultItem.authority = _authority;
+         
+         
+         ADAuthenticationResult *result = [resultItem processTokenResponse:response fromRefresh:YES requestCorrelationId:_correlationId];
+         if (cacheItem)//The request came from the cache item, update it:
+         {
+             [_tokenCache updateCacheToResult:result
+                                    cacheItem:resultItem
+                                 refreshToken:refreshToken
+                                correlationId:_correlationId];
+         }
+         result = [ADAuthenticationContext updateResult:result toUser:_identifier];//Verify the user (just in case)
+         //
+         if (!cacheItem)
+         {
+             SAFE_ARC_RELEASE(resultItem);
+         }
+         
+         completionBlock(result);
+     }];
+}
+
+- (NSString*)createAccessTokenRequestJWTUsingRT:(ADTokenCacheItem*)cacheItem
+{
+    NSString* grantType = @"refresh_token";
+    
+    NSString* ctx = [[[NSUUID UUID] UUIDString] adComputeSHA256];
+    NSDictionary *header = @{
+                             @"alg" : @"HS256",
+                             @"typ" : @"JWT",
+                             @"ctx" : [ADHelpers convertBase64UrlStringToBase64NSString:[ctx adBase64UrlEncode]]
+                             };
+    
+    NSInteger iat = round([[NSDate date] timeIntervalSince1970]);
+    NSDictionary *payload = @{
+                              @"resource" : _resource,
+                              @"client_id" : _clientId,
+                              @"refresh_token" : cacheItem.refreshToken,
+                              @"iat" : [NSNumber numberWithInteger:iat],
+                              @"nbf" : [NSNumber numberWithInteger:iat],
+                              @"exp" : [NSNumber numberWithInteger:iat],
+                              @"scope" : @"openid",
+                              @"grant_type" : grantType,
+                              @"aud" : _authority
+                              };
+    
+    NSString* returnValue = [ADHelpers createSignedJWTUsingKeyDerivation:header
+                                                                 payload:payload
+                                                                 context:ctx
+                                                            symmetricKey:cacheItem.sessionKey];
+    return returnValue;
+}
+
+- (void)acquireTokenWithItem:(ADTokenCacheItem *)item
+                 refreshType:(NSString *)refreshType
+             completionBlock:(ADAuthenticationCallback)completionBlock
+                    fallback:(ADAuthenticationCallback)fallback
+{
+    [self acquireTokenByRefreshToken:item.refreshToken
+                           cacheItem:item
+                     completionBlock:^(ADAuthenticationResult *result)
+     {
+         NSString* resultStatus = @"Succeded";
+         
+         if (result.status == AD_FAILED)
+         {
+             if (result.error.protocolCode)
+             {
+                 resultStatus = [NSString stringWithFormat:@"Failed (%@)", result.error.protocolCode];
+             }
+             else
+             {
+                 resultStatus = [NSString stringWithFormat:@"Failed (%@ %ld)", result.error.domain, (long)result.error.code];
+             }
+         }
+         
+         NSString* msg = nil;
+         if (refreshType)
+         {
+             msg = [NSString stringWithFormat:@"Acquire Token with %@ Refresh Token %@.", refreshType, resultStatus];
+         }
+         else
+         {
+             msg = [NSString stringWithFormat:@"Acquire Token with Refresh Token %@.", resultStatus];
+         }
+         
+         AD_LOG_INFO_F(msg, _correlationId, @"clientId: '%@'; resource: '%@';", _clientId, _resource);
+         
+         if ([ADAuthenticationContext isFinalResult:result])
+         {
+             completionBlock(result);
+             return;
+         }
+         
+         fallback(result);
+     }];
+}
+
+/*
+ This is the beginning of the cache look up sequence. We start by trying to find an access token that is not
+ expired. If there's a single-resource-refresh-token it will be cached along side an expire AT, and we'll
+ attempt to use that. If not we fall into the MRRT<-->FRT code.
+ */
+
+- (void)getAccessToken:(ADAuthenticationCallback)completionBlock
+{
+    //All of these should be set before calling this method:
+    THROW_ON_NIL_ARGUMENT(completionBlock);
+    
+    ADAuthenticationError* error = nil;
+    ADTokenCacheItem* item = [_tokenCache getATRTItemForUser:_identifier
+                                                    resource:_resource
+                                                    clientId:_clientId
+                                               correlationId:_correlationId
+                                                       error:&error];
+    // If some error ocurred during the cache lookup then we need to fail out right away.
+    if (!item && error)
+    {
+        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+        return;
+    }
+    
+    // If we didn't find an item at all there's a chance that we might be dealing with an "ADFS" user
+    // and we need to check the unknown user ADFS token as well
+    if (!item)
+    {
+        item = [_tokenCache getADFSUserTokenForResource:_resource clientId:_clientId correlationId:_correlationId error:&error];
+        if (!item && error)
+        {
+            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+            return;
+        }
+        
+        // If we still don't have anything from the cache to use then we should try to see if we have an MRRT
+        // that matches.
+        if (!item)
+        {
+            [self tryMRRT:completionBlock];
+            return;
+        }
+    }
+    
+    // If we have a good (non-expired) access token then return it right away
+    if (item.accessToken && !item.isExpired)
+    {
+        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
+        ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheItem:item multiResourceRefreshToken:NO correlationId:_correlationId];
+        completionBlock(result);
+        return;
+    }
+    
+    [self tryRT:item completionBlock:completionBlock];
+}
+
+- (void)tryRT:(ADTokenCacheItem*)item completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    ADAuthenticationError* error = nil;
+    
+    if (!item.refreshToken)
+    {
+        // There's nothing usable in this cache item, delete it.
+        if (![_tokenCache.dataSource removeItem:item error:&error] && error)
+        {
+            // If we failed to remove the item with an error, then return that error right away
+            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+            return;
+        }
+        
+        if (!item.userInformation.userId)
+        {
+            // If we don't have any userInformation in this token that means it came from an authority
+            // that supports
+            completionBlock(nil);
+            return;
+        }
+        [self tryMRRT:completionBlock];
+        return;
+    }
+    
+    [self acquireTokenWithItem:item
+                   refreshType:nil
+               completionBlock:completionBlock
+                      fallback:^(ADAuthenticationResult* result)
+     {
+         // If we had an individual RT associated with this item then we aren't
+         // talking to AAD so there won't be an MRRT. End the silent flow immediately.
+         completionBlock(result);
+     }];
+}
+
+/*
+ This method will try to find and use an MRRT, that matches the parameters of the authentication request.
+ If it finds one marked with a family ID it will call tryFRT before attempting to use the MRRT.
+ */
+- (void)tryMRRT:(ADAuthenticationCallback)completionBlock
+{
+    ADAuthenticationError* error = nil;
+    
+    // If we don't have an item yet see if we can pull one out of the cache
+    if (!_mrrtItem)
+    {
+        _mrrtItem = [_tokenCache getMRRTItemForUser:_identifier clientId:_clientId correlationId:_correlationId error:&error];
+        if (!_mrrtItem && error)
+        {
+            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+            return;
+        }
+    }
+    
+    // If we still don't have an item try to use a FRT
+    if (!_mrrtItem)
+    {
+        [self tryFRT:nil completionBlock:completionBlock];
+        return;
+    }
+    
+    SAFE_ARC_RETAIN(_mrrtItem);
+    
+    // If our MRRT is marked with an Family ID and we haven't tried a FRT yet
+    // try that first
+    if (_mrrtItem.familyId && !_attemptedFRT)
+    {
+        [self tryFRT:_mrrtItem.familyId completionBlock:completionBlock];
+        return;
+    }
+    
+    // Otherwise try the MRRT
+    [self acquireTokenWithItem:_mrrtItem
+                   refreshType:@"Multi Resource"
+               completionBlock:completionBlock
+                      fallback:^(ADAuthenticationResult* result)
+     {
+         NSString* familyId = _mrrtItem.familyId;
+         
+         // Clear out the MRRT as it's not good anymore anyways
+         SAFE_ARC_RELEASE(_mrrtItem);
+         _mrrtItem = nil;
+         
+         _mrrtResult = result;
+         SAFE_ARC_RETAIN(_mrrtResult);
+         
+         // Try the FRT in case it's there.
+         [self tryFRT:familyId completionBlock:completionBlock];
+     }];
+}
+
+/*
+ This method will attempt to find and use a FRT matching the given family ID and the parameters of the
+ authentication request, if we've not already tried an FRT during this request. If it fails it will call
+ -tryMRRT: If we have already tried to use an FRT then we go to interactive auth.
+ */
+
+- (void)tryFRT:(NSString*)familyId completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    if (_attemptedFRT)
+    {
+        completionBlock(_mrrtResult);
+        return;
+    }
+    _attemptedFRT = YES;
+    
+    ADAuthenticationError* error = nil;
+    ADTokenCacheItem* frtItem = [_tokenCache getFRTItemForUser:_identifier familyId:familyId correlationId:_correlationId error:&error];
+    if (!frtItem && error)
+    {
+        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
+        return;
+    }
+    
+    if (!frtItem)
+    {
+        if (_mrrtItem)
+        {
+            // If we still have an MRRT item retrieved in this request then attempt to use that.
+            [self tryMRRT:completionBlock];
+        }
+        else
+        {
+            // Otherwise go to interactive auth
+            completionBlock(_mrrtResult);
+        }
+        return;
+    }
+    
+    [self acquireTokenWithItem:frtItem refreshType:@"Family" completionBlock:completionBlock fallback:^(ADAuthenticationResult *result)
+     {
+         (void)result;
+         
+         if (_mrrtItem)
+         {
+             // If we still have an MRRT item retrieved in this request then attempt to use that.
+             [self tryMRRT:completionBlock];
+             return;
+         }
+         
+         completionBlock(_mrrtResult);
+     }];
+}
+
+@end

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -45,13 +45,24 @@
                        completionBlock:(ADAuthenticationCallback)completionBlock
 {
     ADAcquireTokenSilentHandler* handler = [ADAcquireTokenSilentHandler new];
+    
+    // As this is an internal class these properties should all be set by the
+    // authentication request, which created copies of them.
+    
     handler->_authority = authority;
+    SAFE_ARC_RETAIN(authority);
     handler->_resource = resource;
+    SAFE_ARC_RETAIN(resource);
     handler->_clientId = clientId;
+    SAFE_ARC_RETAIN(clientId);
     handler->_redirectUri = redirectUri;
+    SAFE_ARC_RETAIN(redirectUri);
     handler->_identifier = identifier;
+    SAFE_ARC_RETAIN(identifier);
     handler->_tokenCache = tokenCache;
+    SAFE_ARC_RETAIN(tokenCache);
     handler->_correlationId = correlationId;
+    SAFE_ARC_RETAIN(correlationId);
     
     [handler getAccessToken:completionBlock];
 }

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -324,7 +324,7 @@
         if (!item.userInformation.userId)
         {
             // If we don't have any userInformation in this token that means it came from an authority
-            // that supports
+            // that doesn't support MRRTs or FRTs either, so fail right now.
             completionBlock(nil);
             return;
         }

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireAssertion.m
@@ -70,10 +70,7 @@
                                          _resource, OAUTH2_RESOURCE,
                                          OAUTH2_SCOPE_OPENID_VALUE, OAUTH2_SCOPE,
                                          nil];
-    [self executeRequest:_context.authority
-             requestData:request_data
-         handledPkeyAuth:NO
-       additionalHeaders:nil
+    [self executeRequest:request_data
               completion:completionBlock];
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
@@ -38,12 +38,4 @@
 - (void)requestTokenByCode:(NSString*)code
            completionBlock:(ADAuthenticationCallback)completionBlock;
 
-- (void)acquireTokenByRefreshToken:(NSString*)refreshToken
-                         cacheItem:(ADTokenCacheItem*)cacheItem
-                   completionBlock:(ADAuthenticationCallback)completionBlock;
-
-- (void) validatedAcquireTokenByRefreshToken:(NSString*)refreshToken
-                                   cacheItem:(ADTokenCacheItem*)cacheItem
-                             completionBlock:(ADAuthenticationCallback)completionBlock;
-
 @end

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -28,6 +28,7 @@
 #import "ADHelpers.h"
 #import "ADUserIdentifier.h"
 #import "ADTokenCacheKey.h"
+#import "ADAcquireTokenSilentHandler.h"
 
 @implementation ADAuthenticationRequest (AcquireToken)
 
@@ -96,256 +97,31 @@
     
     if (![ADAuthenticationContext isForcedAuthorization:_promptBehavior] && [_context hasCacheStore])
     {
-        [self findAccessToken:completionBlock];
+        [ADAcquireTokenSilentHandler acquireTokenSilentForAuthority:_context.authority
+                                                           resource:_resource
+                                                           clientId:_clientId
+                                                        redirectUri:_redirectUri
+                                                         identifier:_identifier
+                                                      correlationId:_correlationId
+                                                         tokenCache:_tokenCache
+                                                    completionBlock:^(ADAuthenticationResult *result)
+        {
+            if ([ADAuthenticationContext isFinalResult:result])
+            {
+                completionBlock(result);
+                return;
+            }
+            
+            SAFE_ARC_RELEASE(_underlyingError);
+            _underlyingError = result.error;
+            SAFE_ARC_RETAIN(_underlyingError);
+            
+            [self requestToken:completionBlock];
+        }];
         return;
     }
     
     [self requestToken:completionBlock];
-}
-
-- (void)acquireTokenWithItem:(ADTokenCacheItem *)item
-                 refreshType:(NSString *)refreshType
-             completionBlock:(ADAuthenticationCallback)completionBlock
-                    fallback:(ADAuthenticationCallback)fallback
-{
-    [self acquireTokenByRefreshToken:item.refreshToken
-                           cacheItem:item
-                     completionBlock:^(ADAuthenticationResult *result)
-     {
-         NSString* resultStatus = @"Succeded";
-         
-         if (result.status == AD_FAILED)
-         {
-             if (result.error.protocolCode)
-             {
-                 resultStatus = [NSString stringWithFormat:@"Failed (%@)", result.error.protocolCode];
-             }
-             else
-             {
-                 resultStatus = [NSString stringWithFormat:@"Failed (%@ %ld)", result.error.domain, (long)result.error.code];
-             }
-         }
-         
-         NSString* msg = nil;
-         if (refreshType)
-         {
-             msg = [NSString stringWithFormat:@"Acquire Token with %@ Refresh Token %@.", refreshType, resultStatus];
-         }
-         else
-         {
-             msg = [NSString stringWithFormat:@"Acquire Token with Refresh Token %@.", resultStatus];
-         }
-         
-         AD_LOG_INFO_F(msg, _correlationId, @"clientId: '%@'; resource: '%@';", _clientId, _resource);
-         
-         if ([ADAuthenticationContext isFinalResult:result])
-         {
-             completionBlock(result);
-             return;
-         }
-         
-         fallback(result);
-     }];
-}
-
-/*
-    This is the beginning of the cache look up sequence. We start by trying to find an access token that is not
-    expired. If there's a single-resource-refresh-token it will be cached along side an expire AT, and we'll
-    attempt to use that. If not we fall into the MRRT<-->FRT code.
- */
- 
-- (void)findAccessToken:(ADAuthenticationCallback)completionBlock
-{
-    //All of these should be set before calling this method:
-    THROW_ON_NIL_ARGUMENT(completionBlock);
-    AD_REQUEST_CHECK_PROPERTY(_resource);
-    AD_REQUEST_CHECK_PROPERTY(_clientId);
-    
-    [self ensureRequest];
-    
-    BOOL fADFSUser = NO;
-    
-    ADAuthenticationError* error = nil;
-    ADTokenCacheItem* item = [self getItemForResource:_resource clientId:_clientId error:&error];
-    // If some error ocurred during the cache lookup then we need to fail out right away.
-    if (!item && error)
-    {
-        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-        return;
-    }
-    
-    // If we didn't find an item at all there's a chance that we might be dealing with an "ADFS" user
-    // and we need to check the unknown user ADFS token as well
-    if (!item)
-    {
-        item = [self getUnkownUserADFSToken:&error];
-        if (!item && error)
-        {
-            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-            return;
-        }
-        
-        // If we still don't have anything from the cache to use then we should try to see if we have an MRRT
-        // that matches.
-        if (!item)
-        {
-            [self tryMRRT:completionBlock];
-            return;
-        }
-        
-        // If the token was an ADFS user then there's no reason to try any of the MRRT or FRT fallbacks
-        fADFSUser = YES;
-    }
-    
-    // If we have a good (non-expired) access token then return it right away
-    if (item.accessToken && !item.isExpired)
-    {
-        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
-        ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheItem:item multiResourceRefreshToken:NO correlationId:_correlationId];
-        completionBlock(result);
-        return;
-    }
-
-    if (!item.refreshToken)
-    {
-        // There's nothing usable in this cache item, delete it.
-        if (![[_context tokenCacheStore] removeItem:item error:&error] && error)
-        {
-            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-            return;
-        }
-        
-        // If we're not a ADFS user try the MRRT
-        if (!fADFSUser)
-        {
-            [self tryMRRT:completionBlock];
-            return;
-        }
-        
-        // Otherwise go straight to interactive auth
-        [self requestToken:completionBlock];
-        return;
-    }
-    
-    [self acquireTokenWithItem:item
-                   refreshType:nil
-               completionBlock:completionBlock
-                      fallback:^(ADAuthenticationResult* result)
-    {
-        (void)result;
-        // If we had an individual RT associated with this item then we aren't
-        // talking to AAD so there won't be an MRRT. Go straight to interactive
-        // auth.
-        [self requestToken:completionBlock];
-    }];
-}
-
-/*
-    This method will try to find and use an MRRT, that matches the parameters of the authentication request.
-    If it finds one marked with a family ID it will call tryFRT before attempting to use the MRRT.
- */
-- (void)tryMRRT:(ADAuthenticationCallback)completionBlock
-{
-    ADAuthenticationError* error = nil;
-    
-    // If we don't have an item yet see if we can pull one out of the cache
-    if (!_mrrtItem)
-    {
-        _mrrtItem = [self getItemForResource:nil clientId:_clientId error:&error];
-        if (!_mrrtItem && error)
-        {
-            completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-            return;
-        }
-    }
-    
-    // If we still don't have an item try to use a FRT
-    if (!_mrrtItem)
-    {
-        [self tryFRT:nil completionBlock:completionBlock];
-        return;
-    }
-    
-    // If our MRRT is marked with an Family ID and we haven't tried a FRT yet
-    // try that first
-    if (_mrrtItem.familyId && !_attemptedFRT)
-    {
-        [self tryFRT:_mrrtItem.familyId completionBlock:completionBlock];
-        return;
-    }
-    
-    // Otherwise try the MRRT
-    [self acquireTokenWithItem:_mrrtItem
-                   refreshType:@"Multi Resource"
-               completionBlock:completionBlock
-                      fallback:^(ADAuthenticationResult* result)
-    {
-         _underlyingError = result.error;
-         SAFE_ARC_RETAIN(_underlyingError);
-         
-         NSString* familyId = _mrrtItem.familyId;
-         
-         // Clear out the MRRT as it's not good anymore anyways
-         _mrrtItem = nil;
-        
-        // Try the FRT in case it's there.
-         [self tryFRT:familyId completionBlock:completionBlock];
-     }];
-}
-
-/*
-    This method will attempt to find and use a FRT matching the given family ID and the parameters of the
-    authentication request, if we've not already tried an FRT during this request. If it fails it will call
-    -tryMRRT: If we have already tried to use an FRT then we go to interactive auth.
- */
- 
-- (void)tryFRT:(NSString*)familyId completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    if (_attemptedFRT)
-    {
-        [self requestToken:completionBlock];
-        return;
-    }
-    _attemptedFRT = YES;
-    
-    ADAuthenticationError* error = nil;
-    NSString* familyClientId = [ADAuthenticationRequest familyClientId:familyId];
-    
-    ADTokenCacheItem* frtItem = [self getItemForResource:nil clientId:familyClientId error:&error];
-    if (!frtItem && error)
-    {
-        completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-        return;
-    }
-    
-    if (!frtItem)
-    {
-        if (_mrrtItem)
-        {
-            // If we still have an MRRT item retrieved in this request then attempt to use that.
-            [self tryMRRT:completionBlock];
-        }
-        else
-        {
-            // Otherwise go to interactive auth
-            [self requestToken:completionBlock];
-        }
-        return;
-    }
-    
-    [self acquireTokenWithItem:frtItem refreshType:@"Family" completionBlock:completionBlock fallback:^(ADAuthenticationResult *result)
-    {
-        (void)result;
-        
-        if (_mrrtItem)
-        {
-            // If we still have an MRRT item retrieved in this request then attempt to use that.
-            [self tryMRRT:completionBlock];
-            return;
-        }
-        
-        [self requestToken:completionBlock];
-    }];
 }
 
 - (void)requestToken:(ADAuthenticationCallback)completionBlock
@@ -430,7 +206,7 @@
                   {
                       if (AD_SUCCEEDED == result.status)
                       {
-                          [self updateCacheToResult:result cacheItem:nil refreshToken:nil];
+                          [_tokenCache updateCacheToResult:result cacheItem:nil refreshToken:nil correlationId:_correlationId];
                           result = [ADAuthenticationContext updateResult:result toUser:_identifier];
                       }
                       completionBlock(result);
@@ -439,147 +215,6 @@
          }
      }];
 }
-
-#pragma mark -
-#pragma mark Refresh Token
-//Obtains an access token from the passed refresh token. If "cacheItem" is passed, updates it with the additional
-//information and updates the cache:
-- (void)acquireTokenByRefreshToken:(NSString*)refreshToken
-                         cacheItem:(ADTokenCacheItem*)cacheItem
-                   completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    THROW_ON_NIL_ARGUMENT(completionBlock);
-    AD_REQUEST_CHECK_ARGUMENT(refreshToken);
-    AD_REQUEST_CHECK_PROPERTY(_clientId);
-    
-    [self ensureRequest];
-    
-    AD_LOG_VERBOSE_F(@"Attempting to acquire an access token from refresh token.", _correlationId, @"Resource: %@", _resource);
-    
-    if (!_context.validateAuthority)
-    {
-        [self validatedAcquireTokenByRefreshToken:refreshToken
-                                        cacheItem:cacheItem
-                                  completionBlock:completionBlock];
-        return;
-    }
-    
-    [[ADInstanceDiscovery sharedInstance] validateAuthority:_context.authority correlationId:_correlationId completionBlock:^(BOOL validated, ADAuthenticationError *error)
-     {
-         (void)validated;
-         if (error)
-         {
-             completionBlock([ADAuthenticationResult resultFromError:error correlationId:_correlationId]);
-         }
-         else
-         {
-             [self validatedAcquireTokenByRefreshToken:refreshToken
-                                             cacheItem:cacheItem
-                                       completionBlock:completionBlock];
-         }
-     }];
-}
-
-- (void) validatedAcquireTokenByRefreshToken:(NSString*)refreshToken
-                                   cacheItem:(ADTokenCacheItem*)cacheItem
-                             completionBlock:(ADAuthenticationCallback)completionBlock
-{
-    [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:_correlationId];
-    //Fill the data for the token refreshing:
-    NSMutableDictionary *request_data = nil;
-    
-    [self ensureRequest];
-    
-    if(cacheItem.sessionKey)
-    {
-        NSString* jwtToken = [self createAccessTokenRequestJWTUsingRT:cacheItem];
-        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                        _redirectUri, @"redirect_uri",
-                        _clientId, @"client_id",
-                        @"2.0", @"windows_api_version",
-                        @"urn:ietf:params:oauth:grant-type:jwt-bearer", OAUTH2_GRANT_TYPE,
-                        jwtToken, @"request",
-                        nil];
-        
-    }
-    else
-    {
-        request_data = [NSMutableDictionary dictionaryWithObjectsAndKeys:
-                        OAUTH2_REFRESH_TOKEN, OAUTH2_GRANT_TYPE,
-                        refreshToken, OAUTH2_REFRESH_TOKEN,
-                        _clientId, OAUTH2_CLIENT_ID,
-                        nil];
-    }
-    
-    if (![NSString adIsStringNilOrBlank:_resource])
-    {
-        [request_data setObject:_resource forKey:OAUTH2_RESOURCE];
-    }
-    
-    AD_LOG_INFO_F(@"Attempting to acquire an access token from refresh token", nil, @"clientId: '%@'; resource: '%@';", _clientId, _resource);
-    [self requestWithServer:_context.authority
-                requestData:request_data
-            handledPkeyAuth:NO
-          additionalHeaders:nil
-                 completion:^(NSDictionary *response)
-     {
-         ADTokenCacheItem* resultItem = (cacheItem) ? cacheItem : [ADTokenCacheItem new];
-         
-         //Always ensure that the cache item has all of these set, especially in the broad token case, where the passed item
-         //may have empty "resource" property:
-         resultItem.resource = _resource;
-         resultItem.clientId = _clientId;
-         resultItem.authority = _context.authority;
-         
-         
-         ADAuthenticationResult *result = [resultItem processTokenResponse:response fromRefresh:YES requestCorrelationId:_correlationId];
-         if (cacheItem)//The request came from the cache item, update it:
-         {
-             [self updateCacheToResult:result
-                             cacheItem:resultItem
-                          refreshToken:refreshToken];
-         }
-         result = [ADAuthenticationContext updateResult:result toUser:_identifier];//Verify the user (just in case)
-         //
-         if (!cacheItem)
-         {
-             SAFE_ARC_RELEASE(resultItem);
-         }
-         completionBlock(result);
-     }];
-}
-
--(NSString*) createAccessTokenRequestJWTUsingRT:(ADTokenCacheItem*)cacheItem
-{
-    NSString* grantType = @"refresh_token";
-    
-    NSString* ctx = [[[NSUUID UUID] UUIDString] adComputeSHA256];
-    NSDictionary *header = @{
-                             @"alg" : @"HS256",
-                             @"typ" : @"JWT",
-                             @"ctx" : [ADHelpers convertBase64UrlStringToBase64NSString:[ctx adBase64UrlEncode]]
-                             };
-    
-    NSInteger iat = round([[NSDate date] timeIntervalSince1970]);
-    NSDictionary *payload = @{
-                              @"resource" : _resource,
-                              @"client_id" : _clientId,
-                              @"refresh_token" : cacheItem.refreshToken,
-                              @"iat" : [NSNumber numberWithInteger:iat],
-                              @"nbf" : [NSNumber numberWithInteger:iat],
-                              @"exp" : [NSNumber numberWithInteger:iat],
-                              @"scope" : @"openid",
-                              @"grant_type" : grantType,
-                              @"aud" : _context.authority
-                              };
-    
-    NSString* returnValue = [ADHelpers createSignedJWTUsingKeyDerivation:header
-                                                                 payload:payload
-                                                                 context:ctx
-                                                            symmetricKey:cacheItem.sessionKey];
-    return returnValue;
-}
-
 // Generic OAuth2 Authorization Request, obtains a token from an authorization code.
 - (void)requestTokenByCode:(NSString *)code
            completionBlock:(ADAuthenticationCallback)completionBlock
@@ -600,10 +235,7 @@
         [request_data setValue:_scope forKey:OAUTH2_SCOPE];
     }
     
-    [self executeRequest:_context.authority
-             requestData:request_data
-         handledPkeyAuth:NO
-       additionalHeaders:nil
+    [self executeRequest:request_data
               completion:completionBlock];
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -34,6 +34,8 @@
 #import "ADUserIdentifier.h"
 #import "ADUserInformation.h"
 #import "ADWebAuthController+Internal.h"
+#import "ADKeychainTokenCache+Internal.h"
+#import "ADAuthenticationResult.h"
 
 #if TARGET_OS_IPHONE
 #import "ADBrokerKeyHelper.h"
@@ -75,6 +77,7 @@
 
 + (void)internalHandleBrokerResponse:(NSURL *)response
 {
+#if TARGET_OS_IPHONE
     ADAuthenticationCallback completionBlock = [ADBrokerHelper copyAndClearCompletionBlock];
     HANDLE_ARGUMENT(response, nil);
     
@@ -90,7 +93,6 @@
     {
         // Encrypting the broker response should not be a requirement on Mac as there shouldn't be a possibility of the response
         // accidentally going to the wrong app
-#if TARGET_OS_IPHONE
         HANDLE_ARGUMENT([queryParamsMap valueForKey:BROKER_HASH_KEY], nil);
         
         NSString* hash = [queryParamsMap valueForKey:BROKER_HASH_KEY];
@@ -143,17 +145,14 @@
         {
             result = [ADAuthenticationResult resultFromError:error correlationId:correlationId];
         }
-#else // !TARGET_OS_IPHONE
-        // TODO: Broker support on Mac.
-        result = [ADAuthenticationResult resultFromBrokerResponse:queryParamsMap];
-#endif // TARGET_OS_IPHONE
     }
     
     if (AD_SUCCEEDED == result.status)
     {
-        ADAuthenticationRequest* req = [ADAuthenticationRequest requestWithAuthority:result.tokenCacheItem.authority];
+        ADTokenCacheAccessor* cache = [[ADTokenCacheAccessor alloc] initWithDataSource:[ADKeychainTokenCache defaultKeychainCache]
+                                                                             authority:result.tokenCacheItem.authority];
         
-        [req updateCacheToResult:result cacheItem:nil refreshToken:nil];
+        [cache updateCacheToResult:result cacheItem:nil refreshToken:nil correlationId:nil];
         
         NSString* userId = [[[result tokenCacheItem] userInformation] userId];
         [ADAuthenticationContext updateResult:result
@@ -162,9 +161,7 @@
     if (!completionBlock)
     {
         AD_LOG_ERROR(@"Received broker response without a completionBlock.", AD_FAILED, nil, nil);
-#if TARGET_OS_IPHONE
         [ADWebAuthController setInterruptedBrokerResult:result];
-#endif // TARGET_OS_IPHONE
     }
     
     [[NSNotificationCenter defaultCenter] postNotificationName:ADWebAuthDidReceieveResponseFromBroker
@@ -176,6 +173,9 @@
     {
         completionBlock(result);
     }
+#else
+    (void)response;
+#endif
 }
 
 - (BOOL)canUseBroker

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.h
@@ -27,33 +27,8 @@
 // this method will return the matching request
 + (ADAuthenticationRequest*)currentModalRequest;
 
-- (void)executeRequest:(NSString *)authorizationServer
-           requestData:(NSDictionary *)request_data
-       handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-     additionalHeaders:(NSDictionary *)additionalHeaders
+- (void)executeRequest:(NSDictionary *)request_data
             completion:(ADAuthenticationCallback)completionBlock;
-
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-               completion:( void (^)(NSDictionary *) )completionBlock;
-
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-        returnRawResponse:(BOOL)returnRawResponse
-               completion:( void (^)(NSDictionary *) )completionBlock;
-
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-        returnRawResponse:(BOOL)returnRawResponse
-             isGetRequest:(BOOL)isGetRequest
-       retryIfServerError:(BOOL)retryIfServerError
-               completion:( void (^)(NSDictionary *) )completionBlock;
 
 //Requests an OAuth2 code to be used for obtaining a token:
 - (void)requestCode:(ADAuthorizationCodeCallback)completionBlock;

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -36,6 +36,7 @@
 #import "ADUserIdentifier.h"
 #import "ADAuthenticationRequest.h"
 #import "ADTokenCacheItem+Internal.h"
+#import "ADWebAuthRequest.h"
 
 #import <libkern/OSAtomic.h>
 
@@ -48,17 +49,13 @@ static ADAuthenticationRequest* s_modalRequest = nil;
     return s_modalRequest;
 }
 
-- (void)executeRequest:(NSString *)authorizationServer
-           requestData:(NSDictionary *)request_data
-       handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-     additionalHeaders:(NSDictionary *)additionalHeaders
+- (void)executeRequest:(NSDictionary *)request_data
             completion:(ADAuthenticationCallback)completionBlock
 {
-    [self requestWithServer:authorizationServer
-                requestData:request_data
-            handledPkeyAuth:isHandlingPKeyAuthChallenge
-          additionalHeaders:additionalHeaders
-                 completion:^(NSDictionary *response)
+    NSString* urlString = [_context.authority stringByAppendingString:OAUTH2_TOKEN_SUFFIX];
+    ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:urlString] correlationId:_correlationId];
+    [req setRequestDictionary:request_data];
+    [req sendRequest:^(NSDictionary *response)
      {
          //Prefill the known elements in the item. These can be overridden by the response:
          ADTokenCacheItem* item = [ADTokenCacheItem new];
@@ -71,256 +68,6 @@ static ADAuthenticationRequest* s_modalRequest = nil;
          SAFE_ARC_RELEASE(item);
          completionBlock(result);
      }];
-}
-
-
-// Performs an OAuth2 token request using the supplied request dictionary and executes the completion block
-// If the request generates an HTTP error, the method adds details to the "error" parameters of the dictionary.
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-               completion:( void (^)(NSDictionary *) )completionBlock
-{
-    [self requestWithServer:authorizationServer
-                requestData:request_data
-            handledPkeyAuth:isHandlingPKeyAuthChallenge
-          additionalHeaders:additionalHeaders
-          returnRawResponse:NO
-               isGetRequest:NO
-         retryIfServerError:YES
-                 completion:completionBlock];
-}
-
-
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-        returnRawResponse:(BOOL)returnRawResponse
-               completion:( void (^)(NSDictionary *) )completionBlock
-{
-    [self requestWithServer:authorizationServer
-                requestData:request_data
-            handledPkeyAuth:isHandlingPKeyAuthChallenge
-          additionalHeaders:additionalHeaders
-          returnRawResponse:returnRawResponse
-               isGetRequest:NO
-         retryIfServerError:YES
-                 completion:completionBlock];
-}
-
-- (void)requestWithServer:(NSString *)authorizationServer
-              requestData:(NSDictionary *)request_data
-          handledPkeyAuth:(BOOL)isHandlingPKeyAuthChallenge
-        additionalHeaders:(NSDictionary *)additionalHeaders
-        returnRawResponse:(BOOL)returnRawResponse
-             isGetRequest:(BOOL)isGetRequest
-       retryIfServerError:(BOOL)retryIfServerError
-               completion:( void (^)(NSDictionary *) )completionBlock
-{
-    [self ensureRequest];
-    NSString* endPoint = authorizationServer;
-    
-    if (!isHandlingPKeyAuthChallenge && !isGetRequest)
-	{
-        endPoint = [_context.authority stringByAppendingString:OAUTH2_TOKEN_SUFFIX];
-    }
-    
-    if (isGetRequest)
-    {
-        endPoint = [NSString stringWithFormat:@"%@?%@", endPoint, [request_data adURLFormEncode]];
-    }
-    
-    ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:[NSURL URLWithString:endPoint]
-                                                   correlationId:_correlationId];
-    [webRequest setMethodType:isGetRequest ? ADWebRequestGet : ADWebRequestPost];
-    [webRequest.headers setObject:@"application/json" forKey:@"Accept"];
-    [webRequest.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
-    [webRequest.headers setObject:pKeyAuthHeaderVersion forKey:pKeyAuthHeader];
-    if(additionalHeaders){
-        for (NSString* key in [additionalHeaders allKeys] ) {
-            [webRequest.headers setObject:[additionalHeaders objectForKey:key ] forKey:key];
-        }
-    }
-    
-    if (isGetRequest)
-    {
-        AD_LOG_VERBOSE_F(@"Get request", _correlationId, @"Sending GET request to %@ with client-request-id %@", endPoint, [_correlationId UUIDString]);
-    }
-    else
-    {
-        AD_LOG_VERBOSE_F(@"Post request", _correlationId, @"Sending POST request to %@ with client-request-id %@", endPoint, [_correlationId UUIDString]);
-    }
-    
-    webRequest.body = [[request_data adURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding];
-    
-    __block NSDate* startTime = [NSDate new];
-    [[ADClientMetrics getInstance] addClientMetrics:webRequest.headers endpoint:endPoint];
-    
-    [webRequest send:^( NSError *error, ADWebResponse *webResponse ) {
-        // Request completion callback
-        NSMutableDictionary *response = [NSMutableDictionary new];
-        SAFE_ARC_AUTORELEASE(response);
-        
-        if ( error == nil )
-        {
-            NSDictionary* headers = webResponse.headers;
-            //In most cases the correlation id is returned as a separate header
-            NSString* responseCorrelationId = [headers objectForKey:OAUTH2_CORRELATION_ID_REQUEST_VALUE];
-            NSUUID* responseCorrelationUUID = _correlationId;
-            if (![NSString adIsStringNilOrBlank:responseCorrelationId])
-            {
-                [response setObject:responseCorrelationId forKey:OAUTH2_CORRELATION_ID_RESPONSE];//Add it to the dictionary to be logged and checked later.
-                responseCorrelationUUID = [[NSUUID alloc] initWithUUIDString:responseCorrelationId];
-                SAFE_ARC_AUTORELEASE(responseCorrelationUUID);
-            }
-            
-            [response setObject:webResponse.URL forKey:@"url"];
-            
-            switch (webResponse.statusCode)
-            {
-                case 200:
-                    if(returnRawResponse)
-                    {
-                        NSString* rawResponse = [[NSString alloc] initWithData:webResponse.body encoding:NSASCIIStringEncoding];
-                        [response setObject:rawResponse
-                                     forKey:@"raw_response"];
-                        SAFE_ARC_RELEASE(rawResponse);
-                        break;
-                    }
-                case 400:
-                case 401:
-                {
-                    if(!isHandlingPKeyAuthChallenge)
-                    {
-                        NSString* wwwAuthValue = [headers valueForKey:wwwAuthenticateHeader];
-                        if(![NSString adIsStringNilOrBlank:wwwAuthValue] && [wwwAuthValue adContainsString:pKeyAuthName])
-                        {
-                            [self handlePKeyAuthChallenge:endPoint
-                                       wwwAuthHeaderValue:wwwAuthValue
-                                              requestData:request_data
-                                               completion:completionBlock];
-                            return;
-                        }
-                    }
-                    NSError   *jsonError  = nil;
-                    id         jsonObject = [NSJSONSerialization JSONObjectWithData:webResponse.body options:0 error:&jsonError];
-                    
-                    if ( nil != jsonObject && [jsonObject isKindOfClass:[NSDictionary class]] )
-                    {
-                        // Load the response
-                        [response addEntriesFromDictionary:(NSDictionary*)jsonObject];
-                    }
-                    else
-                    {
-                        ADAuthenticationError* adError = nil;
-                        if (jsonError)
-                        {
-                            // Unrecognized JSON response
-                            // We're often seeing the JSON parser being asked to parse whole HTML pages.
-                            // Logging out the whole thing is unhelpful as it contains no useful info.
-                            // If the body is > 1 KB then it's a pretty safe bet that it contains more
-                            // noise then would be helpful
-                            NSString* bodyStr = nil;
-                            
-                            if ([webResponse.body length] < 1024)
-                            {
-                                bodyStr = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
-                            }
-                            else
-                            {
-                                bodyStr = [[NSString alloc] initWithFormat:@"large response, probably HTML, <%lu bytes>", (unsigned long)[webResponse.body length]];
-                            }
-                            
-                            AD_LOG_ERROR_F(@"JSON deserialization", jsonError.code, _correlationId, @"Error: %@. Body text: '%@'. HTTPS Code: %ld. Response correlation id: %@", jsonError.description, bodyStr, (long)webResponse.statusCode, responseCorrelationId);
-                            adError = [ADAuthenticationError errorFromNSError:jsonError errorDetails:jsonError.localizedDescription correlationId:responseCorrelationUUID];
-                            SAFE_ARC_RELEASE(bodyStr);
-                        }
-                        else
-                        {
-                            adError = [ADAuthenticationError unexpectedInternalError:[NSString stringWithFormat:@"Unexpected object type: %@", [jsonObject class]] correlationId:responseCorrelationUUID];
-                        }
-                        [response setObject:adError forKey:AUTH_NON_PROTOCOL_ERROR];
-                    }
-                }
-                    break;
-                case 500:
-                case 503:
-                {
-                    //retry if it is a server error
-                    //500 and 503 are the ones we retry
-                    if (retryIfServerError)
-                    {
-                        //retry once after half second
-                        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                            [self requestWithServer:authorizationServer
-                                        requestData:request_data
-                                    handledPkeyAuth:isHandlingPKeyAuthChallenge
-                                  additionalHeaders:additionalHeaders
-                                  returnRawResponse:returnRawResponse
-                                       isGetRequest:isGetRequest
-                                 retryIfServerError:NO
-                                         completion:completionBlock];
-                        });
-                        return;
-                    }
-                    //no "break;" here
-                    //will go to default for handling if "retryIfServerError" is NO
-                }
-                default:
-                {
-                    // Request failure
-                    NSString* body = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
-                    NSString* errorData = [NSString stringWithFormat:@"Full response: %@", body];
-                    AD_LOG_WARN(([NSString stringWithFormat:@"HTTP Error %ld", (long)webResponse.statusCode]), _correlationId, errorData);
-                    
-                    ADAuthenticationError* adError = [ADAuthenticationError HTTPErrorCode:webResponse.statusCode
-                                                                                     body:[NSString stringWithFormat:@"(%lu bytes)", (unsigned long)webResponse.body.length]
-                                                                            correlationId:_correlationId];
-                    SAFE_ARC_RELEASE(body);
-                    
-                    //Now add the information to the dictionary, so that the parser can extract it:
-                    [response setObject:adError
-                                 forKey:AUTH_NON_PROTOCOL_ERROR];
-                }
-            }
-        }
-        else if (error && [[error domain] isEqualToString:@"NSURLErrorDomain"] && [error code] == -1002)
-        {
-            // Unsupported URL Error
-            // This can happen because the redirect URI isn't a valid URI, or we've tried to jump out of the app with a URL scheme handler
-            // It's worth peeking into this error to see if we have useful information anyways.
-            
-            NSString* url = [[error userInfo] objectForKey:@"NSErrorFailingURLKey"];
-            [response setObject:url forKey:@"url"];
-        }
-        else
-        {
-            AD_LOG_WARN(@"System error while making request.", _correlationId, error.description);
-            // System error
-            ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error
-                                                                        errorDetails:error.localizedDescription
-                                                                       correlationId:_correlationId];
-            
-            [response setObject:adError
-                         forKey:AUTH_NON_PROTOCOL_ERROR];
-        }
-        
-        ADAuthenticationError* adError = [response valueForKey:AUTH_NON_PROTOCOL_ERROR];
-        NSString* errorDetails = [adError errorDetails];
-        [[ADClientMetrics getInstance] endClientMetricsRecord:endPoint
-                                                    startTime:startTime
-                                                correlationId:_correlationId
-                                                 errorDetails:errorDetails];
-        SAFE_ARC_RELEASE(startTime);
-        
-        completionBlock(response);
-    }];
-    
-    // The objc blocks above will hold onto references to this web request and keep it alive until after
-    // the completion block gets hit.
-    SAFE_ARC_RELEASE(webRequest);
 }
 
 //Ensures that a single UI login dialog can be requested at a time.
@@ -533,14 +280,11 @@ static ADAuthenticationRequest* s_modalRequest = nil;
             [requestData setObject:_scope forKey:OAUTH2_SCOPE];
         }
         
-        [self requestWithServer:[_context.authority stringByAppendingString:OAUTH2_AUTHORIZE_SUFFIX]
-                    requestData:requestData
-                handledPkeyAuth:NO
-              additionalHeaders:nil
-              returnRawResponse:NO
-				   isGetRequest:YES
-             retryIfServerError:YES
-                     completion:^(NSDictionary * parameters)
+        NSURL* reqURL = [NSURL URLWithString:[_context.authority stringByAppendingString:OAUTH2_AUTHORIZE_SUFFIX]];
+        ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:reqURL correlationId:_correlationId];
+        [req setIsGetRequest:YES];
+        [req setRequestDictionary:requestData];
+        [req sendRequest:^(NSDictionary * parameters)
          {
              
              NSURL* endURL = nil;
@@ -566,34 +310,5 @@ static ADAuthenticationRequest* s_modalRequest = nil;
          }];
     }
 }
-
-- (void) handlePKeyAuthChallenge:(NSString *)authorizationServer
-              wwwAuthHeaderValue:(NSString *)wwwAuthHeaderValue
-                     requestData:(NSDictionary *)request_data
-                      completion:( void (^)(NSDictionary *) )completionBlock
-{
-    //pkeyauth word length=8 + 1 whitespace
-    wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
-    
-    NSDictionary* authHeaderParams = [wwwAuthHeaderValue authHeaderParams];
-    
-    if (!authHeaderParams)
-    {
-        AD_LOG_ERROR_F(@"Unparseable wwwAuthHeader received.", AD_ERROR_SERVER_WPJ_REQUIRED, _correlationId, @"%@", wwwAuthHeaderValue);
-    }
-    
-    NSString* authHeader = [ADPkeyAuthHelper createDeviceAuthResponse:authorizationServer
-                                                        challengeData:authHeaderParams];
-    
-    NSDictionary* additionalHeaders = @{ @"Authorization" : authHeader };
-
-    
-    [self requestWithServer:authorizationServer
-                requestData:request_data
-            handledPkeyAuth:TRUE
-          additionalHeaders:additionalHeaders
-                 completion:completionBlock];
-}
-
 
 @end

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -26,6 +26,7 @@
 #import "ADAuthenticationContext.h"
 
 @class ADUserIdentifier;
+@class ADTokenCacheAccessor;
 
 #define AD_REQUEST_CHECK_ARGUMENT(_arg) { \
     if (!_arg || ([_arg isKindOfClass:[NSString class]] && [(NSString*)_arg isEqualToString:@""])) { \
@@ -49,6 +50,7 @@
     ADAuthenticationContext* _context;
     NSString* _clientId;
     NSString* _redirectUri;
+    ADTokenCacheAccessor* _tokenCache;
     
     ADUserIdentifier* _identifier;
     
@@ -123,4 +125,3 @@
 #import "ADAuthenticationRequest+AcquireToken.h"
 #import "ADAuthenticationRequest+Broker.h"
 #import "ADAuthenticationRequest+WebRequest.h"
-#import "ADAuthenticationRequest+TokenCaching.h"

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -107,6 +107,7 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     
     SAFE_ARC_RETAIN(context);
     _context = context;
+    _tokenCache = context.tokenCacheStore;
     _redirectUri = [redirectUri adTrimmedString];
     SAFE_ARC_RETAIN(_redirectUri);
     _clientId = [clientId adTrimmedString];

--- a/ADAL/src/request/ADWebAuthRequest.h
+++ b/ADAL/src/request/ADWebAuthRequest.h
@@ -21,28 +21,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "ADKeychainTokenCache.h"
-#import "ADTokenCacheDataSource.h"
+#import "ADWebRequest.h"
 
-@class ADTokenCacheStoreKey;
+@interface ADWebAuthRequest : ADWebRequest
+{
+    NSDate* _startTime;
+    BOOL _retryIfServerError;
+    BOOL _handledPkeyAuthChallenge;
+    BOOL _returnRawResponse;
+    
+    NSMutableDictionary* _responseDictionary;
+    
+    // A dictionary of key/value pairs that is either included as the query parameters on a GET
+    // request or serialized into JSON for a POST request
+    NSDictionary<NSString*,NSString*> * _requestDictionary;
+}
 
-@interface ADKeychainTokenCache (Internal) <ADTokenCacheDataSource>
+@property BOOL returnRawResponse;
 
-+ (BOOL)checkStatus:(OSStatus)status
-          operation:(NSString *)operation
-      correlationId:(NSUUID *)correlationId
-              error:(ADAuthenticationError * __autoreleasing *)error;
-
-- (NSMutableDictionary *)queryDictionaryForKey:(ADTokenCacheKey *)key
-                                        userId:(NSString *)userId
-                                    additional:(NSDictionary*)additional;
-
-- (NSString*)keychainKeyFromCacheKey:(ADTokenCacheKey *)itemKey;
-
-/*! This method should *only* be called in test code, it should never be called
-    in production code */
-- (void)testRemoveAll:(ADAuthenticationError * __autoreleasing *)error;
-
-- (NSDictionary*)defaultKeychainQuery;
+- (void)setRequestDictionary:(NSDictionary<NSString*, NSString*> *)requestDictionary;
+- (void)sendRequest:(void(^)(NSDictionary *))completionBlock;
 
 @end

--- a/ADAL/src/request/ADWebAuthRequest.m
+++ b/ADAL/src/request/ADWebAuthRequest.m
@@ -1,0 +1,315 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADWebAuthRequest.h"
+#import "ADWorkplaceJoinConstants.h"
+#import "ADClientMetrics.h"
+#import "NSDictionary+ADExtensions.h"
+#import "ADOAuth2Constants.h"
+#import "ADWebResponse.h"
+#import "ADPkeyAuthHelper.h"
+
+@implementation ADWebAuthRequest
+
+@synthesize returnRawResponse = _returnRawResponse;
+
+- (id)initWithURL:(NSURL *)url
+    correlationId:(NSUUID *)correlationId
+{
+    self = [super initWithURL:url correlationId:correlationId];
+    if (!self)
+    {
+        return nil;
+    }
+    
+    [self.headers setObject:@"application/json" forKey:@"Accept"];
+    [self.headers setObject:@"application/x-www-form-urlencoded" forKey:@"Content-Type"];
+    [self.headers setObject:pKeyAuthHeaderVersion forKey:pKeyAuthHeader];
+    
+    _retryIfServerError = YES;
+    
+    return self;
+}
+
+- (void)setRequestDictionary:(NSDictionary*)requestDictionary
+{
+    if (requestDictionary == _requestDictionary)
+    {
+        return;
+    }
+    
+    SAFE_ARC_RELEASE(_requestDictionary);
+    _requestDictionary = [requestDictionary copy];
+}
+
+- (void)sendRequest:(void (^)(NSDictionary *))completionBlock
+{
+    if ([self isGetRequest])
+    {
+        NSString* newURL = [NSString stringWithFormat:@"%@?%@", [_requestURL absoluteString], [_requestDictionary adURLFormEncode]];
+        SAFE_ARC_RELEASE(_requestURL);
+        _requestURL = [NSURL URLWithString:newURL];
+        SAFE_ARC_RETAIN(_requestURL);
+    }
+
+    [self setBody:[[_requestDictionary adURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding]];
+    
+    _startTime = [NSDate new];
+    [[ADClientMetrics getInstance] addClientMetrics:self.headers endpoint:[_requestURL absoluteString]];
+    
+    [self send:^( NSError *error, ADWebResponse *webResponse )
+    {
+        _responseDictionary = [NSMutableDictionary new];
+        if (error)
+        {
+            [self handleNSError:error
+                completionBlock:completionBlock];
+        }
+        else
+        {
+            [self handleResponse:webResponse completionBlock:completionBlock];
+        }
+        
+        SAFE_ARC_RELEASE(_responseDictionary);
+        _responseDictionary = nil;
+    }];
+}
+
+- (void)checkCorrelationId:(ADWebResponse*)webResponse
+{
+    NSDictionary* headers = webResponse.headers;
+    //In most cases the correlation id is returned as a separate header
+    NSString* responseCorrelationId = [headers objectForKey:OAUTH2_CORRELATION_ID_REQUEST_VALUE];
+    if (![NSString adIsStringNilOrBlank:responseCorrelationId])
+    {
+        [_responseDictionary setObject:responseCorrelationId forKey:OAUTH2_CORRELATION_ID_RESPONSE];//Add it to the dictionary to be logged and checked later.
+    }
+}
+
+- (void)handleResponse:(ADWebResponse *)webResponse
+       completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    [self checkCorrelationId:webResponse];
+    [_responseDictionary setObject:webResponse.URL forKey:@"url"];
+    
+    switch (webResponse.statusCode)
+    {
+        case 200:
+            if(_returnRawResponse)
+            {
+                NSString* rawResponse = [[NSString alloc] initWithData:webResponse.body encoding:NSASCIIStringEncoding];
+                [_responseDictionary setObject:rawResponse
+                                        forKey:@"raw_response"];
+                SAFE_ARC_RELEASE(rawResponse);
+                break;
+            }
+        case 400:
+        case 401:
+        {
+            if(!_handledPkeyAuthChallenge)
+            {
+                NSString* wwwAuthValue = [webResponse.headers valueForKey:wwwAuthenticateHeader];
+                if(![NSString adIsStringNilOrBlank:wwwAuthValue] && [wwwAuthValue adContainsString:pKeyAuthName])
+                {
+                    [self handlePKeyAuthChallenge:wwwAuthValue
+                                       completion:completionBlock];
+                    return;
+                }
+            }
+            
+            [self handleJSONResponse:webResponse completionBlock:completionBlock];
+            break;
+        }
+        case 500:
+        case 503:
+        {
+            //retry if it is a server error
+            //500 and 503 are the ones we retry
+            if (_retryIfServerError)
+            {
+                _retryIfServerError = NO;
+                //retry once after half second
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    [self sendRequest:completionBlock];
+                });
+                return;
+            }
+            //no "break;" here
+            //will go to default for handling if "retryIfServerError" is NO
+        }
+        default:
+        {
+            // Request failure
+            NSString* body = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
+            NSString* errorData = [NSString stringWithFormat:@"Full response: %@", body];
+            AD_LOG_WARN(([NSString stringWithFormat:@"HTTP Error %ld", (long)webResponse.statusCode]), _correlationId, errorData);
+            
+            ADAuthenticationError* adError = [ADAuthenticationError HTTPErrorCode:webResponse.statusCode
+                                                                             body:[NSString stringWithFormat:@"(%lu bytes)", (unsigned long)webResponse.body.length]
+                                                                    correlationId:_correlationId];
+            SAFE_ARC_RELEASE(body);
+            
+            //Now add the information to the dictionary, so that the parser can extract it:
+            [self handleADError:adError completionBlock:completionBlock];
+        }
+    }
+}
+
+- (void)handleJSONResponse:(ADWebResponse*)webResponse
+           completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    NSError   *jsonError  = nil;
+    id         jsonObject = [NSJSONSerialization JSONObjectWithData:webResponse.body options:0 error:&jsonError];
+    
+    if (!jsonObject)
+    {
+        [self handleJSONError:jsonError body:webResponse.body completionBlock:completionBlock];
+        return;
+    }
+    
+    if (![jsonObject isKindOfClass:[NSDictionary class]])
+    {
+        ADAuthenticationError* adError =
+        [ADAuthenticationError unexpectedInternalError:[NSString stringWithFormat:@"Unexpected object type: %@", [jsonObject class]]
+                                         correlationId:_correlationId];
+        [self handleADError:adError completionBlock:completionBlock];
+        return;
+    }
+    
+    // Load the response
+    [_responseDictionary addEntriesFromDictionary:(NSDictionary*)jsonObject];
+    [self handleSuccess:completionBlock];
+    return;
+}
+
+- (void)handlePKeyAuthChallenge:(NSString *)wwwAuthHeaderValue
+                     completion:(void (^)(NSDictionary *))completionBlock
+{
+    //pkeyauth word length=8 + 1 whitespace
+    wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
+    
+    NSDictionary* authHeaderParams = [wwwAuthHeaderValue authHeaderParams];
+    
+    if (!authHeaderParams)
+    {
+        AD_LOG_ERROR_F(@"Unparseable wwwAuthHeader received.", AD_ERROR_SERVER_WPJ_REQUIRED, _correlationId, @"%@", wwwAuthHeaderValue);
+    }
+    
+    NSString* authHeader = [ADPkeyAuthHelper createDeviceAuthResponse:[_requestURL absoluteString]
+                                                        challengeData:authHeaderParams];
+    
+    // Add Authorization response header to the headers of the request
+    [self.headers setObject:authHeader forKey:@"Authorization"];
+    
+    [self sendRequest:completionBlock];
+}
+
+- (void)handleSuccess:(void (^)(NSDictionary *))completionBlock
+{
+    [[ADClientMetrics getInstance] endClientMetricsRecord:[_requestURL absoluteString]
+                                                startTime:_startTime
+                                            correlationId:_correlationId
+                                             errorDetails:nil];
+    SAFE_ARC_RELEASE(_startTime);
+    _startTime = nil;
+    
+    completionBlock(_responseDictionary);
+}
+
+#pragma mark -
+#pragma mark Error Handlers
+
+- (void)handleJSONError:(NSError*)jsonError
+                   body:(NSData*)body
+        completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    
+    // Unrecognized JSON response
+    // We're often seeing the JSON parser being asked to parse whole HTML pages.
+    // Logging out the whole thing is unhelpful as it contains no useful info.
+    // If the body is > 1 KB then it's a pretty safe bet that it contains more
+    // noise then would be helpful
+    NSString* bodyStr = nil;
+    
+    if (body.length == 0)
+    {
+        AD_LOG_ERROR(@"Empty body received, expected JSON response.", jsonError.code, _correlationId, nil);
+    }
+    else
+    {
+        if ([body length] < 1024)
+        {
+            bodyStr = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+        }
+        else
+        {
+            bodyStr = [[NSString alloc] initWithFormat:@"large response, probably HTML, <%lu bytes>", (unsigned long)[body length]];
+        }
+        
+        NSString* errorMsg = [NSString stringWithFormat:@"JSON deserialization error: %@", jsonError.description];
+        
+        AD_LOG_ERROR_F(errorMsg, jsonError.code, _correlationId, @"%@", bodyStr);
+        SAFE_ARC_RELEASE(bodyStr);
+    }
+    
+    [self handleNSError:jsonError completionBlock:completionBlock];
+}
+
+- (void)handleNSError:(NSError*)error completionBlock:(void (^)(NSDictionary*))completionBlock
+{
+    if ([[error domain] isEqualToString:@"NSURLErrorDomain"] && [error code] == -1002)
+    {
+        // Unsupported URL Error
+        // This can happen because the redirect URI isn't a valid URI, or we've tried to jump out of the app with a URL scheme handler
+        // It's worth peeking into this error to see if we have useful information anyways.
+        
+        NSString* url = [[error userInfo] objectForKey:@"NSErrorFailingURLKey"];
+        [_responseDictionary setObject:url forKey:@"url"];
+    }
+    
+    AD_LOG_WARN(@"System error while making request.", _correlationId, error.description);
+    // System error
+    ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error
+                                                                errorDetails:error.localizedDescription
+                                                               correlationId:_correlationId];
+    
+    [self handleADError:adError completionBlock:completionBlock];
+}
+
+- (void)handleADError:(ADAuthenticationError*)adError completionBlock:(void (^)(NSDictionary*))completionBlock
+{
+    [_responseDictionary setObject:adError
+                            forKey:AUTH_NON_PROTOCOL_ERROR];
+    
+    [[ADClientMetrics getInstance] endClientMetricsRecord:[_requestURL absoluteString]
+                                                startTime:_startTime
+                                            correlationId:_correlationId
+                                             errorDetails:[adError errorDetails]];
+    
+    SAFE_ARC_RELEASE(_startTime);
+    _startTime = nil;
+    
+    completionBlock(_responseDictionary);
+}
+
+@end

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -24,19 +24,11 @@
 @class ADWebRequest;
 @class ADWebResponse;
 
-
-typedef enum
-{
-    ADWebRequestGet,
-    ADWebRequestPost,
-} ADWebRequestMethodType;
-
 @interface ADWebRequest : NSObject <NSURLConnectionDelegate>
 {
     NSURLConnection * _connection;
     
     NSURL * _requestURL;
-    __WEAK NSString* _requestMethod;
     NSMutableDictionary* _requestHeaders;
     NSData * _requestData;
     
@@ -49,21 +41,21 @@ typedef enum
     
     NSOperationQueue * _operationQueue;
     
+    BOOL _isGetRequest;
+    
     void (^_completionHandler)( NSError *, ADWebResponse *);
 }
 
 @property (strong, readonly, nonatomic) NSURL               *URL;
-@property (weak, readonly)              NSString            *method;
-@property (strong, readonly, nonatomic) NSMutableDictionary *headers;
+@property (copy, nonatomic)             NSMutableDictionary *headers;
 @property (strong)                      NSData              *body;
-@property (nonatomic)           NSUInteger           timeout;
+@property (nonatomic)                   NSUInteger           timeout;
+@property BOOL isGetRequest;
 
 - (id)initWithURL: (NSURL*)url
     correlationId: (NSUUID*) correlationId;
 
 - (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
-
-- (void)setMethodType:(ADWebRequestMethodType)methodType;
 
 @end
 

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -33,9 +33,6 @@
 #import "ADLogger+Internal.h"
 #import "ADURLProtocol.h"
 
-static NSString *const HTTPGet  = @"GET";
-static NSString *const HTTPPost = @"POST";
-
 @interface ADWebRequest () <NSURLConnectionDelegate>
 
 - (void)completeWithError:(NSError *)error andResponse:(ADWebResponse *)response;
@@ -50,8 +47,8 @@ static NSString *const HTTPPost = @"POST";
 
 @synthesize URL      = _requestURL;
 @synthesize headers  = _requestHeaders;
-@synthesize method   = _requestMethod;
 @synthesize timeout  = _timeout;
+@synthesize isGetRequest = _isGetRequest;
 
 - (NSData *)body
 {
@@ -62,7 +59,6 @@ static NSString *const HTTPPost = @"POST";
 {
     if ( body != nil )
     {
-        _requestMethod = HTTPPost;
         
         if (_requestData == body)
         {
@@ -77,15 +73,6 @@ static NSString *const HTTPPost = @"POST";
     }
 }
 
-- (void)setMethodType:(ADWebRequestMethodType)methodType
-{
-    switch (methodType)
-    {
-        case ADWebRequestGet: _requestMethod = HTTPGet; break;
-        case ADWebRequestPost: _requestMethod = HTTPPost; break;
-    }
-}
-
 #pragma mark - Initialization
 
 - (id)initWithURL:(NSURL *)requestURL
@@ -97,7 +84,6 @@ static NSString *const HTTPPost = @"POST";
     }
     
     _requestURL        = [requestURL copy];
-    _requestMethod     = HTTPGet;
     _requestHeaders    = [[NSMutableDictionary alloc] init];
     
     // Default timeout for ADWebRequest is 30 seconds
@@ -121,7 +107,6 @@ static NSString *const HTTPPost = @"POST";
     SAFE_ARC_RELEASE(_requestURL);
     _requestURL = nil;
     
-    _requestMethod = nil;
     SAFE_ARC_RELEASE(_requestHeaders);
     _requestHeaders = nil;
     SAFE_ARC_RELEASE(_requestData);
@@ -148,15 +133,6 @@ static NSString *const HTTPPost = @"POST";
 - (void)completeWithError:(NSError *)error andResponse:(ADWebResponse *)response
 {
     // Cleanup
-    SAFE_ARC_RELEASE(_requestURL);
-    _requestURL     = nil;
-    
-    _requestMethod  = nil;
-    SAFE_ARC_RELEASE(_requestHeaders);
-    _requestHeaders = nil;
-    SAFE_ARC_RELEASE(_requestData);
-    _requestData    = nil;
-    
     SAFE_ARC_RELEASE(_response);
     _response       = nil;
     SAFE_ARC_RELEASE(_responseData);
@@ -210,7 +186,7 @@ static NSString *const HTTPPost = @"POST";
                                                                 cachePolicy:NSURLRequestReloadIgnoringCacheData
                                                             timeoutInterval:_timeout];
     
-    request.HTTPMethod          = _requestMethod;
+    request.HTTPMethod          = _isGetRequest ? @"GET" : @"POST";
     request.allHTTPHeaderFields = _requestHeaders;
     request.HTTPBody            = _requestData;
     

--- a/ADAL/tests/ADTokenCacheKeyTests.m
+++ b/ADAL/tests/ADTokenCacheKeyTests.m
@@ -51,49 +51,6 @@
     [super tearDown];
 }
 
-- (void)testCreate
-{
-    ADAuthenticationError* error = nil;
-    ADTokenCacheKey* key = [ADTokenCacheKey keyWithAuthority:mAuthority resource:mResource clientId:mClientId error:&error];
-    ADAssertNoError;
-    XCTAssertNotNil(key);
-    
-    [self adSetLogTolerance:ADAL_LOG_LEVEL_ERROR];
-    //Bad authority:
-    error = nil;
-    ADTokenCacheKey* badKey = [ADTokenCacheKey keyWithAuthority:nil resource:mResource clientId:mClientId error:&error];
-    [self adValidateFactoryForInvalidArgument:@"authority"
-                             returnedObject:badKey
-                                      error:error];
-    error = nil;
-    badKey = [ADTokenCacheKey keyWithAuthority:@"   " resource:mResource clientId:mClientId error:&error];
-    [self adValidateFactoryForInvalidArgument:@"authority"
-                             returnedObject:badKey
-                                      error:error];
-
-    //Bad clientId
-    error = nil;
-    badKey = [ADTokenCacheKey keyWithAuthority:mAuthority resource:mResource clientId:nil error:&error];
-    [self adValidateFactoryForInvalidArgument:@"clientId"
-                             returnedObject:badKey
-                                      error:error];
-    error = nil;
-    badKey = [ADTokenCacheKey keyWithAuthority:mAuthority resource:mResource clientId:@"    " error:&error];
-    [self adValidateFactoryForInvalidArgument:@"clientId"
-                             returnedObject:badKey
-                                      error:error];
-    
-    error = nil;
-    ADTokenCacheKey* normal = [ADTokenCacheKey keyWithAuthority:mAuthority resource:mResource clientId:mClientId error:&error];
-    ADAssertNoError;
-    XCTAssertNotNil(normal);
-    
-    error = nil;
-    ADTokenCacheKey* broad = [ADTokenCacheKey keyWithAuthority:mAuthority resource:nil clientId:mClientId error:&error];
-    ADAssertNoError;
-    XCTAssertNotNil(broad);
-}
-
 -(void) assertKey: (ADTokenCacheKey*) key1
          equalsTo: (ADTokenCacheKey*) key2
 {

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenView.xib
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenView.xib
@@ -62,7 +62,7 @@
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="fullScreen" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="snj-kw-2kl">
                             <rect key="frame" x="8" y="56" width="69" height="23"/>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="broker" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cXL-sG-boM">
@@ -71,7 +71,7 @@
                                 <constraint firstAttribute="height" constant="19" id="VmK-2R-par"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="webView" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kAX-W6-Ehf">
@@ -80,7 +80,7 @@
                                 <constraint firstAttribute="width" constant="69" id="HNp-jJ-lZr"/>
                             </constraints>
                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                            <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                            <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                             <nil key="highlightedColor"/>
                         </label>
                     </subviews>
@@ -129,7 +129,7 @@
                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="userId" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="jOf-i3-Mew">
                     <rect key="frame" x="8" y="32" width="41" height="17"/>
                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
-                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
                     <nil key="highlightedColor"/>
                 </label>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="ZMN-vd-zcr">
@@ -223,7 +223,7 @@
                     </connections>
                 </button>
             </subviews>
-            <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+            <color key="backgroundColor" red="0.93725490199999995" green="0.93725490199999995" blue="0.95686274510000002" alpha="1" colorSpace="calibratedRGB"/>
             <constraints>
                 <constraint firstItem="ZJD-6I-rIr" firstAttribute="leading" secondItem="orS-Qq-OUM" secondAttribute="leading" id="FtL-As-I70"/>
                 <constraint firstItem="ZJD-6I-rIr" firstAttribute="top" secondItem="orS-Qq-OUM" secondAttribute="top" constant="27" id="ZMs-UM-LL9"/>


### PR DESCRIPTION
* Rename the ADTokenCacheAccessor protocol to ADTokenCacheDataStore
* Add a ADTokenCacheAccessor class for retrieving, adding and removing ADTokenCacheItems from a ADTokenCacheDataStore
* Remove the ADAuthenticationRequest+TokenCache category
* Move the functionality in the -requestWithServer: methods in ADAuthenticationRequest+WebRequest to ADWebAuthRequest, a subclass of ADWebRequest
* Move the AcquireTokenSilent flow into ADAcquireTokenSilentHandler