### PR TITLE
Split off the response processing logic from ADWebAuthRequest

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -231,6 +231,9 @@
 		97A522491A1A752D001D77CE /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
 		97A522501A1A8999001D77CE /* ADClientMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */; };
 		D68040301D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */; };
+		D68040331D22F686007A61AC /* ADWebAuthResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D68040311D22F686007A61AC /* ADWebAuthResponse.h */; };
+		D68040341D22F686007A61AC /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
+		D68040351D22F686007A61AC /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
 		D6E43A6A1B04026D000F5BE2 /* ADAuthenticationContext+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */; };
 		D6F095151CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */; };
 		D6F095161CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */; };
@@ -470,6 +473,8 @@
 		97A522511A1A89C4001D77CE /* ADClientMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADClientMetrics.h; sourceTree = "<group>"; };
 		97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoinUtil.m; sourceTree = "<group>"; };
+		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
+		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
 		D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+Internal.h"; sourceTree = "<group>"; };
 		D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADAuthenticationContext+Internal.m"; sourceTree = "<group>"; };
 		D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADAcquireTokenSilentHandler.h; sourceTree = "<group>"; };
@@ -819,6 +824,8 @@
 				9453C38B1C5820E3006B9E79 /* ADWebRequest.m */,
 				D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */,
 				D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */,
+				D68040311D22F686007A61AC /* ADWebAuthResponse.h */,
+				D68040321D22F686007A61AC /* ADWebAuthResponse.m */,
 				9453C38C1C5820E3006B9E79 /* ADWebResponse.h */,
 				9453C38D1C5820E3006B9E79 /* ADWebResponse.m */,
 			);
@@ -985,6 +992,7 @@
 				9453C4121C586456006B9E79 /* ADInstanceDiscovery.h in Headers */,
 				9453C43A1C586476006B9E79 /* ADURLProtocol.h in Headers */,
 				9453C4221C586462006B9E79 /* ADTokenCacheAccessor.h in Headers */,
+				D68040331D22F686007A61AC /* ADWebAuthResponse.h in Headers */,
 				9453C44A1C586485006B9E79 /* ADRegistrationInformation.h in Headers */,
 				9453C4261C586462006B9E79 /* ADTokenCacheKey.h in Headers */,
 				94DD18D21C5AC8DE00F80C62 /* ADAuthenticationParameters.h in Headers */,
@@ -1204,6 +1212,7 @@
 				9453C3451C57FC2A006B9E79 /* ADTokenCacheKey.m in Sources */,
 				9453C3701C580157006B9E79 /* NSString+ADHelperMethods.m in Sources */,
 				9453C39E1C5826F2006B9E79 /* ADURLProtocol.m in Sources */,
+				D68040341D22F686007A61AC /* ADWebAuthResponse.m in Sources */,
 				9453C35D1C580143006B9E79 /* ADWorkPlaceJoinUtil.m in Sources */,
 				9453C46D1C5872AD006B9E79 /* ADJwtHelper.m in Sources */,
 				9453C39D1C5826F2006B9E79 /* ADNTLMHandler.m in Sources */,
@@ -1293,6 +1302,7 @@
 				94DD18CA1C5A00BC00F80C62 /* ADAuthenticationViewController.m in Sources */,
 				946818A71C59B7F200CA0378 /* ADWebAuthController.m in Sources */,
 				9453C4071C586456006B9E79 /* ADAuthenticationContext.m in Sources */,
+				D68040351D22F686007A61AC /* ADWebAuthResponse.m in Sources */,
 				9453C4291C58646D006B9E79 /* ADAuthenticationRequest.m in Sources */,
 				9453C41D1C586456006B9E79 /* ADUserIdentifier.m in Sources */,
 				9453C4251C586462006B9E79 /* ADTokenCacheItem+Internal.m in Sources */,

--- a/ADAL/src/request/ADWebAuthRequest.h
+++ b/ADAL/src/request/ADWebAuthRequest.h
@@ -38,6 +38,9 @@
 }
 
 @property BOOL returnRawResponse;
+@property BOOL retryIfServerError;
+@property BOOL handledPkeyAuthChallenge;
+@property (readonly) NSDate* startTime;
 
 - (void)setRequestDictionary:(NSDictionary<NSString*, NSString*> *)requestDictionary;
 - (void)sendRequest:(void(^)(NSDictionary *))completionBlock;

--- a/ADAL/src/request/ADWebAuthRequest.m
+++ b/ADAL/src/request/ADWebAuthRequest.m
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import "ADWebAuthRequest.h"
+#import "ADWebAuthResponse.h"
 #import "ADWorkplaceJoinConstants.h"
 #import "ADClientMetrics.h"
 #import "NSDictionary+ADExtensions.h"
@@ -32,6 +33,9 @@
 @implementation ADWebAuthRequest
 
 @synthesize returnRawResponse = _returnRawResponse;
+@synthesize retryIfServerError = _retryIfServerError;
+@synthesize startTime = _startTime;
+@synthesize handledPkeyAuthChallenge = _handledPkeyAuthChallenge;
 
 - (id)initWithURL:(NSURL *)url
     correlationId:(NSUUID *)correlationId
@@ -77,249 +81,20 @@
     _startTime = [NSDate new];
     [[ADClientMetrics getInstance] addClientMetrics:self.headers endpoint:[_requestURL absoluteString]];
     
+    CFRetain((CFTypeRef)self);
+    
     [self send:^( NSError *error, ADWebResponse *webResponse )
     {
-        _responseDictionary = [NSMutableDictionary new];
         if (error)
         {
-            [self handleNSError:error
-                completionBlock:completionBlock];
+            [ADWebAuthResponse processError:error correlationId:_correlationId completion:completionBlock];
         }
         else
         {
-            [self handleResponse:webResponse completionBlock:completionBlock];
+            [ADWebAuthResponse processResponse:webResponse request:self completion:completionBlock];
         }
-        
-        SAFE_ARC_RELEASE(_responseDictionary);
-        _responseDictionary = nil;
     }];
 }
 
-- (void)checkCorrelationId:(ADWebResponse*)webResponse
-{
-    NSDictionary* headers = webResponse.headers;
-    //In most cases the correlation id is returned as a separate header
-    NSString* responseCorrelationId = [headers objectForKey:OAUTH2_CORRELATION_ID_REQUEST_VALUE];
-    if (![NSString adIsStringNilOrBlank:responseCorrelationId])
-    {
-        [_responseDictionary setObject:responseCorrelationId forKey:OAUTH2_CORRELATION_ID_RESPONSE];//Add it to the dictionary to be logged and checked later.
-    }
-}
-
-- (void)handleResponse:(ADWebResponse *)webResponse
-       completionBlock:(void (^)(NSDictionary *))completionBlock
-{
-    [self checkCorrelationId:webResponse];
-    [_responseDictionary setObject:webResponse.URL forKey:@"url"];
-    
-    switch (webResponse.statusCode)
-    {
-        case 200:
-            if(_returnRawResponse)
-            {
-                NSString* rawResponse = [[NSString alloc] initWithData:webResponse.body encoding:NSASCIIStringEncoding];
-                [_responseDictionary setObject:rawResponse
-                                        forKey:@"raw_response"];
-                SAFE_ARC_RELEASE(rawResponse);
-                break;
-            }
-        case 400:
-        case 401:
-        {
-            if(!_handledPkeyAuthChallenge)
-            {
-                NSString* wwwAuthValue = [webResponse.headers valueForKey:wwwAuthenticateHeader];
-                if(![NSString adIsStringNilOrBlank:wwwAuthValue] && [wwwAuthValue adContainsString:pKeyAuthName])
-                {
-                    [self handlePKeyAuthChallenge:wwwAuthValue
-                                       completion:completionBlock];
-                    return;
-                }
-            }
-            
-            [self handleJSONResponse:webResponse completionBlock:completionBlock];
-            break;
-        }
-        case 500:
-        case 503:
-        case 504:
-        {
-            //retry if it is a server error
-            //500, 503 and 504 are the ones we retry
-            if (_retryIfServerError)
-            {
-                _retryIfServerError = NO;
-                //retry once after half second
-                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
-                    [self sendRequest:completionBlock];
-                });
-                return;
-            }
-            //no "break;" here
-            //will go to default for handling if "retryIfServerError" is NO
-        }
-        default:
-        {
-            // Request failure
-            NSString* body = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
-            NSString* errorData = [NSString stringWithFormat:@"Full response: %@", body];
-            AD_LOG_WARN(([NSString stringWithFormat:@"HTTP Error %ld", (long)webResponse.statusCode]), _correlationId, errorData);
-            
-            ADAuthenticationError* adError = [ADAuthenticationError HTTPErrorCode:webResponse.statusCode
-                                                                             body:[NSString stringWithFormat:@"(%lu bytes)", (unsigned long)webResponse.body.length]
-                                                                    correlationId:_correlationId];
-            SAFE_ARC_RELEASE(body);
-            
-            //Now add the information to the dictionary, so that the parser can extract it:
-            [self handleADError:adError completionBlock:completionBlock];
-        }
-    }
-}
-
-- (void)handleJSONResponse:(ADWebResponse*)webResponse
-           completionBlock:(void (^)(NSDictionary *))completionBlock
-{
-    NSError   *jsonError  = nil;
-    id         jsonObject = [NSJSONSerialization JSONObjectWithData:webResponse.body options:0 error:&jsonError];
-    
-    if (!jsonObject)
-    {
-        [self handleJSONError:jsonError body:webResponse.body completionBlock:completionBlock];
-        return;
-    }
-    
-    if (![jsonObject isKindOfClass:[NSDictionary class]])
-    {
-        ADAuthenticationError* adError =
-        [ADAuthenticationError unexpectedInternalError:[NSString stringWithFormat:@"Unexpected object type: %@", [jsonObject class]]
-                                         correlationId:_correlationId];
-        [self handleADError:adError completionBlock:completionBlock];
-        return;
-    }
-    
-    // Load the response
-    [_responseDictionary addEntriesFromDictionary:(NSDictionary*)jsonObject];
-    [self handleSuccess:completionBlock];
-    return;
-}
-
-- (void)handlePKeyAuthChallenge:(NSString *)wwwAuthHeaderValue
-                     completion:(void (^)(NSDictionary *))completionBlock
-{
-    //pkeyauth word length=8 + 1 whitespace
-    wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
-    
-    NSDictionary* authHeaderParams = [wwwAuthHeaderValue authHeaderParams];
-    
-    if (!authHeaderParams)
-    {
-        AD_LOG_ERROR_F(@"Unparseable wwwAuthHeader received.", AD_ERROR_SERVER_WPJ_REQUIRED, _correlationId, @"%@", wwwAuthHeaderValue);
-    }
-    
-    ADAuthenticationError* adError = nil;
-    NSString* authHeader = [ADPkeyAuthHelper createDeviceAuthResponse:[_requestURL absoluteString]
-                                                        challengeData:authHeaderParams
-                                                        correlationId:_correlationId
-                                                                error:&adError];
-    
-    if (!authHeader)
-    {
-        [self handleADError:adError completionBlock:completionBlock];
-        return;
-    }
-    
-    // Add Authorization response header to the headers of the request
-    [self.headers setObject:authHeader forKey:@"Authorization"];
-    
-    [self sendRequest:completionBlock];
-}
-
-- (void)handleSuccess:(void (^)(NSDictionary *))completionBlock
-{
-    [[ADClientMetrics getInstance] endClientMetricsRecord:[_requestURL absoluteString]
-                                                startTime:_startTime
-                                            correlationId:_correlationId
-                                             errorDetails:nil];
-    SAFE_ARC_RELEASE(_startTime);
-    _startTime = nil;
-    
-    completionBlock(_responseDictionary);
-}
-
-#pragma mark -
-#pragma mark Error Handlers
-
-- (void)handleJSONError:(NSError*)jsonError
-                   body:(NSData*)body
-        completionBlock:(void (^)(NSDictionary *))completionBlock
-{
-    
-    // Unrecognized JSON response
-    // We're often seeing the JSON parser being asked to parse whole HTML pages.
-    // Logging out the whole thing is unhelpful as it contains no useful info.
-    // If the body is > 1 KB then it's a pretty safe bet that it contains more
-    // noise then would be helpful
-    NSString* bodyStr = nil;
-    
-    if (body.length == 0)
-    {
-        AD_LOG_ERROR(@"Empty body received, expected JSON response.", jsonError.code, _correlationId, nil);
-    }
-    else
-    {
-        if ([body length] < 1024)
-        {
-            bodyStr = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
-        }
-        else
-        {
-            bodyStr = [[NSString alloc] initWithFormat:@"large response, probably HTML, <%lu bytes>", (unsigned long)[body length]];
-        }
-        
-        NSString* errorMsg = [NSString stringWithFormat:@"JSON deserialization error: %@", jsonError.description];
-        
-        AD_LOG_ERROR_F(errorMsg, jsonError.code, _correlationId, @"%@", bodyStr);
-        SAFE_ARC_RELEASE(bodyStr);
-    }
-    
-    [self handleNSError:jsonError completionBlock:completionBlock];
-}
-
-- (void)handleNSError:(NSError*)error completionBlock:(void (^)(NSDictionary*))completionBlock
-{
-    if ([[error domain] isEqualToString:@"NSURLErrorDomain"] && [error code] == -1002)
-    {
-        // Unsupported URL Error
-        // This can happen because the redirect URI isn't a valid URI, or we've tried to jump out of the app with a URL scheme handler
-        // It's worth peeking into this error to see if we have useful information anyways.
-        
-        NSString* url = [[error userInfo] objectForKey:@"NSErrorFailingURLKey"];
-        [_responseDictionary setObject:url forKey:@"url"];
-    }
-    
-    AD_LOG_WARN(@"System error while making request.", _correlationId, error.description);
-    // System error
-    ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error
-                                                                errorDetails:error.localizedDescription
-                                                               correlationId:_correlationId];
-    
-    [self handleADError:adError completionBlock:completionBlock];
-}
-
-- (void)handleADError:(ADAuthenticationError*)adError completionBlock:(void (^)(NSDictionary*))completionBlock
-{
-    [_responseDictionary setObject:adError
-                            forKey:AUTH_NON_PROTOCOL_ERROR];
-    
-    [[ADClientMetrics getInstance] endClientMetricsRecord:[_requestURL absoluteString]
-                                                startTime:_startTime
-                                            correlationId:_correlationId
-                                             errorDetails:[adError errorDetails]];
-    
-    SAFE_ARC_RELEASE(_startTime);
-    _startTime = nil;
-    
-    completionBlock(_responseDictionary);
-}
 
 @end

--- a/ADAL/src/request/ADWebAuthResponse.h
+++ b/ADAL/src/request/ADWebAuthResponse.h
@@ -21,49 +21,25 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@class ADWebRequest;
-@class ADWebResponse;
+#import <Foundation/Foundation.h>
 
-@interface ADWebRequest : NSObject <NSURLConnectionDelegate>
+@class ADWebResponse;
+@class ADWebAuthRequest;
+
+@interface ADWebAuthResponse : NSObject
 {
-    NSURLConnection * _connection;
-    
-    NSURL * _requestURL;
-    NSMutableDictionary* _requestHeaders;
-    NSData * _requestData;
-    
-    NSHTTPURLResponse * _response;
-    NSMutableData * _responseData;
-    
-    NSUUID * _correlationId;
-    
-    NSUInteger _timeout;
-    
-    NSOperationQueue * _operationQueue;
-    
-    BOOL _isGetRequest;
-    
-    void (^_completionHandler)( NSError *, ADWebResponse *);
+    NSMutableDictionary* _responseDictionary;
+    ADWebAuthRequest* _request;
+    ADWebAuthRequest* _retryRequest;
+    NSUUID* _correlationId;
 }
 
-@property (strong, readonly, nonatomic) NSURL               *URL;
-@property (copy, nonatomic)             NSMutableDictionary *headers;
-@property (strong)                      NSData              *body;
-@property (nonatomic)                   NSUInteger           timeout;
-@property BOOL isGetRequest;
-@property (readonly) NSUUID* correlationId;
++ (void)processError:(NSError *)error
+       correlationId:(NSUUID *)correlationId
+          completion:(void (^)(NSDictionary *))completionBlock;
 
-- (id)initWithURL: (NSURL*)url
-    correlationId: (NSUUID*) correlationId;
-
-- (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
-
-/*!
-    Resends a request. Note, this will cause the completionHandler previously set
-    in -send: to be hit again. As such this method should only be called from
-    within the completionHandler block on -send:
- */
-- (void)resend;
++ (void)processResponse:(ADWebResponse *)webResponse
+                request:(ADWebAuthRequest *)request
+             completion:(void (^)(NSDictionary *))completionBlock;
 
 @end
-

--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -1,0 +1,304 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import "ADWebAuthResponse.h"
+#import "ADWebResponse.h"
+#import "ADWebAuthRequest.h"
+#import "ADOauth2Constants.h"
+#import "ADWorkplaceJoinConstants.h"
+#import "ADPKeyAuthHelper.h"
+#import "ADClientMetrics.h"
+
+@implementation ADWebAuthResponse
+
++ (void)processError:(NSError *)error
+       correlationId:(NSUUID *)correlationId
+          completion:(void (^)(NSDictionary *))completionBlock
+{
+    ADWebAuthResponse* response = [ADWebAuthResponse new];
+    response->_correlationId = correlationId;
+    SAFE_ARC_RETAIN(correlationId);
+    
+    [response handleNSError:error completionBlock:completionBlock];
+}
+
+
++ (void)processResponse:(ADWebResponse *)webResponse
+                request:(ADWebAuthRequest *)request
+             completion:(void (^)(NSDictionary *))completionBlock
+{
+    ADWebAuthResponse* response = [ADWebAuthResponse new];
+    response->_request = request;
+    SAFE_ARC_RETAIN(request);
+    
+    NSUUID* correlationId = request.correlationId;
+    SAFE_ARC_RETAIN(correlationId);
+    response->_correlationId = correlationId;
+    
+    [response handleResponse:webResponse completionBlock:completionBlock];
+}
+
+- (id)init
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    _responseDictionary = [NSMutableDictionary new];
+    
+    return self;
+}
+
+
+- (void)dealloc
+{
+    SAFE_ARC_RELEASE(_responseDictionary);
+    SAFE_ARC_RELEASE(_request);
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+- (void)checkCorrelationId:(ADWebResponse*)webResponse
+{
+    NSDictionary* headers = webResponse.headers;
+    //In most cases the correlation id is returned as a separate header
+    NSString* responseCorrelationId = [headers objectForKey:OAUTH2_CORRELATION_ID_REQUEST_VALUE];
+    if (![NSString adIsStringNilOrBlank:responseCorrelationId])
+    {
+        [_responseDictionary setObject:responseCorrelationId forKey:OAUTH2_CORRELATION_ID_RESPONSE];//Add it to the dictionary to be logged and checked later.
+    }
+}
+
+- (void)handleResponse:(ADWebResponse *)webResponse
+       completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    [self checkCorrelationId:webResponse];
+    [_responseDictionary setObject:webResponse.URL forKey:@"url"];
+    
+    switch (webResponse.statusCode)
+    {
+        case 200:
+            if(_request.returnRawResponse)
+            {
+                NSString* rawResponse = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
+                [_responseDictionary setObject:rawResponse
+                                        forKey:@"raw_response"];
+                SAFE_ARC_RELEASE(rawResponse);
+                break;
+            }
+        case 400:
+        case 401:
+        {
+            if(!_request.handledPkeyAuthChallenge)
+            {
+                NSString* wwwAuthValue = [webResponse.headers valueForKey:wwwAuthenticateHeader];
+                if(![NSString adIsStringNilOrBlank:wwwAuthValue] && [wwwAuthValue adContainsString:pKeyAuthName])
+                {
+                    [self handlePKeyAuthChallenge:wwwAuthValue
+                                       completion:completionBlock];
+                    return;
+                }
+            }
+            
+            [self handleJSONResponse:webResponse completionBlock:completionBlock];
+            break;
+        }
+        case 500:
+        case 503:
+        case 504:
+        {
+            //retry if it is a server error
+            //500, 503 and 504 are the ones we retry
+            if (_request.retryIfServerError)
+            {
+                _request.retryIfServerError = NO;
+                //retry once after half second
+                dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+                    [_request resend];
+                });
+                return;
+            }
+            //no "break;" here
+            //will go to default for handling if "retryIfServerError" is NO
+        }
+        default:
+        {
+            // Request failure
+            NSString* body = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
+            NSString* errorData = [NSString stringWithFormat:@"Full response: %@", body];
+            AD_LOG_WARN(([NSString stringWithFormat:@"HTTP Error %ld", (long)webResponse.statusCode]), _correlationId, errorData);
+            
+            ADAuthenticationError* adError = [ADAuthenticationError HTTPErrorCode:webResponse.statusCode
+                                                                             body:[NSString stringWithFormat:@"(%lu bytes)", (unsigned long)webResponse.body.length]
+                                                                    correlationId:_correlationId];
+            SAFE_ARC_RELEASE(body);
+            
+            //Now add the information to the dictionary, so that the parser can extract it:
+            [self handleADError:adError completionBlock:completionBlock];
+        }
+    }
+}
+
+- (void)handleJSONResponse:(ADWebResponse*)webResponse
+           completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    NSError   *jsonError  = nil;
+    id         jsonObject = [NSJSONSerialization JSONObjectWithData:webResponse.body options:0 error:&jsonError];
+    
+    if (!jsonObject)
+    {
+        [self handleJSONError:jsonError body:webResponse.body completionBlock:completionBlock];
+        return;
+    }
+    
+    if (![jsonObject isKindOfClass:[NSDictionary class]])
+    {
+        ADAuthenticationError* adError =
+        [ADAuthenticationError unexpectedInternalError:[NSString stringWithFormat:@"Unexpected object type: %@", [jsonObject class]]
+                                         correlationId:_correlationId];
+        [self handleADError:adError completionBlock:completionBlock];
+        return;
+    }
+    
+    // Load the response
+    [_responseDictionary addEntriesFromDictionary:(NSDictionary*)jsonObject];
+    [self handleSuccess:completionBlock];
+    return;
+}
+
+- (void)handlePKeyAuthChallenge:(NSString *)wwwAuthHeaderValue
+                     completion:(void (^)(NSDictionary *))completionBlock
+{
+    //pkeyauth word length=8 + 1 whitespace
+    wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
+    
+    NSDictionary* authHeaderParams = [wwwAuthHeaderValue authHeaderParams];
+    
+    if (!authHeaderParams)
+    {
+        AD_LOG_ERROR_F(@"Unparseable wwwAuthHeader received.", AD_ERROR_SERVER_WPJ_REQUIRED, _correlationId, @"%@", wwwAuthHeaderValue);
+    }
+    
+    ADAuthenticationError* adError = nil;
+    NSString* authHeader = [ADPkeyAuthHelper createDeviceAuthResponse:[[_request URL] absoluteString]
+                                                        challengeData:authHeaderParams
+                                                        correlationId:_correlationId
+                                                                error:&adError];
+    
+    if (!authHeader)
+    {
+        [self handleADError:adError completionBlock:completionBlock];
+        return;
+    }
+    
+    // Add Authorization response header to the headers of the request
+    [_request.headers setObject:authHeader forKey:@"Authorization"];
+    
+    [_request resend];
+}
+
+- (void)handleSuccess:(void (^)(NSDictionary *))completionBlock
+{
+    [[ADClientMetrics getInstance] endClientMetricsRecord:[[_request URL] absoluteString]
+                                                startTime:[_request startTime]
+                                            correlationId:_correlationId
+                                             errorDetails:nil];
+    
+    completionBlock(_responseDictionary);
+}
+
+#pragma mark -
+#pragma mark Error Handlers
+
+- (void)handleJSONError:(NSError*)jsonError
+                   body:(NSData*)body
+        completionBlock:(void (^)(NSDictionary *))completionBlock
+{
+    
+    // Unrecognized JSON response
+    // We're often seeing the JSON parser being asked to parse whole HTML pages.
+    // Logging out the whole thing is unhelpful as it contains no useful info.
+    // If the body is > 1 KB then it's a pretty safe bet that it contains more
+    // noise then would be helpful
+    NSString* bodyStr = nil;
+    
+    if (body.length == 0)
+    {
+        AD_LOG_ERROR(@"Empty body received, expected JSON response.", jsonError.code, _correlationId, nil);
+    }
+    else
+    {
+        if ([body length] < 1024)
+        {
+            bodyStr = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+        }
+        else
+        {
+            bodyStr = [[NSString alloc] initWithFormat:@"large response, probably HTML, <%lu bytes>", (unsigned long)[body length]];
+        }
+        
+        NSString* errorMsg = [NSString stringWithFormat:@"JSON deserialization error: %@", jsonError.description];
+        
+        AD_LOG_ERROR_F(errorMsg, jsonError.code, _correlationId, @"%@", bodyStr);
+        SAFE_ARC_RELEASE(bodyStr);
+    }
+    
+    [self handleNSError:jsonError completionBlock:completionBlock];
+}
+
+- (void)handleNSError:(NSError*)error completionBlock:(void (^)(NSDictionary*))completionBlock
+{
+    if ([[error domain] isEqualToString:@"NSURLErrorDomain"] && [error code] == -1002)
+    {
+        // Unsupported URL Error
+        // This can happen because the redirect URI isn't a valid URI, or we've tried to jump out of the app with a URL scheme handler
+        // It's worth peeking into this error to see if we have useful information anyways.
+        
+        NSString* url = [[error userInfo] objectForKey:@"NSErrorFailingURLKey"];
+        [_responseDictionary setObject:url forKey:@"url"];
+    }
+    
+    AD_LOG_WARN(@"System error while making request.", _correlationId, error.description);
+    // System error
+    ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error
+                                                                errorDetails:error.localizedDescription
+                                                               correlationId:_correlationId];
+    
+    [self handleADError:adError completionBlock:completionBlock];
+}
+
+- (void)handleADError:(ADAuthenticationError*)adError completionBlock:(void (^)(NSDictionary*))completionBlock
+{
+    [_responseDictionary setObject:adError
+                            forKey:AUTH_NON_PROTOCOL_ERROR];
+    
+    [[ADClientMetrics getInstance] endClientMetricsRecord:[[_request URL] absoluteString]
+                                                startTime:[_request startTime]
+                                            correlationId:_correlationId
+                                             errorDetails:[adError errorDetails]];
+    
+    completionBlock(_responseDictionary);
+}
+
+@end

--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -76,6 +76,7 @@
 {
     SAFE_ARC_RELEASE(_responseDictionary);
     SAFE_ARC_RELEASE(_request);
+    SAFE_ARC_RELEASE(_correlationId);
     SAFE_ARC_SUPER_DEALLOC();
 }
 

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -49,6 +49,7 @@
 @synthesize headers  = _requestHeaders;
 @synthesize timeout  = _timeout;
 @synthesize isGetRequest = _isGetRequest;
+@synthesize correlationId = _correlationId;
 
 - (NSData *)body
 {
@@ -141,12 +142,7 @@
     SAFE_ARC_RELEASE(_connection);
     _connection     = nil;
     
-    if ( _completionHandler != nil )
-    {
-        _completionHandler( error, response );
-        SAFE_ARC_RELEASE(_completionHandler);
-        _completionHandler = nil;
-    }
+    _completionHandler(error, response);
 }
 
 - (void)send:(void (^)(NSError *, ADWebResponse *))completionHandler
@@ -159,6 +155,16 @@
     SAFE_ARC_RELEASE(_responseData);
     _responseData      = [[NSMutableData alloc] init];
     
+    [self send];
+}
+
+- (void)resend
+{
+    SAFE_ARC_RELEASE(_response);
+    _response          = nil;
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData      = [[NSMutableData alloc] init];
+
     [self send];
 }
 


### PR DESCRIPTION
Modify ADWebRequest to properly handle completion block management when re-sending requests