### PR TITLE
Make keychainTeamId use an always accessible item

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -232,6 +232,8 @@
 		97A522501A1A8999001D77CE /* ADClientMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */; };
 		D60D8FE81D25C8D400F3E6C9 /* ADHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */; };
 		D60D8FE91D25C8D400F3E6C9 /* ADHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */; };
+		D610015E1D39A5620087AB81 /* ADKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D610015D1D39A5620087AB81 /* ADKeychainUtil.m */; };
+		D610015F1D39A5620087AB81 /* ADKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D610015D1D39A5620087AB81 /* ADKeychainUtil.m */; };
 		D616AD1A1D25EF12006EF8B5 /* ADAL.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 9453C3B71C583AE6006B9E79 /* ADAL.h */; };
 		D616AD1B1D25EF12006EF8B5 /* ADAuthenticationContext.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 9453C3B81C583AE6006B9E79 /* ADAuthenticationContext.h */; };
 		D616AD1C1D25EF12006EF8B5 /* ADAuthenticationError.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 9453C3B91C583AE6006B9E79 /* ADAuthenticationError.h */; };
@@ -563,6 +565,8 @@
 		97A522511A1A89C4001D77CE /* ADClientMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADClientMetrics.h; sourceTree = "<group>"; };
 		97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADHelpersTests.m; sourceTree = "<group>"; };
+		D610015C1D39A5620087AB81 /* ADKeychainUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADKeychainUtil.h; sourceTree = "<group>"; };
+		D610015D1D39A5620087AB81 /* ADKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADKeychainUtil.m; sourceTree = "<group>"; };
 		D616AD171D25EEA7006EF8B5 /* adal__ios__app_extension__staticlib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adal__ios__app_extension__staticlib.xcconfig; sourceTree = "<group>"; };
 		D616AD621D25EF12006EF8B5 /* libADALiOS-AppExtension.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libADALiOS-AppExtension.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D664F1481D25FC4C0017B799 /* ADWorkPlaceJoinConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADWorkPlaceJoinConstants.h; sourceTree = "<group>"; };
@@ -824,6 +828,7 @@
 				9453C3691C580157006B9E79 /* NSURL+ADExtensions.m */,
 				9453C36A1C580157006B9E79 /* NSUUID+ADExtensions.h */,
 				9453C36B1C580157006B9E79 /* NSUUID+ADExtensions.m */,
+				D610015B1D39A5450087AB81 /* ios */,
 			);
 			path = utils;
 			sourceTree = "<group>";
@@ -1059,6 +1064,15 @@
 				D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */,
 			);
 			path = mac;
+			sourceTree = "<group>";
+		};
+		D610015B1D39A5450087AB81 /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				D610015C1D39A5620087AB81 /* ADKeychainUtil.h */,
+				D610015D1D39A5620087AB81 /* ADKeychainUtil.m */,
+			);
+			name = ios;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1362,6 +1376,7 @@
 				9453C37D1C5801CB006B9E79 /* ADBrokerKeyHelper.m in Sources */,
 				946818AA1C59B80800CA0378 /* ADAuthenticationViewController.m in Sources */,
 				D6F095161CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */,
+				D610015E1D39A5620087AB81 /* ADKeychainUtil.m in Sources */,
 				9453C3711C580157006B9E79 /* NSURL+ADExtensions.m in Sources */,
 				D6FB3E3C1B30D3630032F883 /* ADUserIdentifier.m in Sources */,
 				9453C3721C580157006B9E79 /* NSUUID+ADExtensions.m in Sources */,
@@ -1537,6 +1552,7 @@
 				D616AD431D25EF12006EF8B5 /* ADBrokerKeyHelper.m in Sources */,
 				D616AD441D25EF12006EF8B5 /* ADAuthenticationViewController.m in Sources */,
 				D616AD451D25EF12006EF8B5 /* ADAcquireTokenSilentHandler.m in Sources */,
+				D610015F1D39A5620087AB81 /* ADKeychainUtil.m in Sources */,
 				D616AD461D25EF12006EF8B5 /* NSURL+ADExtensions.m in Sources */,
 				D616AD471D25EF12006EF8B5 /* ADUserIdentifier.m in Sources */,
 				D616AD481D25EF12006EF8B5 /* NSUUID+ADExtensions.m in Sources */,

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -134,6 +134,15 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 #if TARGET_OS_IPHONE
     tokenCache = [ADKeychainTokenCache defaultKeychainCache];
+    if (!tokenCache)
+    {
+        ADAuthenticationError* adError = [ADAuthenticationError unexpectedInternalError:@"Unable to get kecyhain token cache" correlationId:nil];
+        if (error)
+        {
+            *error = adError;
+        }
+        return nil;
+    }
 #else
     tokenCache = [ADTokenCache new];
     [(ADTokenCache*)tokenCache setDelegate:[ADAuthenticationSettings sharedInstance].defaultStorageDelegate];

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -24,6 +24,7 @@
 #import <Security/Security.h>
 #import "ADAL_Internal.h"
 #import "ADKeychainTokenCache+Internal.h"
+#import "ADKeychainUtil.h"
 #import "ADTokenCacheItem.h"
 #import "NSString+ADHelperMethods.h"
 #import "ADTokenCacheKey.h"
@@ -121,7 +122,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
         sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
     }
     
-    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId:nil];
+    NSString* teamId = [ADKeychainUtil keychainTeamId:nil];
 #if !TARGET_OS_SIMULATOR
     // If we didn't find a team ID and we're on device then the rest of ADAL not only will not work
     // particularly well, we'll probably induce other issues by continuing.

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -121,7 +121,15 @@ static ADKeychainTokenCache* s_defaultCache = nil;
         sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
     }
     
-    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId];
+    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId:nil];
+#if !TARGET_OS_SIMULATOR
+    // If we didn't find a team ID and we're on device then the rest of ADAL not only will not work
+    // particularly well, we'll probably induce other issues by continuing.
+    if (!teamId)
+    {
+        return nil;
+    }
+#endif
     if (teamId)
     {
         _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", teamId, sharedGroup];

--- a/ADAL/src/utils/ADKeychainUtil.h
+++ b/ADAL/src/utils/ADKeychainUtil.h
@@ -23,11 +23,8 @@
 
 #import <Foundation/Foundation.h>
 
-@class ADRegistrationInformation;
+@interface ADKeychainUtil : NSObject
 
-@interface ADWorkPlaceJoinUtil : NSObject
-
-+ (ADRegistrationInformation*)getRegistrationInformation:(NSUUID *)correlationId
-                                                   error:(ADAuthenticationError * __autoreleasing *)error;
++ (NSString*)keychainTeamId:(ADAuthenticationError* __autoreleasing *)error;
 
 @end

--- a/ADAL/src/utils/ADKeychainUtil.m
+++ b/ADAL/src/utils/ADKeychainUtil.m
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADKeychainUtil.h"
+
+@implementation ADKeychainUtil
+
++ (NSString*)keychainTeamId:(ADAuthenticationError* __autoreleasing *)error
+{
+    static dispatch_once_t s_once;
+    static NSString* s_keychainTeamId = nil;
+    
+    static ADAuthenticationError* adError = nil;
+    
+    dispatch_once(&s_once, ^{
+        ADAuthenticationError* localError = nil;
+        s_keychainTeamId = [self retrieveTeamIDFromKeychain:&localError];
+        adError = localError;
+        SAFE_ARC_RETAIN(s_keychainTeamId);
+        AD_LOG_INFO(([NSString stringWithFormat:@"Using \"%@\" Team ID for Keychain.", s_keychainTeamId]), nil, nil);
+    });
+    
+    if (!s_keychainTeamId && error)
+    {
+        *error = adError;
+    }
+    
+    return s_keychainTeamId;
+}
+
++ (NSString*)retrieveTeamIDFromKeychain:(ADAuthenticationError * __autoreleasing *)error
+{
+    NSDictionary *query = @{ (id)kSecClass : (id)kSecClassGenericPassword,
+                             (id)kSecAttrAccount : @"teamIDHint",
+                             (id)kSecAttrService : @"",
+                             (id)kSecAttrAccessible : (id)kSecAttrAccessibleAlways,
+                             (id)kSecReturnAttributes : @YES };
+    CFDictionaryRef result = nil;
+    
+    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    
+    if (status == errSecItemNotFound)
+    {
+        status = SecItemAdd((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    }
+    
+    if (status != errSecSuccess)
+    {
+        ADAuthenticationError* adError = [ADAuthenticationError keychainErrorFromOperation:@"team ID" status:status correlationId:nil];
+        if (error)
+        {
+            *error = adError;
+        }
+        return nil;
+    }
+    
+    NSString *accessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge id)(kSecAttrAccessGroup)];
+    NSArray *components = [accessGroup componentsSeparatedByString:@"."];
+    NSString *bundleSeedID = [components firstObject];
+    
+    CFRelease(result);
+    
+    return [bundleSeedID length] ? bundleSeedID : nil;
+}
+
+@end

--- a/ADAL/src/workplacejoin/ADWorkPlaceJoinUtil.h
+++ b/ADAL/src/workplacejoin/ADWorkPlaceJoinUtil.h
@@ -30,6 +30,6 @@
 + (ADRegistrationInformation*)getRegistrationInformation:(NSUUID *)correlationId
                                                    error:(ADAuthenticationError * __autoreleasing *)error;
 
-+ (NSString*)keychainTeamId;
++ (NSString*)keychainTeamId:(ADAuthenticationError* __autoreleasing *)error;
 
 @end

--- a/ADAL/src/workplacejoin/mac/ADWorkPlaceJoinUtil.m
+++ b/ADAL/src/workplacejoin/mac/ADWorkPlaceJoinUtil.m
@@ -23,7 +23,6 @@
 
 #import "ADWorkPlaceJoinUtil.h"
 
-
 @implementation ADWorkPlaceJoinUtil
 
 + (ADRegistrationInformation*)getRegistrationInformation:(NSUUID *)correlationId
@@ -41,50 +40,6 @@
     }
     
     return nil;
-}
-
-+ (NSString*)keychainTeamId
-{
-    static dispatch_once_t s_once;
-    static NSString* s_keychainTeamId = nil;
-    
-    dispatch_once(&s_once, ^{
-        s_keychainTeamId = [self retrieveTeamIDFromKeychain];
-        AD_LOG_INFO(([NSString stringWithFormat:@"Using \"%@\" Team ID for Keychain.", s_keychainTeamId]), nil, nil);
-    });
-    
-    return s_keychainTeamId;
-}
-
-+ (NSString*)retrieveTeamIDFromKeychain
-{
-    NSDictionary *query = [NSDictionary dictionaryWithObjectsAndKeys:
-                           (__bridge id)(kSecClassGenericPassword), kSecClass,
-                           @"bundleSeedID", kSecAttrAccount,
-                           @"", kSecAttrService,
-                           (id)kCFBooleanTrue, kSecReturnAttributes,
-                           nil];
-    CFDictionaryRef result = nil;
-    
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
-    
-    if (status == errSecItemNotFound)
-    {
-        status = SecItemAdd((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
-    }
-    
-    if (status != errSecSuccess)
-    {
-        return nil;
-    }
-    
-    NSString *accessGroup = [(__bridge NSDictionary *)result objectForKey:(__bridge id)(kSecAttrAccessGroup)];
-    NSArray *components = [accessGroup componentsSeparatedByString:@"."];
-    NSString *bundleSeedID = [components firstObject];
-    
-    CFRelease(result);
-    
-    return [bundleSeedID length] ? bundleSeedID : nil;
 }
 
 @end

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
@@ -64,7 +64,7 @@
 {
     [super viewDidLoad];
     
-    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId];
+    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId:nil];
     
     [_keychainId setText: teamId ? teamId : @"<No Team ID>" ];
     

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
@@ -27,6 +27,7 @@
 
 // Internal ADAL headers
 #import "ADWorkPlaceJoinUtil.h"
+#import "ADKeychainUtil.h"
 #import "ADRegistrationInformation.h"
 
 
@@ -64,7 +65,7 @@
 {
     [super viewDidLoad];
     
-    NSString* teamId = [ADWorkPlaceJoinUtil keychainTeamId:nil];
+    NSString* teamId = [ADKeychainUtil keychainTeamId:nil];
     
     [_keychainId setText: teamId ? teamId : @"<No Team ID>" ];
     


### PR DESCRIPTION
The previous keychainTeamId check used an item which did not specify an accessibility attribute, which defaults to only being accessible while the device is unlocked. This can create issues for background applications that might kick up while the device is locked. Extra error checking and logging are being added on that keychain query as well to make sure we have a better idea what happened and to make sure ADAL doesn't try to do things which might make it worse.