### PR TITLE
Add app identifier prefix to keychain shared group

### DIFF
--- a/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
+++ b/ADALiOS/ADALiOS/ADKeychainTokenCacheStore.m
@@ -25,6 +25,7 @@
 #import "ADProfileInfo.h"
 #import "ADKeychainQuery.h"
 #import "ADKeychainItem.h"
+#import "ADWorkPlaceJoinUtil.h"
 
 
 /************************************************************************************************
@@ -85,7 +86,12 @@ static void adkeychain_dispatch_if_needed(dispatch_block_t block)
         return nil;
     }
     
-    _sharedGroup = sharedGroup;
+    if (!sharedGroup)
+    {
+        sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
+    }
+    
+    _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  getApplicationIdentifierPrefix], sharedGroup];
     _serviceKey = s_kDefaultADALServiceKey;
     
     return self;


### PR DESCRIPTION
Application identifier prefix is now added when we set the keychain shared group.