### PR TITLE
Make macro CHECK_PROFILE_INFO_ERROR more robust

### DIFF
--- a/ADALiOS/ADALiOS/ADProfileInfo.m
+++ b/ADALiOS/ADALiOS/ADProfileInfo.m
@@ -86,7 +86,7 @@ static ADAuthenticationError* _errorFromInfo(const char* cond, NSString* profile
 
 #define CHECK_PROFILE_INFO_ERROR(_cond) \
 { \
-    if (!_cond) { \
+    if (!(_cond)) { \
         ADAuthenticationError* _profileError = _errorFromInfo(#_cond, encodedString); \
         if (error) \
         { \


### PR DESCRIPTION
XCode 7.3 is giving an error message "Logical not is only applied to the left hand side of this comparison" for the above macro.

Fixed it by adding parenthesis.