### PR TITLE
Remove resiliency from the public API

### DIFF
--- a/ADAL/src/ADAuthenticationContext+Internal.h
+++ b/ADAL/src/ADAuthenticationContext+Internal.h
@@ -81,6 +81,10 @@ extern NSString* const ADRedirectUriInvalidError;
 
 - (BOOL)hasCacheStore;
 
+// ADAL_RESILIENCY_NOT_YET: Move back to public header
+/*! Enable to return access token with extended lifetime during server outage. */
+@property BOOL extendedLifetimeEnabled;
+
 @end
 
 @interface ADAuthenticationContext (CacheStorage)

--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -34,6 +34,18 @@ NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is conf
 
 @implementation ADAuthenticationContext (Internal)
 
+// ADAL_RESILIENCY_NOT_YET: Remove when feature goes into public API
+- (BOOL)extendedLifetimeEnabled
+{
+    return _extendedLifetimeEnabled;
+}
+
+// ADAL_RESILIENCY_NOT_YET: Remove when feature goes into public API
+- (void)setExtendedLifetimeEnabled:(BOOL)extendedLifetimeEnabled
+{
+    _extendedLifetimeEnabled = extendedLifetimeEnabled;
+}
+
 /*! Verifies that the string parameter is not nil or empty. If it is,
  the method generates an error and set it to an authentication result.
  Then the method calls the callback with the result.

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -43,7 +43,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 @synthesize validateAuthority = _validateAuthority;
 @synthesize correlationId = _correlationId;
 @synthesize credentialsType = _credentialsType;
-@synthesize extendedLifetimeEnabled = _extendedLifetimeEnabled;
+//@synthesize extendedLifetimeEnabled = _extendedLifetimeEnabled; ADAL_RESILIENCY_NOT_YET
 @synthesize logComponent = _logComponent;
 @synthesize webView = _webView;
 

--- a/ADAL/src/ADAuthenticationResult+Internal.h
+++ b/ADAL/src/ADAuthenticationResult+Internal.h
@@ -52,4 +52,9 @@
 /*! Internal method to set the extendedLifetimeToken flag. */
 - (void)setExtendedLifeTimeToken:(BOOL)extendedLifeTimeToken;
 
+// ADAL_RESILIENCY_NOT_YET: Move back to public header
+/*! Some access tokens have extended lifetime when server is in an unavailable state.
+ This property indicates whether the access token is returned in such a state. */
+@property (readonly) BOOL extendedLifeTimeToken;
+
 @end

--- a/ADAL/src/ADAuthenticationResult+Internal.m
+++ b/ADAL/src/ADAuthenticationResult+Internal.m
@@ -30,6 +30,12 @@
 
 @implementation ADAuthenticationResult (Internal)
 
+// ADAL_RESILIENCY_NOT_YET: Remove when we add feature to public API
+- (BOOL)extendedLifeTimeToken
+{
+    return _extendedLifeTimeToken;
+}
+
 - (id)initWithCancellation:(NSUUID*)correlationId
 {
     ADAuthenticationError* error = [ADAuthenticationError errorFromCancellation:correlationId];

--- a/ADAL/src/ADAuthenticationResult.m
+++ b/ADAL/src/ADAuthenticationResult.m
@@ -34,7 +34,7 @@
 @synthesize error = _error;
 @synthesize multiResourceRefreshToken = _multiResourceRefreshToken;
 @synthesize correlationId = _correlationId;
-@synthesize extendedLifeTimeToken = _extendedLifeTimeToken;
+//@synthesize extendedLifeTimeToken = _extendedLifeTimeToken; ADAL_RESILIENCY_NOT_YET
 
 - (id)init
 {

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -256,9 +256,6 @@ typedef enum
     definition for details */
 @property ADCredentialsType credentialsType;
 
-/*! Enable to return access token with extended lifttime during server outage. */
-@property BOOL extendedLifetimeEnabled;
-
 /*! The name of the component using this authentication context. Used in some logging and telemetry
     for clarification purposes. */
 @property (retain) NSString* logComponent;

--- a/ADAL/src/public/ADAuthenticationResult.h
+++ b/ADAL/src/public/ADAuthenticationResult.h
@@ -62,10 +62,6 @@ typedef enum
  case of error.*/
 @property (readonly) NSString* accessToken;
 
-/*! Some access tokens have extended lifetime when server is in an unavailable state.
- This property indicates whether the access token is returned in such a state. */
-@property (readonly) BOOL extendedLifeTimeToken;
-
 @property (readonly) ADTokenCacheItem* tokenCacheItem;
 
 /*! The error that occurred or nil, if the operation was successful */


### PR DESCRIPTION
Move the properties to turn on resiliency into the private API, this way it doesn't block us releasing.