### PR TITLE
B2C fixes: remove reserved scope values for cache lookup

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -114,7 +114,7 @@
     
     [self ensureRequest];
     
-    if (useAccessToken && [item containsScopes:[self scopesWithoutReservedValues:_scopes]])
+    if (useAccessToken && [item containsScopes:_scopesWithoutReservedValues])
     {
         //Access token is good, just use it:
         [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:nil];

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest+AcquireToken.m
@@ -114,7 +114,7 @@
     
     [self ensureRequest];
     
-    if (useAccessToken && [item containsScopes:_scopes])
+    if (useAccessToken && [item containsScopes:[self scopesWithoutReservedValues:_scopes]])
     {
         //Access token is good, just use it:
         [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:nil];

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.h
@@ -52,6 +52,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
     ADPromptBehavior _promptBehavior;
     
     NSSet* _scopes;
+    NSSet* _scopesWithoutReservedValues;
     NSSet* _additionalScopes;
     
     NSString* _policy;
@@ -93,7 +94,6 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 //- (BOOL)isClientID:(NSString*)scope;
 
 - (NSSet*)combinedScopes;
-- (NSSet*)scopesWithoutReservedValues:(NSSet*)scopes;
 
 - (ADTokenCacheStoreKey*)cacheStoreKey:(ADAuthenticationError* __autoreleasing *)error;
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.h
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.h
@@ -93,6 +93,7 @@ typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 //- (BOOL)isClientID:(NSString*)scope;
 
 - (NSSet*)combinedScopes;
+- (NSSet*)scopesWithoutReservedValues:(NSSet*)scopes;
 
 - (ADTokenCacheStoreKey*)cacheStoreKey:(ADAuthenticationError* __autoreleasing *)error;
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -279,7 +279,7 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
                                          uniqueId:uniqueId
                                            idType:_identifier.type
                                            policy:_policy
-                                           scopes:_scopes
+                                           scopes:[self scopesWithoutReservedValues:_scopes]
                                             error:error];
 }
 
@@ -311,5 +311,14 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
     return YES;
 }
 
+- (NSSet*)scopesWithoutReservedValues:(NSSet*)scopes
+{
+    NSMutableSet* newScopes = [scopes mutableCopy];
+    [newScopes removeObject:@"openid"];
+    [newScopes removeObject:@"offline_access"];
+    [newScopes removeObject:@"email"];
+    [newScopes removeObject:@"profile"];
+    return newScopes;
+}
 
 @end

--- a/ADALiOS/ADALiOS/ADAuthenticationRequest.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationRequest.m
@@ -170,6 +170,13 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
     
     _scopes = [NSSet setWithArray:lowercaseScopes];
     
+    NSMutableSet* scopesWithNoReservedValues = [_scopes mutableCopy];
+    [scopesWithNoReservedValues removeObject:@"openid"];
+    [scopesWithNoReservedValues removeObject:@"offline_access"];
+    [scopesWithNoReservedValues removeObject:@"email"];
+    [scopesWithNoReservedValues removeObject:@"profile"];
+    _scopesWithoutReservedValues = scopesWithNoReservedValues;
+    
     return nil;
 }
 
@@ -279,7 +286,7 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
                                          uniqueId:uniqueId
                                            idType:_identifier.type
                                            policy:_policy
-                                           scopes:[self scopesWithoutReservedValues:_scopes]
+                                           scopes:_scopesWithoutReservedValues
                                             error:error];
 }
 
@@ -309,16 +316,6 @@ static NSMutableArray* _arrayOfLowercaseStrings(NSArray* strings, NSString* cont
     }
     
     return YES;
-}
-
-- (NSSet*)scopesWithoutReservedValues:(NSSet*)scopes
-{
-    NSMutableSet* newScopes = [scopes mutableCopy];
-    [newScopes removeObject:@"openid"];
-    [newScopes removeObject:@"offline_access"];
-    [newScopes removeObject:@"email"];
-    [newScopes removeObject:@"profile"];
-    return newScopes;
 }
 
 @end

--- a/ADALiOS/ADALiOS/ADUserIdentifier.m
+++ b/ADALiOS/ADALiOS/ADUserIdentifier.m
@@ -111,7 +111,7 @@
     {
         case UniqueId: return info.subject;
         case OptionalDisplayableId: return nil;
-        case RequiredDisplayableId: return info.username;
+        case RequiredDisplayableId: return info.username.lowercaseString;
     }
     
     NSString* log = [NSString stringWithFormat:@"Unrecognized type on identifier match: %d", _type];

--- a/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
+++ b/ADALiOS/ADALiOSTests/ADAuthenticationContextTests.m
@@ -1054,7 +1054,7 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
                                                      dictionaryAsJSON:@{ OAUTH2_TOKEN_TYPE : @"Bearer",
                                                                          OAUTH2_REFRESH_TOKEN : newRefreshToken,
                                                                          OAUTH2_ID_TOKEN : newIdToken,
-                                                                         OAUTH2_SCOPE : @"plantetarydefense.fire planetarydefense.target openid offline_access"
+                                                                         OAUTH2_SCOPE : @"plantetarydefense.fire planetarydefense.target"
                                                                          }];
     [ADTestURLConnection addResponse:response];
     
@@ -1068,8 +1068,6 @@ static ADKeychainTokenCacheStore* s_testCacheStore = nil;
     XCTAssertEqual(_result.status, AD_SUCCEEDED);
     XCTAssertEqualObjects(_result.accessToken, newIdToken);
     XCTAssertEqualObjects(_result.tokenCacheStoreItem.refreshToken, newRefreshToken);
-    
-    
 }
 
 - (void)testUnreachableAuthority


### PR DESCRIPTION
make the following fixes:

1) during cache item lookup, the following four scope values are now removed for lookup purpose. Because server will not return such scopes and they are not stored with the cache item.

*offline_access, openid, profile, email*

2) fix a bug where displayable userId is not lowercased for comparison.