### PR TITLE
Remove !TARGET_IPHONE_SIMULATOR ifdefs and keychain team ID change

### DIFF
--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -126,9 +126,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     _default = @{
                  (id)kSecClass : (id)kSecClassGenericPassword,
                  //Apps are not signed on the simulator, so the shared group doesn't apply there.
-#if !(TARGET_IPHONE_SIMULATOR)
                  (id)kSecAttrAccessGroup : (id)_sharedGroup,
-#endif
                  (id)kSecAttrGeneric : [s_libraryString dataUsingEncoding:NSUTF8StringEncoding]
                  };
     SAFE_ARC_RETAIN(_default);
@@ -137,9 +135,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     _defaultTombstone = @{
                  (id)kSecClass : (id)kSecClassGenericPassword,
                  //Apps are not signed on the simulator, so the shared group doesn't apply there.
-#if !(TARGET_IPHONE_SIMULATOR)
                  (id)kSecAttrAccessGroup : (id)_sharedGroup,
-#endif
                  (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding]
                  };
     SAFE_ARC_RETAIN(_defaultTombstone);

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -121,25 +121,37 @@ static ADKeychainTokenCache* s_defaultCache = nil;
         sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
     }
     
-    _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  keychainTeamId], sharedGroup];
+    NSString* teamId = [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager] keychainTeamId];
+    if (teamId)
+    {
+        _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", teamId, sharedGroup];
+    }
     
-    _default = @{
-                 (id)kSecClass : (id)kSecClassGenericPassword,
-                 //Apps are not signed on the simulator, so the shared group doesn't apply there.
-                 (id)kSecAttrAccessGroup : (id)_sharedGroup,
-                 (id)kSecAttrGeneric : [s_libraryString dataUsingEncoding:NSUTF8StringEncoding]
-                 };
-    SAFE_ARC_RETAIN(_default);
+    NSMutableDictionary* defaultQuery =
+    [@{
+       (id)kSecClass : (id)kSecClassGenericPassword,
+       (id)kSecAttrGeneric : [s_libraryString dataUsingEncoding:NSUTF8StringEncoding]
+       } mutableCopy];
     
     // Use a different generic attribute so that past versions of ADAL don't trip up on this entry
-    _defaultTombstone = @{
-                 (id)kSecClass : (id)kSecClassGenericPassword,
-                 //Apps are not signed on the simulator, so the shared group doesn't apply there.
-                 (id)kSecAttrAccessGroup : (id)_sharedGroup,
-                 (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding]
-                 };
-    SAFE_ARC_RETAIN(_defaultTombstone);
+    NSMutableDictionary* defaultTombstoneQuery =
+    [@{
+       (id)kSecClass : (id)kSecClassGenericPassword,
+       (id)kSecAttrGeneric : [s_tombstoneLibraryString dataUsingEncoding:NSUTF8StringEncoding]
+       } mutableCopy];
 
+    // Depending on the environment we may or may not have keychain access groups. Which environments
+    // have keychain access group support also varies over time. They should always work on device,
+    // in Simulator they work when running within an app bundle but not in unit tests, as of Xcode 7.3
+    
+    if (_sharedGroup)
+    {
+        [defaultQuery setObject:_sharedGroup forKey:(id)kSecAttrAccessGroup];
+        [defaultTombstoneQuery setObject:_sharedGroup forKey:(id)kSecAttrAccessGroup];
+    }
+    
+    _default = defaultQuery;
+    _defaultTombstone = defaultTombstoneQuery;
     
     static dispatch_once_t onceToken = 0;
     dispatch_once(&onceToken, ^{

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -121,7 +121,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
         sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
     }
     
-    _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  getApplicationIdentifierPrefix], sharedGroup];
+    _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  keychainTeamId], sharedGroup];
     
     _default = @{
                  (id)kSecClass : (id)kSecClassGenericPassword,

--- a/ADAL/src/workplacejoin/ios/ADWorkPlaceJoin.m
+++ b/ADAL/src/workplacejoin/ios/ADWorkPlaceJoin.m
@@ -49,7 +49,7 @@ static ADWorkPlaceJoin* wpjManager;
     self = [super init];
     if (self) {
         [ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager].workplaceJoin = self;
-        _sharedGroup = [NSString stringWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  getApplicationIdentifierPrefix], _defaultSharedGroup];
+        _sharedGroup = [NSString stringWithFormat:@"%@.%@", [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  keychainTeamId], _defaultSharedGroup];
     }
     return self;
 }

--- a/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.h
+++ b/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.h
@@ -46,6 +46,6 @@
                    underlyingError:(NSError*) underlyingError
                        shouldRetry:(BOOL) retry;
 
-- (NSString*)getApplicationIdentifierPrefix;
+- (NSString*)keychainTeamId;
 
 @end

--- a/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
+++ b/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
@@ -307,28 +307,20 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     return theData;
 }
 
-- (NSString*)getApplicationIdentifierPrefix{
+- (NSString*)keychainTeamId
+{
+    static dispatch_once_t s_once;
+    static NSString* s_keychainTeamId = nil;
     
-    AD_LOG_VERBOSE(@"Looking for application identifier prefix in app data", nil, nil);
-    //NSUserDefaults* c = [NSUserDefaults standardUserDefaults];
-    //NSString* appIdentifierPrefix = [c objectForKey:applicationIdentifierPrefix];
+    dispatch_once(&s_once, ^{
+        s_keychainTeamId = [self retrieveTeamIDFromKeychain];
+        AD_LOG_INFO(([NSString stringWithFormat:@"Using \"%@\" Team ID for Keychain.", s_keychainTeamId]), nil, nil);
+    });
     
-    NSString* appIdentifierPrefix = nil;
-    
-    if (!appIdentifierPrefix)
-    {
-        appIdentifierPrefix = [self bundleSeedID];
-        
-        AD_LOG_VERBOSE(@"Storing application identifier prefix in app data", nil, nil);
-        NSUserDefaults* c = [NSUserDefaults standardUserDefaults];
-        [c setObject:appIdentifierPrefix forKey:applicationIdentifierPrefix];
-        [c synchronize];
-    }
-    
-    return appIdentifierPrefix;
+    return s_keychainTeamId;
 }
 
-- (NSString*)bundleSeedID {
+- (NSString*)retrieveTeamIDFromKeychain {
     NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
                            (__bridge id)(kSecClassGenericPassword), kSecClass,
                            @"bundleSeedID", kSecAttrAccount,

--- a/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
+++ b/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
@@ -105,7 +105,6 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnRef)];
     [identityAttr setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
     [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnAttributes)];
-    
     [identityAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     
     CFDictionaryRef  result;
@@ -182,7 +181,6 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     [identityAttr setObject:(__bridge id)kSecClassIdentity forKey:(__bridge id)kSecClass];
     [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnRef)];
     [identityAttr setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
-    
     [identityAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
     
     SecItemCopyMatching((__bridge CFDictionaryRef)identityAttr, (CFTypeRef*)identity);
@@ -320,7 +318,8 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     return s_keychainTeamId;
 }
 
-- (NSString*)retrieveTeamIDFromKeychain {
+- (NSString*)retrieveTeamIDFromKeychain
+{
     NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
                            (__bridge id)(kSecClassGenericPassword), kSecClass,
                            @"bundleSeedID", kSecAttrAccount,
@@ -328,18 +327,26 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
                            (id)kCFBooleanTrue, kSecReturnAttributes,
                            nil];
     CFDictionaryRef result = nil;
+    
     OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    
     if (status == errSecItemNotFound)
+    {
         status = SecItemAdd((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    }
+    
     if (status != errSecSuccess)
+    {
         return nil;
+    }
+    
     NSString *accessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge id)(kSecAttrAccessGroup)];
     NSArray *components = [accessGroup componentsSeparatedByString:@"."];
-    NSString *bundleSeedID = [[components objectEnumerator] nextObject];
-    SecItemDelete((__bridge CFDictionaryRef)(query));
+    NSString *bundleSeedID = [components firstObject];
     
     CFRelease(result);
-    return bundleSeedID;
+    
+    return [bundleSeedID length] ? bundleSeedID : nil;
 }
 
 @end

--- a/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
+++ b/ADAL/src/workplacejoin/ios/ADWorkPlaceJoinUtil.m
@@ -59,9 +59,7 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     [privateKeyAttr setObject:(__bridge id)kSecClassKey forKey:(__bridge id)kSecClass];
     [privateKeyAttr setObject:(__bridge id)(kSecAttrKeyTypeRSA) forKey:(__bridge id<NSCopying>)(kSecAttrKeyType)];
     [privateKeyAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnData)];
-#if !TARGET_IPHONE_SIMULATOR
     [privateKeyAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
-#endif
     
     status = SecItemCopyMatching((__bridge CFDictionaryRef)privateKeyAttr, (CFTypeRef*)&item);
     SAFE_ARC_RELEASE(privateKeyAttr);
@@ -108,9 +106,7 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     [identityAttr setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
     [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnAttributes)];
     
-#if !TARGET_IPHONE_SIMULATOR
     [identityAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
-#endif
     
     CFDictionaryRef  result;
     OSStatus status = noErr;
@@ -187,10 +183,7 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
     [identityAttr setObject:(__bridge id)kCFBooleanTrue forKey:(__bridge id<NSCopying>)(kSecReturnRef)];
     [identityAttr setObject:(__bridge id) kSecAttrKeyClassPrivate forKey:(__bridge id)kSecAttrKeyClass];
     
-    
-#if !TARGET_IPHONE_SIMULATOR
     [identityAttr setObject:sharedAccessGroup forKey:(__bridge id)kSecAttrAccessGroup];
-#endif
     
     SecItemCopyMatching((__bridge CFDictionaryRef)identityAttr, (CFTypeRef*)identity);
     
@@ -317,8 +310,10 @@ ADWorkPlaceJoinUtil* wpjUtilManager = nil;
 - (NSString*)getApplicationIdentifierPrefix{
     
     AD_LOG_VERBOSE(@"Looking for application identifier prefix in app data", nil, nil);
-    NSUserDefaults* c = [NSUserDefaults standardUserDefaults];
-    NSString* appIdentifierPrefix = [c objectForKey:applicationIdentifierPrefix];
+    //NSUserDefaults* c = [NSUserDefaults standardUserDefaults];
+    //NSString* appIdentifierPrefix = [c objectForKey:applicationIdentifierPrefix];
+    
+    NSString* appIdentifierPrefix = nil;
     
     if (!appIdentifierPrefix)
     {

--- a/ADAL/tests/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/ios/ADKeychainTokenCacheTests.m
@@ -115,7 +115,9 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     XCTAssertTrue([self count] == 0, "Start empty.");
     
     ADTokenCacheItem* item = [self adCreateCacheItem:@"eric_cartman@contoso.com"];
-    [mStore addOrUpdateItem:item correlationId:nil error:nil];
+    ADAuthenticationError* error = nil;
+    XCTAssertTrue([mStore addOrUpdateItem:item correlationId:nil error:&error]);
+    XCTAssertNil(error, @"Error occurred on add: %@", error);
     
     NSArray* allItems = [mStore allItems:nil];
     
@@ -179,7 +181,6 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     [self adSetLogTolerance:ADAL_LOG_LEVEL_ERROR];
     ADKeychainTokenCache* simple = [ADKeychainTokenCache new];
     XCTAssertNotNil(simple);
-    XCTAssertNotNil(simple.sharedGroup);
     NSString* group = @"test";
     ADKeychainTokenCache* withGroup = [[ADKeychainTokenCache alloc] initWithGroup:group];
     XCTAssertNotNil(withGroup);

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
@@ -60,10 +60,13 @@
     return self;
 }
 
-- (void)viewDidLoad {
+- (void)viewDidLoad
+{
     [super viewDidLoad];
     
-    [_keychainId setText:[[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  keychainTeamId]];
+    NSString* teamId = [[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager] keychainTeamId];
+    
+    [_keychainId setText: teamId ? teamId : @"<No Team ID>" ];
     
     [self refreshProfileSettings];
 }

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
@@ -63,7 +63,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    [_keychainId setText:[[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  getApplicationIdentifierPrefix]];
+    [_keychainId setText:[[ADWorkPlaceJoinUtil WorkPlaceJoinUtilManager]  keychainTeamId]];
     
     [self refreshProfileSettings];
 }


### PR DESCRIPTION
- I confirmed with an Apple Engineer at WWDC that Keychain Access Groups are intended to work in the iOS Simulator now in Xcode 7+
- The NSUserDefaults cache of the keychain ID could cause issues in older simulators, best to remove that and cache it on a per-app-launch basis instead. This also could have caused issues when apps were migrated between publishers.