### PR TITLE
Add haschrome QP and log string for ADErrorCode enum

### DIFF
--- a/ADAL/src/ADAuthenticationError.m
+++ b/ADAL/src/ADAuthenticationError.m
@@ -64,10 +64,10 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
 {
     NSString* superDescription = [super description];
     
-    NSString* codeStr = [self getStringForADErrorCode:self.code domain:self.domain];
+    NSString* codeStr = [self getStringForErrorCode:self.code domain:self.domain];
     
-    return [NSString stringWithFormat:@"Error with code: %lu %@ Domain: %@ ProtocolCode:%@ Details:%@. Inner error details: %@",
-            (long)self.code, codeStr, self.domain, self.protocolCode, self.errorDetails, superDescription];
+    return [NSString stringWithFormat:@"Error with code: %@ Domain: %@ ProtocolCode:%@ Details:%@. Inner error details: %@",
+            codeStr, self.domain, self.protocolCode, self.errorDetails, superDescription];
 }
 
 - (id)initInternalWithDomain:(NSString *)domain
@@ -96,8 +96,8 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
     
     if (!quiet)
     {
-        NSString* codeStr = [self getStringForADErrorCode:code domain:domain];
-        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code: %lu %@ ProtocolCode: \"%@\" Details: \"%@\"", domain, (long)code, codeStr, protocolCode, details];
+        NSString* codeStr = [self getStringForErrorCode:code domain:domain];
+        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code: %@ ProtocolCode: \"%@\" Details: \"%@\"", domain, codeStr, protocolCode, details];
         NSDictionary* logDict = nil;
         if (correlationId)
         {
@@ -288,17 +288,17 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
                                 userInfo:nil];
 }
 
-- (NSString*)getStringForADErrorCode:(NSInteger)code
+- (NSString*)getStringForErrorCode:(NSInteger)code
                               domain:(NSString *)domain
 {
-    //code value is ADErrorCode enum if domain is one of following
+    //code is ADErrorCode enum if domain is one of following
     if ([domain isEqualToString:ADAuthenticationErrorDomain] ||
         [domain isEqualToString:ADBrokerResponseErrorDomain] ||
         [domain isEqualToString:ADOAuthServerErrorDomain])
     {
         return [self stringForADErrorCode:(ADErrorCode)code];
     }
-    return @"";
+    return [NSString stringWithFormat:@"%ld", (long)code];
 }
 
 #define AD_ERROR_CODE_ENUM_CASE(_enum) case _enum: return @#_enum;
@@ -338,8 +338,9 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
             AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_RESPONSE_NOT_RECEIVED);
             AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_FAILED_TO_CREATE_KEY);
             AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_DECRYPTION_FAILED);
+            default:
+                return [NSString stringWithFormat:@"%ld", (long)code];
     }
-    return @"";
 }
 
 @end

--- a/ADAL/src/ADAuthenticationError.m
+++ b/ADAL/src/ADAuthenticationError.m
@@ -64,8 +64,10 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
 {
     NSString* superDescription = [super description];
     
-    return [NSString stringWithFormat:@"Error with code: %lu Domain: %@ ProtocolCode:%@ Details:%@. Inner error details: %@",
-            (long)self.code, self.domain, self.protocolCode, self.errorDetails, superDescription];
+    NSString* codeStr = [self getStringForADErrorCode:self.code domain:self.domain];
+    
+    return [NSString stringWithFormat:@"Error with code: %lu %@ Domain: %@ ProtocolCode:%@ Details:%@. Inner error details: %@",
+            (long)self.code, codeStr, self.domain, self.protocolCode, self.errorDetails, superDescription];
 }
 
 - (id)initInternalWithDomain:(NSString *)domain
@@ -94,7 +96,8 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
     
     if (!quiet)
     {
-        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code: %lu ProtocolCode: \"%@\" Details: \"%@\"", domain, (long)code, protocolCode, details];
+        NSString* codeStr = [self getStringForADErrorCode:code domain:domain];
+        NSString* message = [NSString stringWithFormat:@"Error raised: (Domain: \"%@\" Code: %lu %@ ProtocolCode: \"%@\" Details: \"%@\"", domain, (long)code, codeStr, protocolCode, details];
         NSDictionary* logDict = nil;
         if (correlationId)
         {
@@ -285,6 +288,57 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
                                 userInfo:nil];
 }
 
+- (NSString*)getStringForADErrorCode:(NSInteger)code
+                              domain:(NSString *)domain
+{
+    if ([domain isEqualToString:ADAuthenticationErrorDomain] ||
+        [domain isEqualToString:ADBrokerResponseErrorDomain] ||
+        [domain isEqualToString:ADOAuthServerErrorDomain])
+    {
+        return [self stringForADErrorCode:(ADErrorCode)code];
+    }
+    return @"";
+}
 
+#define AD_ERROR_CODE_ENUM_CASE(_enum) case _enum: return @#_enum;
+
+- (NSString*)stringForADErrorCode:(ADErrorCode)code
+{
+    switch (code)
+    {
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SUCCEEDED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UNEXPECTED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_USER_INPUT_NEEDED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_WPJ_REQUIRED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_OAUTH);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_REFRESH_TOKEN_REJECTED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_WRONG_USER);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_NON_HTTPS_REDIRECT);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_INVALID_ID_TOKEN);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_MISSING_AUTHENTICATE_HEADER);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_UNAUTHORIZED_CODE_EXPECTED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_UNSUPPORTED_REQUEST);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_SERVER_AUTHORIZATION_CODE);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_CACHE_MULTIPLE_USERS);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_CACHE_VERSION_MISMATCH);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_CACHE_BAD_FORMAT);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_CACHE_NO_REFRESH_TOKEN);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UI_MULTLIPLE_INTERACTIVE_REQUESTS);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UI_NO_MAIN_VIEW_CONTROLLER);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UI_NOT_SUPPORTED_IN_APP_EXTENSION);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UI_USER_CANCEL);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_UI_NOT_ON_MAIN_THREAD);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_UNKNOWN);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_RESPONSE_HASH_MISMATCH);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_RESPONSE_NOT_RECEIVED);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_FAILED_TO_CREATE_KEY);
+            AD_ERROR_CODE_ENUM_CASE(AD_ERROR_TOKENBROKER_DECRYPTION_FAILED);
+    }
+    return @"";
+}
 
 @end

--- a/ADAL/src/ADAuthenticationError.m
+++ b/ADAL/src/ADAuthenticationError.m
@@ -291,6 +291,7 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
 - (NSString*)getStringForADErrorCode:(NSInteger)code
                               domain:(NSString *)domain
 {
+    //code value is ADErrorCode enum if domain is one of following
     if ([domain isEqualToString:ADAuthenticationErrorDomain] ||
         [domain isEqualToString:ADBrokerResponseErrorDomain] ||
         [domain isEqualToString:ADOAuthServerErrorDomain])

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -223,7 +223,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
                                                 @"username": [[NSDictionary adURLFormDecode:[end query]] valueForKey:@"username"],
                                                 };
                      NSError* err = [NSError errorWithDomain:ADAuthenticationErrorDomain
-                                                        code:AD_ERROR_WPJ_REQUIRED
+                                                        code:AD_ERROR_SERVER_WPJ_REQUIRED
                                                     userInfo:userInfo];
                      error = [ADAuthenticationError errorFromNSError:err errorDetails:@"work place join is required"];
                  }

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -150,6 +150,9 @@ static ADAuthenticationRequest* s_modalRequest = nil;
         //Force the server to ignore cookies, by specifying explicitly the prompt behavior:
         [startUrl appendString:[NSString stringWithFormat:@"&prompt=%@", promptParam]];
     }
+    
+    [startUrl appendString:@"&haschrome=1"]; //to hide back button in UI
+    
     if (![NSString adIsStringNilOrBlank:_queryParams])
     {//Append the additional query parameters if specified:
         queryParams = _queryParams.adTrimmedString;


### PR DESCRIPTION
(for #632 #495)

1) "haschrome=1" QP is added for all interactive requests

2) String of the ADErrorCode enum is now printed in the logs as well as the error code itself.

3) Fix a place where new ADErrorCode value should be used, i.e. update *AD_ERROR_WPJ_REQUIRED* to *AD_ERROR_SERVER_WPJ_REQUIRED*