### PR TITLE
ADTokenCacheItem forward compatible extensibility

### DIFF
--- a/ADAL/src/cache/ADTokenCacheItem+Internal.h
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.h
@@ -29,6 +29,11 @@
 
 @interface ADTokenCacheItem (Internal)
 
+- (NSDictionary*)additionalServer;
+- (NSMutableDictionary*)additionalClient;
+
+- (void)setAdditionalClient:(NSMutableDictionary*)additionalClient;
+
 - (void)checkCorrelationId:(NSDictionary*)response
       requestCorrelationId:(NSUUID*)requestCorrelationId;
 

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -200,6 +200,24 @@
     
     [self logWithCorrelationId:[responseDictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE] mrrt:isMRRT];
     
+    NSMutableDictionary* additional = [responseDictionary mutableCopy];
+    
+    // Remove any fields from the dictionary that we've already cached elsewhere
+    [additional removeObjectForKey:OAUTH2_AUTHORITY];
+    [additional removeObjectForKey:OAUTH2_RESOURCE];
+    [additional removeObjectForKey:OAUTH2_CLIENT_ID];
+    [additional removeObjectForKey:OAUTH2_ACCESS_TOKEN];
+    [additional removeObjectForKey:OAUTH2_REFRESH_TOKEN];
+    [additional removeObjectForKey:OAUTH2_TOKEN_TYPE];
+    [additional removeObjectForKey:ADAL_CLIENT_FAMILY_ID];
+    [additional removeObjectForKey:OAUTH2_ID_TOKEN];
+    [additional removeObjectForKey:@"expires_in"];
+    [additional removeObjectForKey:@"expires_on"];
+    
+    // Go thro
+    SAFE_ARC_RELEASE(_additionalServer);
+    _additionalServer = additional;
+    
     return isMRRT;
 }
 
@@ -285,6 +303,28 @@
          userInfo:nil
            format:@"{\n\tresource = %@\n\tclientId = %@\n\tauthority = %@\n\tuserId = %@\n}",
      _resource, _clientId, _authority, _userInformation.userId];
+}
+
+- (NSDictionary*)additionalServer
+{
+    return _additionalServer;
+}
+
+- (NSMutableDictionary*)additionalClient
+{
+    return _additionalClient;
+}
+
+- (void)setAdditionalClient:(NSMutableDictionary *)additionalClient
+{
+    if (_additionalClient == additionalClient)
+    {
+        return;
+    }
+    
+    SAFE_ARC_RELEASE(_additionalClient);
+    _additionalClient = additionalClient;
+    SAFE_ARC_RETAIN(_additionalClient);
 }
 
 

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -214,7 +214,6 @@
     [additional removeObjectForKey:@"expires_in"];
     [additional removeObjectForKey:@"expires_on"];
     
-    // Go thro
     SAFE_ARC_RELEASE(_additionalServer);
     _additionalServer = additional;
     

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -79,6 +79,8 @@
     item->_userInformation = [_userInformation copyWithZone:zone];
     item->_sessionKey = [_sessionKey copyWithZone:zone];
 	item->_tombstone = [_tombstone mutableCopyWithZone:zone];
+    item->_additionalClient = [_additionalClient mutableCopyWithZone:zone];
+    item->_additionalServer = [_additionalServer copyWithZone:zone];
     
     [item calculateHash];
     
@@ -155,6 +157,8 @@
     [aCoder encodeObject:_expiresOn forKey:@"expiresOn"];
     [aCoder encodeObject:_userInformation forKey:@"userInformation"];
 	[aCoder encodeObject:_tombstone forKey:@"tombstone"];
+    [aCoder encodeObject:_additionalClient forKey:@"additionalClient"];
+    [aCoder encodeObject:_additionalServer forKey:@"additionalServer"];
 }
 
 //Deserializer:
@@ -189,6 +193,10 @@
     SAFE_ARC_RETAIN(_userInformation);
 	_tombstone = [aDecoder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"tombstone"];
 	SAFE_ARC_RETAIN(_tombstone);
+    _additionalClient = [aDecoder decodeObjectOfClass:[NSMutableDictionary class] forKey:@"additionalClient"];
+    SAFE_ARC_RETAIN(_additionalClient);
+    _additionalServer = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
+    SAFE_ARC_RETAIN(_additionalServer);
     
     [self calculateHash];
     

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -43,6 +43,16 @@
     NSDate* _expiresOn;
     ADUserInformation* _userInformation;
 	NSMutableDictionary* _tombstone;
+    
+    // Any extra properties that have been added to ADTokenCacheItem since 2.2,
+    // coming from the server that we didn't process, but potentially want to
+    // retain to make sure we have as much information as possible,
+    NSDictionary* _additionalServer;
+    
+    // Any extra properties we generate on the client side on an item that we
+    // potentially want to make sure don't get clobbered in old versions of ADAL.
+    // NOTE: Will get clobbered by versions of ADAL prior to 2.2
+    NSMutableDictionary* _additionalClient;
 }
 
 /*! Applicable resource. Should be nil, in case the item stores multi-resource refresh token. */


### PR DESCRIPTION
Add dictionaries for additional properties coming from the server or client so that we don't have to worry about old client clobbering new properties anymore if they're sharing the same cache and everyone is on ADAL 2.2 or greater.

Also, any properties we're not currently caching coming from the server we'll store in "additionalServer" so regardless of the version of ADAL involved we will retain any information we get from the server so that it might potentially be used in later versions of ADAL.