### PR TITLE
Fix the bug where NTLM dialog does not show up

### DIFF
--- a/ADAL/src/urlprotocol/ADNTLMHandler.m
+++ b/ADAL/src/urlprotocol/ADNTLMHandler.m
@@ -98,7 +98,7 @@ static NSURLConnection *_conn = nil;
                 _challengeCancelled = YES;
                 AD_LOG_INFO_F(@"NTLM challenge cancelled", nil, @"host: %@", challenge.protectionSpace.host);
                 [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
-                [protocol stopLoading];
+                [protocol connection:connection didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil]];
             }
         }];
     }//@synchronized

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -208,11 +208,16 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
     
     NSMutableURLRequest* mutableRequest = [request mutableCopy];
     SAFE_ARC_AUTORELEASE(mutableRequest);
+    
+    //it is a redirect if response is not nil (otherwise this method is called because of URL canonicalization)
+    if (response)
+    {
+        [[self class] removePropertyForKey:@"ADURLProtocol" inRequest:mutableRequest];
+        [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:response];
+    }
     [ADCustomHeaderHandler applyCustomHeadersTo:mutableRequest];
     [ADURLProtocol addCorrelationId:_correlationId toRequest:mutableRequest];
-    [NSURLProtocol setProperty:@YES forKey:@"ADURLProtocol" inRequest:mutableRequest];
     
-    [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:response];
     return mutableRequest;
 }
 


### PR DESCRIPTION
(for #666)
The NTLM dialog does not show up because, during redirect, the "ADURLProtocol" property in request is not properly set
Such a property is used to indicate which request will be intercepted and monitored for NTLM challenge:
if "ADURLProtocol" property is set, request will not be intercepted;
if "ADURLProtocol" property is NOT set, request will be intercepted.

Besides, fix another place that causes no-return when user click "cancel" button in NTLM dialog.