### PR TITLE
PKeyAuth No WPJ Unit Test

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -241,6 +241,7 @@
 		D6F0951A1CDC2BC300D28FC2 /* ADWebAuthRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */; };
 		D6F0951B1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */; };
 		D6F0951C1CDC2BC300D28FC2 /* ADWebAuthRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */; };
+		D6F999801D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F9997F1D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m */; };
 		D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
 /* End PBXBuildFile section */
 
@@ -481,6 +482,7 @@
 		D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenSilentHandler.m; sourceTree = "<group>"; };
 		D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthRequest.h; sourceTree = "<group>"; };
 		D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthRequest.m; sourceTree = "<group>"; };
+		D6F9997F1D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenPkeyAuthTests.m; sourceTree = "<group>"; };
 		D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADUserIdentifier.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -613,6 +615,7 @@
 				6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */,
 				6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */,
 				8BB8346A1807BE3F007F9F0D /* ADAcquireTokenTests.m */,
+				D6F9997F1D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m */,
 				9430C3551C55862A00D6506D /* ADAuthorityValidationTests.m */,
 				9430C34D1C54320400D6506D /* ADAuthenticationContextTests.m */,
 				8BB8346C1807C5F5007F9F0D /* ADAuthenticationParametersTests.m */,
@@ -1263,6 +1266,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6F999801D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				601BEE341C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */,
 				6071B5E41C14C0B0006F6CC2 /* ADTestURLConnection.m in Sources */,
 				8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */,

--- a/ADAL/tests/ADAcquireTokenPkeyAuthTests.m
+++ b/ADAL/tests/ADAcquireTokenPkeyAuthTests.m
@@ -1,0 +1,160 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "XCTestCase+TestHelperMethods.h"
+#import "ADTokenCache+Internal.h"
+#import "ADAuthenticationContext+Internal.h"
+#import "ADTestURLConnection.h"
+#import "ADTokenCacheItem+Internal.h"
+
+@interface ADAcquireTokenPkeyAuthTests : XCTestCase
+{
+    dispatch_semaphore_t _dsem;
+}
+
+@end
+
+@implementation ADAcquireTokenPkeyAuthTests
+
+- (void)setUp
+{
+    [super setUp];
+    _dsem = dispatch_semaphore_create(0);
+}
+
+- (void)tearDown
+{
+#if !__has_feature(objc_arc)
+    dispatch_release(_dsem);
+#endif
+    _dsem = nil;
+    
+    XCTAssertTrue([ADTestURLConnection noResponsesLeft]);
+    [ADTestURLConnection clearResponses];
+    [self adTestEnd];
+    [super tearDown];
+}
+
+- (ADAuthenticationContext *)getTestAuthenticationContext
+{
+    ADAuthenticationContext* context =
+    [[ADAuthenticationContext alloc] initWithAuthority:TEST_AUTHORITY
+                                     validateAuthority:NO
+                                                 error:nil];
+    
+    NSAssert(context, @"If this is failing for whatever reason you should probably fix it before trying to run tests.");
+    ADTokenCache *tokenCache = [ADTokenCache new];
+    SAFE_ARC_AUTORELEASE(tokenCache);
+    [context setTokenCacheStore:tokenCache];
+    [context setCorrelationId:TEST_CORRELATION_ID];
+    
+    SAFE_ARC_AUTORELEASE(context);
+    
+    return context;
+}
+
+
+- (ADTestURLResponse *)defaultTokenEndpointPkeyAuthChallenge
+{
+    return [self adDefaultRefreshReponseCode:200
+                             responseHeaders:@{ @"WWW-Authenticate" : @"PKeyAuth nonce=\"AAABAAEAiL9Kn2Z27UubvWFPbm0gLdtsn-PXocm89MSCN-jy-PyMb1txkhQMWoFNUDgLkmMs1OnKIexU4jwre7oqMSKjpKk3wjvHvJlE6ZFBdeEKVQtd_IXHzbR9wT-obZUI5kM779akwJHoPQ4aBnGlrbqUTCAA\", CertAuthorities=\"OU=82dbaca4-3e81-46ca-9c73-0950c1eaca97,CN=MS-Organization-Access,DC=windows,DC=net\", Version=\"1.0\", Context=\"pkeyauth_context\"" }
+                                responseJson:nil];
+}
+
+- (ADTestURLResponse *)defaultPkeyAuthNoWPJResponse
+{
+    NSString* expectedAuthHeader = @"PKeyAuth  Context=\"pkeyauth_context\", Version=\"1.0\"";
+    return [self adResponseRefreshToken:TEST_REFRESH_TOKEN
+                              authority:TEST_AUTHORITY
+                               resource:TEST_RESOURCE
+                               clientId:TEST_CLIENT_ID
+                         requestHeaders:@{ @"Authorization" : expectedAuthHeader }
+                          correlationId:TEST_CORRELATION_ID
+                        newRefreshToken:@"new refresh token"
+                         newAccessToken:@"new access token"
+                       additionalFields:nil];
+}
+
+- (void)testTokenEndpointPkeyAuthNoWPJ
+{
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    
+    // Add an MRRT to the cache
+    [context.tokenCacheStore.dataSource addOrUpdateItem:[self adCreateMRRTCacheItem] correlationId:nil error:&error];
+    XCTAssertNil(error);
+    
+    [ADTestURLConnection addResponses:@[[self defaultTokenEndpointPkeyAuthChallenge],
+                                        [self defaultPkeyAuthNoWPJResponse]]];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         XCTAssertNotNil(result.tokenCacheItem);
+         XCTAssertTrue([result.correlationId isKindOfClass:[NSUUID class]]);
+         XCTAssertEqualObjects(result.accessToken, @"new access token");
+         
+         TEST_SIGNAL;
+     }];
+    
+    TEST_WAIT;
+    
+    NSArray* allItems = [context.tokenCacheStore.dataSource allItems:&error];
+    XCTAssertNil(error);
+    XCTAssertNotNil(allItems);
+    XCTAssertEqual(allItems.count, 2);
+    
+    ADTokenCacheItem* mrrtItem = nil;
+    ADTokenCacheItem* atItem = nil;
+    
+    // Pull the MRRT and AT items out of the cache
+    for (ADTokenCacheItem * item in allItems)
+    {
+        if (item.refreshToken)
+        {
+            mrrtItem = item;
+        }
+        else if (item.accessToken)
+        {
+            atItem = item;
+        }
+    }
+    
+    XCTAssertNotNil(mrrtItem);
+    XCTAssertNotNil(atItem);
+    
+    XCTAssertNil(atItem.refreshToken);
+    XCTAssertNil(mrrtItem.accessToken);
+    
+    // Make sure the tokens got updated
+    XCTAssertEqualObjects(atItem.accessToken, @"new access token");
+    XCTAssertEqualObjects(mrrtItem.refreshToken, @"new refresh token");
+}
+
+@end

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -46,8 +46,6 @@ const int sAsyncContextTimeout = 10;
 }
 @end
 
-#define TEST_SIGNAL dispatch_semaphore_signal(_dsem)
-#define TEST_WAIT dispatch_semaphore_wait(_dsem, DISPATCH_TIME_FOREVER)
 
 @implementation ADAcquireTokenTests
 

--- a/ADAL/tests/ADTestURLConnection.m
+++ b/ADAL/tests/ADTestURLConnection.m
@@ -198,6 +198,13 @@
 
 - (void)setJSONResponse:(id)jsonResponse
 {
+    if (!jsonResponse)
+    {
+        SAFE_ARC_RELEASE(_responseData);
+        _responseData = nil;
+        return;
+    }
+    
     NSError* error = nil;
     NSData* responseData = [NSJSONSerialization dataWithJSONObject:jsonResponse options:0 error:&error];
     if (_responseData == responseData)

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -37,6 +37,9 @@
 #define TEST_REFRESH_TOKEN @"refresh token"
 #define TEST_CORRELATION_ID ({NSUUID *testID = [[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"]; SAFE_ARC_AUTORELEASE(testID); testID;})
 
+#define TEST_SIGNAL dispatch_semaphore_signal(_dsem)
+#define TEST_WAIT dispatch_semaphore_wait(_dsem, DISPATCH_TIME_FOREVER)
+
 typedef enum
 {
     TEST_LOG_LEVEL,
@@ -86,6 +89,7 @@ typedef enum
                               newRefreshToken:(NSString *)newRefreshToken
                                newAccessToken:(NSString *)newAccessToken;
 
+/*! Used for constructing a refresh token response with additional information in the JSON body */
 - (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
                                     authority:(NSString *)authority
                                      resource:(NSString *)resource
@@ -94,6 +98,44 @@ typedef enum
                               newRefreshToken:(NSString *)newRefreshToken
                                newAccessToken:(NSString *)newAccessToken
                              additionalFields:(NSDictionary *)additionalFields;
+
+
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                               requestHeaders:(NSDictionary *)requestHeaders
+                                correlationId:(NSUUID *)correlationId
+                              newRefreshToken:(NSString *)newRefreshToken
+                               newAccessToken:(NSString *)newAccessToken
+                             additionalFields:(NSDictionary *)additionalFields;
+
+/*! Used for constructing a response with the provided refresh token parameters */
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                                correlationId:(NSUUID *)correlationId
+                                 responseCode:(NSInteger)responseCode
+                              responseHeaders:(NSDictionary *)responseHeaders
+                                 responseJson:(NSDictionary *)responseJson;
+
+
+- (ADTestURLResponse *)adResponseRefreshToken:(NSString *)oldRefreshToken
+                                    authority:(NSString *)authority
+                                     resource:(NSString *)resource
+                                     clientId:(NSString *)clientId
+                               requestHeaders:(NSDictionary *)requestHeaders
+                                correlationId:(NSUUID *)correlationId
+                                 responseCode:(NSInteger)responseCode
+                              responseHeaders:(NSDictionary *)responseHeaders
+                                 responseJson:(NSDictionary *)responseJson;
+
+/*! Used for constructing a response with a specific HTTP code and HTTP headers 
+    to a default refresh token request */
+- (ADTestURLResponse *)adDefaultRefreshReponseCode:(NSInteger)responseCode
+                                   responseHeaders:(NSDictionary *)responseHeaders
+                                      responseJson:(NSDictionary *)responseJson;
 
 /*! Verifies that the correct error is returned when any method was passed invalid arguments.
  */


### PR DESCRIPTION
Add a unit test that goes through the pkeyauth flow on the token endpoint when there's no WPJ. I didn't add other cases yet as anything that touches and uses keychain items becomes much more involved.