### PR TITLE
Change ADNTLMHandler to return AD_ERROR_UI_USER_CANCEL on cancel

### DIFF
--- a/ADAL/src/urlprotocol/ADNTLMHandler.m
+++ b/ADAL/src/urlprotocol/ADNTLMHandler.m
@@ -98,7 +98,7 @@ static NSURLConnection *_conn = nil;
                 _challengeCancelled = YES;
                 AD_LOG_INFO_F(@"NTLM challenge cancelled", nil, @"host: %@", challenge.protectionSpace.host);
                 [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
-                [protocol connection:connection didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain code:NSUserCancelledError userInfo:nil]];
+                [protocol connection:connection didFailWithError:[NSError errorWithDomain:ADAuthenticationErrorDomain code:AD_ERROR_UI_USER_CANCEL userInfo:nil]];
             }
         }];
     }//@synchronized


### PR DESCRIPTION
(for #702)

Changed the returning error code when NTLM dialog is canceled by user.