### PR TITLE
Extend ADAL to support WatchOS

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -248,6 +248,60 @@
 		94E0FD8E1C59614B00CD707B /* ADTokenCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3C61C583AE6006B9E79 /* ADTokenCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		97A522491A1A752D001D77CE /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
 		97A522501A1A8999001D77CE /* ADClientMetricsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */; };
+		B61D6FB41D4C2AAF00DD4639 /* ADKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D610015D1D39A5620087AB81 /* ADKeychainUtil.m */; };
+		B681E9321D380674001157CE /* ADAuthenticationContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8345B18074A58007F9F0D /* ADAuthenticationContext.m */; };
+		B681E9341D380674001157CE /* ADAuthenticationContext+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = D6E43A691B04026D000F5BE2 /* ADAuthenticationContext+Internal.m */; };
+		B681E9361D380674001157CE /* ADAuthenticationError.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B5989501811A3DB00744AEE /* ADAuthenticationError.m */; };
+		B681E9381D380674001157CE /* ADAuthenticationParameters+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BD14618182189C800796E79 /* ADAuthenticationParameters+Internal.m */; };
+		B681E9391D380674001157CE /* ADAuthenticationParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8346118074CFA007F9F0D /* ADAuthenticationParameters.m */; };
+		B681E93B1D380674001157CE /* ADAuthenticationResult+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B0DA7DD182AD01100CF5E1E /* ADAuthenticationResult+Internal.m */; };
+		B681E93C1D380674001157CE /* ADAuthenticationResult.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8345E18074B74007F9F0D /* ADAuthenticationResult.m */; };
+		B681E93D1D380674001157CE /* ADAuthenticationSettings.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB83464180764B6007F9F0D /* ADAuthenticationSettings.m */; };
+		B681E93F1D380674001157CE /* ADInstanceDiscovery.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B611400186E517D007759C2 /* ADInstanceDiscovery.m */; };
+		B681E9401D380674001157CE /* ADLogger.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B92DB6F181B2335004AAB0E /* ADLogger.m */; };
+		B681E9431D380674001157CE /* ADOAuth2Constants.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E6FC71856A1E8000DC3C8 /* ADOAuth2Constants.m */; };
+		B681E9441D380674001157CE /* ADUserInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8B59893D180DE8A100744AEE /* ADUserInformation.m */; };
+		B681E9451D380674001157CE /* ADClientMetrics.m in Sources */ = {isa = PBXBuildFile; fileRef = 97A522481A1A752D001D77CE /* ADClientMetrics.m */; };
+		B681E9471D380674001157CE /* ADUserIdentifier.m in Sources */ = {isa = PBXBuildFile; fileRef = D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */; };
+		B681E9481D380685001157CE /* ADTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3371C57FC2A006B9E79 /* ADTokenCache.m */; };
+		B681E94B1D380685001157CE /* ADTokenCacheAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */; };
+		B681E94C1D380685001157CE /* ADTokenCacheItem.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33B1C57FC2A006B9E79 /* ADTokenCacheItem.m */; };
+		B681E94E1D380685001157CE /* ADTokenCacheItem+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33D1C57FC2A006B9E79 /* ADTokenCacheItem+Internal.m */; };
+		B681E9501D380685001157CE /* ADTokenCacheKey.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C33F1C57FC2A006B9E79 /* ADTokenCacheKey.m */; };
+		B681E9531D38068E001157CE /* ADAuthenticationRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3811C5820E3006B9E79 /* ADAuthenticationRequest.m */; };
+		B681E9551D38068E001157CE /* ADAuthenticationRequest+AcquireAssertion.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3831C5820E3006B9E79 /* ADAuthenticationRequest+AcquireAssertion.m */; };
+		B681E9571D38068E001157CE /* ADAuthenticationRequest+AcquireToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3851C5820E3006B9E79 /* ADAuthenticationRequest+AcquireToken.m */; };
+		B681E95B1D38068E001157CE /* ADAuthenticationRequest+WebRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3891C5820E3006B9E79 /* ADAuthenticationRequest+WebRequest.m */; };
+		B681E95D1D38068E001157CE /* ADAcquireTokenSilentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */; };
+		B681E9611D38068E001157CE /* ADWebAuthRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */; };
+		B681E9631D38068E001157CE /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
+		B681E9651D38068E001157CE /* ADWebResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C38D1C5820E3006B9E79 /* ADWebResponse.m */; };
+		B681E9671D38069B001157CE /* ADCustomHeaderHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3971C5826F2006B9E79 /* ADCustomHeaderHandler.m */; };
+		B681E96D1D3806A4001157CE /* ADALFrameworkUtils.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C35F1C580157006B9E79 /* ADALFrameworkUtils.m */; };
+		B681E96F1D3806A4001157CE /* ADHelpers.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3611C580157006B9E79 /* ADHelpers.m */; };
+		B681E9711D3806A4001157CE /* NSDictionary+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3651C580157006B9E79 /* NSDictionary+ADExtensions.m */; };
+		B681E9731D3806A4001157CE /* NSString+ADHelperMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3671C580157006B9E79 /* NSString+ADHelperMethods.m */; };
+		B681E9751D3806A4001157CE /* NSURL+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3691C580157006B9E79 /* NSURL+ADExtensions.m */; };
+		B681E9771D3806A4001157CE /* NSUUID+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C36B1C580157006B9E79 /* NSUUID+ADExtensions.m */; };
+		B681E9791D3806B0001157CE /* ADJwtHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C46C1C5872AD006B9E79 /* ADJwtHelper.m */; };
+		B681E97C1D3806B0001157CE /* ADPkeyAuthHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3491C5800E1006B9E79 /* ADPkeyAuthHelper.m */; };
+		B681E97F1D3806B5001157CE /* ADRegistrationInformation.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3561C580143006B9E79 /* ADRegistrationInformation.m */; };
+		B681E9801D3806B5001157CE /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C35A1C580143006B9E79 /* ADWorkPlaceJoinUtil.m */; };
+		B681E9811D38076A001157CE /* ADKeychainTokenCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3C41C583AE6006B9E79 /* ADKeychainTokenCache.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9821D380773001157CE /* ADTokenCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BF1C583AE6006B9E79 /* ADTokenCacheItem.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9831D38077A001157CE /* ADErrorCodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BD1C583AE6006B9E79 /* ADErrorCodes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9841D380785001157CE /* ADAuthenticationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BB1C583AE6006B9E79 /* ADAuthenticationResult.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9851D38078C001157CE /* ADLogger.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BE1C583AE6006B9E79 /* ADLogger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9861D380796001157CE /* ADAuthenticationParameters.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BA1C583AE6006B9E79 /* ADAuthenticationParameters.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9871D38079E001157CE /* ADAuthenticationError.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3B91C583AE6006B9E79 /* ADAuthenticationError.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9881D3807A6001157CE /* ADAuthenticationSettings.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3BC1C583AE6006B9E79 /* ADAuthenticationSettings.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E9891D3807AD001157CE /* ADUserIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3C01C583AE6006B9E79 /* ADUserIdentifier.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E98A1D3807B6001157CE /* ADAuthenticationContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3B81C583AE6006B9E79 /* ADAuthenticationContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E98B1D3807BD001157CE /* ADAL.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3B71C583AE6006B9E79 /* ADAL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E98C1D3807C4001157CE /* ADUserInformation.h in Headers */ = {isa = PBXBuildFile; fileRef = 9453C3C11C583AE6006B9E79 /* ADUserInformation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B681E98D1D380C72001157CE /* ADKeychainTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = 9453C3741C58016D006B9E79 /* ADKeychainTokenCache.m */; };
+		B681E9A11D381809001157CE /* ADWebRequest+NSURLSession.h in Headers */ = {isa = PBXBuildFile; fileRef = B681E99F1D381809001157CE /* ADWebRequest+NSURLSession.h */; };
+		B681E9A21D381809001157CE /* ADWebRequest+NSURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = B681E9A01D381809001157CE /* ADWebRequest+NSURLSession.m */; };
 		D60D8FE81D25C8D400F3E6C9 /* ADHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */; };
 		D60D8FE91D25C8D400F3E6C9 /* ADHelpersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */; };
 		D610015E1D39A5620087AB81 /* ADKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D610015D1D39A5620087AB81 /* ADKeychainUtil.m */; };
@@ -594,6 +648,10 @@
 		97A5224F1A1A8999001D77CE /* ADClientMetricsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADClientMetricsTests.m; sourceTree = "<group>"; };
 		97A522511A1A89C4001D77CE /* ADClientMetrics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADClientMetrics.h; sourceTree = "<group>"; };
 		97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		B681E9101D380633001157CE /* ADAL.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = ADAL.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B681E98E1D380D22001157CE /* watchOS */ = {isa = PBXFileReference; lastKnownFileType = folder; path = watchOS; sourceTree = "<group>"; };
+		B681E99F1D381809001157CE /* ADWebRequest+NSURLSession.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADWebRequest+NSURLSession.h"; sourceTree = "<group>"; };
+		B681E9A01D381809001157CE /* ADWebRequest+NSURLSession.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADWebRequest+NSURLSession.m"; sourceTree = "<group>"; };
 		D60D8FE71D25C8D400F3E6C9 /* ADHelpersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADHelpersTests.m; sourceTree = "<group>"; };
 		D610015C1D39A5620087AB81 /* ADKeychainUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADKeychainUtil.h; sourceTree = "<group>"; };
 		D610015D1D39A5620087AB81 /* ADKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADKeychainUtil.m; sourceTree = "<group>"; };
@@ -658,6 +716,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B681E90C1D380633001157CE /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		D616AD5B1D25EF12006EF8B5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -708,6 +773,7 @@
 				9453C3FD1C586425006B9E79 /* ADAL.framework */,
 				94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */,
 				D616AD621D25EF12006EF8B5 /* libADALiOS-AppExtension.a */,
+				B681E9101D380633001157CE /* ADAL.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -846,6 +912,7 @@
 		9453C3151C57EE57006B9E79 /* resouces */ = {
 			isa = PBXGroup;
 			children = (
+				B681E98E1D380D22001157CE /* watchOS */,
 				9453C3161C57EE65006B9E79 /* iOS */,
 			);
 			name = resouces;
@@ -984,6 +1051,8 @@
 				D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */,
 				9453C38A1C5820E3006B9E79 /* ADWebRequest.h */,
 				9453C38B1C5820E3006B9E79 /* ADWebRequest.m */,
+				B681E99F1D381809001157CE /* ADWebRequest+NSURLSession.h */,
+				B681E9A01D381809001157CE /* ADWebRequest+NSURLSession.m */,
 				D6F095181CDC2BC300D28FC2 /* ADWebAuthRequest.h */,
 				D6F095191CDC2BC300D28FC2 /* ADWebAuthRequest.m */,
 				D68040311D22F686007A61AC /* ADWebAuthResponse.h */,
@@ -1209,6 +1278,26 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B681E90D1D380633001157CE /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B681E98C1D3807C4001157CE /* ADUserInformation.h in Headers */,
+				B681E98B1D3807BD001157CE /* ADAL.h in Headers */,
+				B681E98A1D3807B6001157CE /* ADAuthenticationContext.h in Headers */,
+				B681E9891D3807AD001157CE /* ADUserIdentifier.h in Headers */,
+				B681E9881D3807A6001157CE /* ADAuthenticationSettings.h in Headers */,
+				B681E9871D38079E001157CE /* ADAuthenticationError.h in Headers */,
+				B681E9861D380796001157CE /* ADAuthenticationParameters.h in Headers */,
+				B681E9851D38078C001157CE /* ADLogger.h in Headers */,
+				B681E9841D380785001157CE /* ADAuthenticationResult.h in Headers */,
+				B681E9831D38077A001157CE /* ADErrorCodes.h in Headers */,
+				B681E9A11D381809001157CE /* ADWebRequest+NSURLSession.h in Headers */,
+				B681E9821D380773001157CE /* ADTokenCacheItem.h in Headers */,
+				B681E9811D38076A001157CE /* ADKeychainTokenCache.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1302,6 +1391,24 @@
 			productReference = 94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B681E90F1D380633001157CE /* ADALwatchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B681E9201D380633001157CE /* Build configuration list for PBXNativeTarget "ADALwatchOS" */;
+			buildPhases = (
+				B681E90B1D380633001157CE /* Sources */,
+				B681E90C1D380633001157CE /* Frameworks */,
+				B681E90D1D380633001157CE /* Headers */,
+				B681E90E1D380633001157CE /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ADALwatchOS;
+			productName = ADALwatchOS;
+			productReference = B681E9101D380633001157CE /* ADAL.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		D616AD181D25EF12006EF8B5 /* ADALiOS-AppExtension */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = D616AD5E1D25EF12006EF8B5 /* Build configuration list for PBXNativeTarget "ADALiOS-AppExtension" */;
@@ -1340,6 +1447,9 @@
 					94DD18E01C5ACFBF00F80C62 = {
 						CreatedOnToolsVersion = 7.2;
 					};
+					B681E90F1D380633001157CE = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 				};
 			};
 			buildConfigurationList = 8B0965A517F25770002BDFB8 /* Build configuration list for PBXProject "ADAL" */;
@@ -1361,6 +1471,7 @@
 				9453C3FC1C586425006B9E79 /* ADAL Mac */,
 				94DD18E01C5ACFBF00F80C62 /* ADAL Mac Tests */,
 				9453C4571C5866D0006B9E79 /* Build All */,
+				B681E90F1D380633001157CE /* ADALwatchOS */,
 			);
 		};
 /* End PBXProject section */
@@ -1389,6 +1500,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		94DD18DF1C5ACFBF00F80C62 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B681E90E1D380633001157CE /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1581,6 +1699,54 @@
 				601BEE321C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */,
 				94DD18F61C5ACFF900F80C62 /* ADTestNSStringHelperMethods.m in Sources */,
 				94DD18FC1C5ACFF900F80C62 /* ADInstanceDiscoveryTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B681E90B1D380633001157CE /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B681E98D1D380C72001157CE /* ADKeychainTokenCache.m in Sources */,
+				B681E9481D380685001157CE /* ADTokenCache.m in Sources */,
+				B681E9471D380674001157CE /* ADUserIdentifier.m in Sources */,
+				B681E96F1D3806A4001157CE /* ADHelpers.m in Sources */,
+				B681E9321D380674001157CE /* ADAuthenticationContext.m in Sources */,
+				B681E9381D380674001157CE /* ADAuthenticationParameters+Internal.m in Sources */,
+				B681E9731D3806A4001157CE /* NSString+ADHelperMethods.m in Sources */,
+				B681E95D1D38068E001157CE /* ADAcquireTokenSilentHandler.m in Sources */,
+				B681E9361D380674001157CE /* ADAuthenticationError.m in Sources */,
+				B681E9631D38068E001157CE /* ADWebAuthResponse.m in Sources */,
+				B681E93D1D380674001157CE /* ADAuthenticationSettings.m in Sources */,
+				B681E9651D38068E001157CE /* ADWebResponse.m in Sources */,
+				B681E9401D380674001157CE /* ADLogger.m in Sources */,
+				B681E95B1D38068E001157CE /* ADAuthenticationRequest+WebRequest.m in Sources */,
+				B681E94E1D380685001157CE /* ADTokenCacheItem+Internal.m in Sources */,
+				B681E9551D38068E001157CE /* ADAuthenticationRequest+AcquireAssertion.m in Sources */,
+				B681E9791D3806B0001157CE /* ADJwtHelper.m in Sources */,
+				B61D6FB41D4C2AAF00DD4639 /* ADKeychainUtil.m in Sources */,
+				B681E97F1D3806B5001157CE /* ADRegistrationInformation.m in Sources */,
+				B681E9801D3806B5001157CE /* ADWorkPlaceJoinUtil.m in Sources */,
+				B681E9391D380674001157CE /* ADAuthenticationParameters.m in Sources */,
+				B681E93B1D380674001157CE /* ADAuthenticationResult+Internal.m in Sources */,
+				B681E9501D380685001157CE /* ADTokenCacheKey.m in Sources */,
+				B681E93F1D380674001157CE /* ADInstanceDiscovery.m in Sources */,
+				B681E97C1D3806B0001157CE /* ADPkeyAuthHelper.m in Sources */,
+				B681E9711D3806A4001157CE /* NSDictionary+ADExtensions.m in Sources */,
+				B681E9751D3806A4001157CE /* NSURL+ADExtensions.m in Sources */,
+				B681E96D1D3806A4001157CE /* ADALFrameworkUtils.m in Sources */,
+				B681E9671D38069B001157CE /* ADCustomHeaderHandler.m in Sources */,
+				B681E9441D380674001157CE /* ADUserInformation.m in Sources */,
+				B681E9771D3806A4001157CE /* NSUUID+ADExtensions.m in Sources */,
+				B681E9A21D381809001157CE /* ADWebRequest+NSURLSession.m in Sources */,
+				B681E9431D380674001157CE /* ADOAuth2Constants.m in Sources */,
+				B681E93C1D380674001157CE /* ADAuthenticationResult.m in Sources */,
+				B681E9451D380674001157CE /* ADClientMetrics.m in Sources */,
+				B681E94B1D380685001157CE /* ADTokenCacheAccessor.m in Sources */,
+				B681E94C1D380685001157CE /* ADTokenCacheItem.m in Sources */,
+				B681E9571D38068E001157CE /* ADAuthenticationRequest+AcquireToken.m in Sources */,
+				B681E9531D38068E001157CE /* ADAuthenticationRequest.m in Sources */,
+				B681E9611D38068E001157CE /* ADWebAuthRequest.m in Sources */,
+				B681E9341D380674001157CE /* ADAuthenticationContext+Internal.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2249,6 +2415,107 @@
 			};
 			name = Release;
 		};
+		B681E9191D380633001157CE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = resources/watchOS/Info.plist;
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-Objc";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.ADALwatchOS;
+				PRODUCT_NAME = ADAL;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Debug;
+		};
+		B681E91B1D380633001157CE /* CodeCoverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = resources/watchOS/Info.plist;
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-Objc";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.ADALwatchOS;
+				PRODUCT_NAME = ADAL;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = CodeCoverage;
+		};
+		B681E91C1D380633001157CE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				COPY_PHASE_STRIP = NO;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				INFOPLIST_FILE = resources/watchOS/Info.plist;
+				INSTALL_PATH = "@executable_path/../Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-Objc";
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.ADALwatchOS;
+				PRODUCT_NAME = ADAL;
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 4;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+				WATCHOS_DEPLOYMENT_TARGET = 2.2;
+			};
+			name = Release;
+		};
 		D616AD5F1D25EF12006EF8B5 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D616AD171D25EEA7006EF8B5 /* adal__ios__app_extension__staticlib.xcconfig */;
@@ -2395,6 +2662,16 @@
 				94DD18EA1C5ACFBF00F80C62 /* Debug */,
 				94DD18EB1C5ACFBF00F80C62 /* CodeCoverage */,
 				94DD18EC1C5ACFBF00F80C62 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		B681E9201D380633001157CE /* Build configuration list for PBXNativeTarget "ADALwatchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B681E9191D380633001157CE /* Debug */,
+				B681E91B1D380633001157CE /* CodeCoverage */,
+				B681E91C1D380633001157CE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/ADAL/resources/watchOS/Info.plist
+++ b/ADAL/resources/watchOS/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>2.1</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -54,10 +54,12 @@
 typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
 
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 //iOS:
 #   include <UIKit/UIKit.h>
 typedef UIWebView WebViewType;
+#elif TARGET_OS_WATCH
+typedef NSObject WebViewType; // Should never be called
 #else
 //OS X:
 #   include <WebKit/WebKit.h>

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -346,6 +346,21 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:completionBlock];
 }
 
+#if TARGET_OS_WATCH
+- (void)acquireTokenSlientWithAuthData:(NSData *)authData
+                              resource:(NSString *)resource
+                              clientId:(NSString *)clientId
+                           redirectUri:(NSURL *)redirectUri
+                       completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    API_ENTRY;
+    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
+    
+    [request setSilent:YES];
+    [request acquireTokenWithAuthData:authData completionBlock:completionBlock];
+}
+#endif
+
 - (void)acquireTokenSilentWithResource:(NSString*)resource
                               clientId:(NSString*)clientId
                            redirectUri:(NSURL*)redirectUri

--- a/ADAL/src/ADLogger.m
+++ b/ADAL/src/ADLogger.m
@@ -28,6 +28,9 @@
 #include <sys/sysctl.h>
 #include <mach/machine.h>
 #include <CommonCrypto/CommonDigest.h>
+#if TARGET_OS_WATCH
+#include <WatchKit/WatchKit.h>
+#endif
 
 @protocol LoggerContext <NSObject>
 
@@ -208,7 +211,7 @@ correlationId:(NSUUID*)correlationId
 + (NSDictionary*)adalId
 {
     dispatch_once(&s_logOnce, ^{
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
         //iOS:
         UIDevice* device = [UIDevice currentDevice];
         NSMutableDictionary* result = [NSMutableDictionary dictionaryWithDictionary:
@@ -218,6 +221,16 @@ correlationId:(NSUUID*)correlationId
                                          ADAL_ID_OS_VER:device.systemVersion,
                                          ADAL_ID_DEVICE_MODEL:device.model,//Prints out only "iPhone" or "iPad".
                                          }];
+#elif TARGET_OS_WATCH
+        WKInterfaceDevice* device = [WKInterfaceDevice currentDevice];
+        NSMutableDictionary* result = [NSMutableDictionary dictionaryWithDictionary:
+                                       @{
+                                         ADAL_ID_PLATFORM:@"watchOS",
+                                         ADAL_ID_VERSION:[ADLogger getAdalVersion],
+                                         ADAL_ID_OS_VER:device.systemVersion,
+                                         ADAL_ID_DEVICE_MODEL:device.model,
+                                         }];
+
 #else
         NSDictionary *systemVersionDictionary = [NSDictionary dictionaryWithContentsOfFile:
                                                  @"/System/Library/CoreServices/SystemVersion.plist"];

--- a/ADAL/src/cache/ADTokenCacheAccessor.h
+++ b/ADAL/src/cache/ADTokenCacheAccessor.h
@@ -85,4 +85,16 @@
                refreshToken:(NSString *)refreshToken
               correlationId:(NSUUID *)correlationId;
 
+#if TARGET_OS_WATCH
+/*!
+ This is a API exposed to the usage for watchOS only. Note it's still internal in the project. This method will update the ADTokenCacheItem into proper cache system.
+ 
+ @param cacheItem       The ADTokenCacheItem to update into Cache
+ @param MRRT            If the refresh token from cacheItem is a Multi-Resource Refresh Token (MRRT)
+ */
+- (void)updateCacheToItem:(ADTokenCacheItem *)cacheItem
+                     MRRT:(BOOL)isMRRT
+            correlationId:(NSUUID *)correlationId;
+#endif
+
 @end

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -152,12 +152,13 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     // Depending on the environment we may or may not have keychain access groups. Which environments
     // have keychain access group support also varies over time. They should always work on device,
     // in Simulator they work when running within an app bundle but not in unit tests, as of Xcode 7.3
-    
+#if !TARGET_OS_SIMULATOR
     if (_sharedGroup)
     {
         [defaultQuery setObject:_sharedGroup forKey:(id)kSecAttrAccessGroup];
         [defaultTombstoneQuery setObject:_sharedGroup forKey:(id)kSecAttrAccessGroup];
     }
+#endif
     
     _default = defaultQuery;
     _defaultTombstone = defaultTombstoneQuery;

--- a/ADAL/src/public/ADAL.h
+++ b/ADAL/src/public/ADAL.h
@@ -33,9 +33,12 @@ FOUNDATION_EXPORT double ADALFrameworkVersionNumber;
 //! Project version string for ADALFramework.
 FOUNDATION_EXPORT const unsigned char ADALFrameworkVersionString[];
 
-#if TARGET_OS_IPHONE
+#if TARGET_OS_IOS
 //iOS:
 typedef UIWebView WebViewType;
+#elif TARGET_OS_WATCH
+//Watch:
+typedef NSObject WebViewType; // Should never be used
 #else
 //OS X:
 #   include <WebKit/WebKit.h>
@@ -57,7 +60,10 @@ typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
 #import <ADAL/ADTokenCacheItem.h>
 #import <ADAL/ADUserIdentifier.h>
 #import <ADAL/ADUserInformation.h>
+
+#if !TARGET_OS_WATCH
 #import <ADAL/ADWebAuthController.h>
+#endif
 
 #if TARGET_OS_IPHONE
 #import <ADAL/ADKeychainTokenCache.h>

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -415,6 +415,25 @@ typedef enum
                                 userId:(NSString*)userId
                        completionBlock:(ADAuthenticationCallback)completionBlock;
 
+#if TARGET_OS_WATCH
+/*! This is an API exposed for WatchOS only. The authData is the ADTokenCacheItem transmitted from paired phone to watch. Internally, this method will save this authData info into the cache on Watch, and then call acquireTokenSilentWithResource to finish the authentication process as the standard ADAL library does
+ @param authData: the ADTokenCacheItem saved on the paired phone cache and then transmitted from phone to watch
+ @param resource: the resource whose token is needed.
+ @param clientId: the client identifier
+ @param redirectUri: The redirect URI according to OAuth2 protocol
+ @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ it may not be used if it belongs to different token. This parameter can be nil.
+ @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+- (void)acquireTokenSlientWithAuthData:(NSData *)authData
+                              resource:(NSString *)resource
+                              clientId:(NSString *)clientId
+                           redirectUri:(NSURL *)redirectUri
+                       completionBlock:(ADAuthenticationCallback)completionBlock;
+#endif
+
+
+
 @end
 
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.h
@@ -25,6 +25,16 @@
 
 @interface ADAuthenticationRequest (AcquireToken)
 
+#if TARGET_OS_WATCH
+/*! This is an API exposed for WatchOS only. The authData is the ADTokenCacheItem transmitted from paired phone to watch. Internally, this method will save this authData info into the cache on Watch, and then call acquireToken to finish the authentication process as the standard ADAL library does
+ @param authData: the ADTokenCacheItem saved on the paired phone cache and then transmitted from phone to watch
+ @param completionBlock: the callback handler after the authentication finishes
+ */
+- (void)acquireTokenWithAuthData:(NSData *)authData
+                 completionBlock: (ADAuthenticationCallback)completionBlock;
+#endif
+
+
 - (void)acquireToken:(ADAuthenticationCallback)completionBlock;
 
 // For use after the authority has been validated

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -35,6 +35,18 @@
 #pragma mark -
 #pragma mark AcquireToken
 
+#if TARGET_OS_WATCH
+- (void)acquireTokenWithAuthData:(NSData *)authData
+                 completionBlock: (ADAuthenticationCallback)completionBlock
+{
+    ADTokenCacheItem *authInfo = [NSKeyedUnarchiver unarchiveObjectWithData:authData];
+    [_tokenCache updateCacheToItem:authInfo
+                              MRRT:authInfo.isMultiResourceRefreshToken
+                     correlationId:_correlationId];
+    [self acquireToken:completionBlock];
+}
+#endif
+
 - (void)acquireToken:(ADAuthenticationCallback)completionBlock
 {
     THROW_ON_NIL_ARGUMENT(completionBlock);

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -29,8 +29,10 @@
 #import "ADWebResponse.h"
 #import "ADPkeyAuthHelper.h"
 #import "ADAuthenticationSettings.h"
+#if !TARGET_OS_WATCH
 #import "ADWebAuthController.h"
 #import "ADWebAuthController+Internal.h"
+#endif
 #import "ADHelpers.h"
 #import "NSURL+ADExtensions.h"
 #import "ADUserIdentifier.h"
@@ -174,6 +176,14 @@ static ADAuthenticationRequest* s_modalRequest = nil;
 - (void)launchWebView:(NSString*)startUrl
       completionBlock:(void (^)(ADAuthenticationError*, NSURL*))completionBlock
 {
+#if TARGET_OS_WATCH
+    (void)startUrl;
+    (void)completionBlock;
+    @throw [NSException exceptionWithName:@"WebViewException"
+                                   reason:@"WebView is not supported on apple watch"
+                                 userInfo:nil];
+#else
+
     [[ADWebAuthController sharedInstance] start:[NSURL URLWithString:startUrl]
                                             end:[NSURL URLWithString:_redirectUri]
                                     refreshCred:_refreshTokenCredential
@@ -184,6 +194,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
                                         webView:_context.webView
                                   correlationId:_correlationId
                                      completion:completionBlock];
+#endif
 }
 
 //Requests an OAuth2 code to be used for obtaining a token:

--- a/ADAL/src/request/ADWebRequest+NSURLSession.h
+++ b/ADAL/src/request/ADWebRequest+NSURLSession.h
@@ -24,12 +24,16 @@
 @class ADWebRequest;
 @class ADWebResponse;
 
-@interface ADWebRequest : NSObject <NSURLConnectionDelegate>
+typedef enum
 {
-    NSURLConnection * _connection;
-    
+    ADWebRequestGet,
+    ADWebRequestPost,
+} ADWebRequestMethodType;
+
+@interface ADWebRequest : NSObject
+{
     NSURL * _requestURL;
-    NSMutableDictionary* _requestHeaders;
+    NSMutableDictionary * _requestHeaders;
     NSData * _requestData;
     
     NSHTTPURLResponse * _response;
@@ -43,27 +47,25 @@
     
     BOOL _isGetRequest;
     
-    void (^_completionHandler)( NSError *, ADWebResponse *);
+    void (^_completionHandler)(NSError *, ADWebResponse *);
 }
 
-@property (strong, readonly, nonatomic) NSURL               *URL;
-@property (strong, nonatomic)           NSMutableDictionary *headers;
-@property (strong)                      NSData              *body;
-@property (nonatomic)                   NSUInteger           timeout;
-@property BOOL isGetRequest;
-@property (readonly) NSUUID* correlationId;
+@property (strong, readonly, nonatomic)     NSURL               *URL;
+@property (strong, nonatomic)               NSMutableDictionary *headers;
+@property (strong)                          NSData              *body;
+@property (nonatomic)                       NSUInteger          timeout;
+@property                                   BOOL                isGetRequest;
+@property (readonly)                        NSUUID              *correlationId;
 
-- (id)initWithURL: (NSURL*)url
-    correlationId: (NSUUID*) correlationId;
+- (id)initWithURL: (NSURL *)url correlationId: (NSUUID*)correlationId;
 
-- (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
+- (void)send: ( void(^)(NSError *, ADWebResponse *) )completionHandler;
 
 /*!
-    Resends a request. Note, this will cause the completionHandler previously set
-    in -send: to be hit again. As such this method should only be called from
-    within the completionHandler block on -send:
+ Resends a request. Note, this will cause the completionHandler previously set
+ in -send: to be hit again. As such this method should only be called from
+ within the completionHandler block on -send:
  */
 - (void)resend;
 
 @end
-

--- a/ADAL/src/request/ADWebRequest+NSURLSession.m
+++ b/ADAL/src/request/ADWebRequest+NSURLSession.m
@@ -1,0 +1,219 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADAL_Internal.h"
+#import "ADOAuth2Constants.h"
+#import "NSURL+ADExtensions.h"
+#import "ADErrorCodes.h"
+#import "NSString+ADHelperMethods.h"
+#import "ADWebResponse.h"
+#import "ADAuthenticationSettings.h"
+#import "ADHelpers.h"
+#import "ADLogger+Internal.h"
+#import "ADURLProtocol.h"
+#import "ADWebRequest+NSURLSession.h"
+
+@interface ADWebRequest ()
+
+- (void)completeWithError:(NSError *)error andResponse:(ADWebResponse *)response;
+- (void)send;
+- (BOOL)verifyRequestURL:(NSURL *)requestURL;
+
+@end
+
+@implementation ADWebRequest
+
+#pragma mark - Properties
+
+@synthesize URL      = _requestURL;
+@synthesize headers  = _requestHeaders;
+@synthesize timeout  = _timeout;
+@synthesize isGetRequest = _isGetRequest;
+@synthesize correlationId = _correlationId;
+
+- (NSData *)body
+{
+    return _requestData;
+}
+
+- (void)setBody:(NSData *)body
+{
+    if (body != nil) {
+        if (_requestData == body) {
+            return;
+        }
+        SAFE_ARC_RELEASE(_requestData);
+        _requestData = [body copy];
+    }
+}
+
+#pragma mark - Initialization
+
+- (id)initWithURL:(NSURL *)url correlationId:(NSUUID *)correlationId
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+    
+    _requestURL = [url copy];
+    _requestHeaders = [[NSMutableDictionary alloc] init];
+    
+    // Default timeout for ADWebRequest is 30 seconds
+    _timeout = [[ADAuthenticationSettings sharedInstance] requestTimeOut];
+    
+    _correlationId = correlationId;
+    SAFE_ARC_RETAIN(_correlationId);
+    
+    _operationQueue = [[NSOperationQueue alloc] init];
+    [_operationQueue setMaxConcurrentOperationCount:1];
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    SAFE_ARC_RELEASE(_requestURL);
+    _requestURL = nil;
+    
+    SAFE_ARC_RELEASE(_requestHeaders);
+    _requestHeaders = nil;
+    SAFE_ARC_RELEASE(_requestData);
+    _requestData = nil;
+    
+    SAFE_ARC_RELEASE(_response);
+    _response = nil;
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData = nil;
+    
+    SAFE_ARC_RELEASE(_correlationId);
+    _correlationId = nil;
+    
+    SAFE_ARC_RELEASE(_operationQueue);
+    _operationQueue = nil;
+    
+    SAFE_ARC_RELEASE(_completionHandler);
+    _completionHandler = nil;
+    
+    SAFE_ARC_SUPER_DEALLOC();
+}
+
+// Cleans up and then calls the completion handler
+- (void)completeWithError:(NSError *)error andResponse:(ADWebResponse *)response
+{
+    // Cleanup
+    SAFE_ARC_RELEASE(_response);
+    _response       = nil;
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData   = nil;
+    
+    _completionHandler(error, response);
+}
+
+- (void)send:(void (^)(NSError *, ADWebResponse *))completionHandler
+{
+    SAFE_ARC_RELEASE(_completionHandler);
+    _completionHandler = [completionHandler copy];
+    
+    SAFE_ARC_RELEASE(_response);
+    _response          = nil;
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData      = [[NSMutableData alloc] init];
+    
+    [self send];
+}
+
+- (void)resend
+{
+    SAFE_ARC_RELEASE(_response);
+    _response          = nil;
+    SAFE_ARC_RELEASE(_responseData);
+    _responseData      = [[NSMutableData alloc] init];
+    
+    [self send];
+}
+
+- (void)send
+{
+    [_requestHeaders addEntriesFromDictionary:[ADLogger adalId]];
+    // Correlation id:
+    if (_correlationId) {
+        [_requestHeaders addEntriesFromDictionary:
+         @{
+           OAUTH2_CORRELATION_ID_REQUEST:@"true",
+           OAUTH2_CORRELATION_ID_REQUEST_VALUE:[_correlationId UUIDString]
+           }];
+    }
+    
+    // If there is request data, then set the Content-Length header
+    if (_requestData != nil) {
+        [_requestHeaders setValue:[NSString stringWithFormat:@"%ld", (unsigned long)_requestData.length] forKey:@"Content-Length"];
+    }
+    
+    NSURL* requestURL = [ADHelpers addClientVersionToURL:_requestURL];
+    NSMutableURLRequest *request = [[NSMutableURLRequest alloc] initWithURL:requestURL
+                                                                cachePolicy:NSURLRequestReloadIgnoringCacheData timeoutInterval:_timeout];
+    request.HTTPMethod = _isGetRequest ? @"GET" : @"POST";
+    request.allHTTPHeaderFields = _requestHeaders;
+    request.HTTPBody = _requestData;
+    
+    // For some reason, setting cutom properties in request on watchOS doesn't work properly
+    //[ADURLProtocol addCorrelationId:_correlationId toRequest:request];
+    
+    NSURLSessionConfiguration *config = [NSURLSessionConfiguration defaultSessionConfiguration];
+    NSURLSession *session = [NSURLSession sessionWithConfiguration:config
+                                                          delegate:nil
+                                                     delegateQueue:_operationQueue];
+    
+    [[session dataTaskWithRequest:request
+                completionHandler:^(NSData * _Nullable data,
+                                    NSURLResponse * _Nullable response,
+                                    NSError * _Nullable error) {
+        if(error){
+            [self completeWithError:error andResponse:nil];
+        }
+        else {
+            _response = (NSHTTPURLResponse *)response;
+            [_responseData appendData:data];
+
+            NSAssert(_response != nil, @"No HTTP Response available");
+            ADWebResponse *response = [[ADWebResponse alloc] initWithResponse:_response data:_responseData];
+            SAFE_ARC_AUTORELEASE(response);
+            
+            [self completeWithError:nil andResponse:response];
+        }
+    }] resume];
+    SAFE_ARC_RELEASE(request);
+}
+
+- (BOOL)verifyRequestURL:(NSURL *)requestURL
+{
+    if (requestURL == nil)
+        return NO;
+    
+    if (![requestURL.scheme isEqualToString:@"http"] && ![requestURL.scheme isEqualToString:@"https"])
+        return NO;
+    
+    return YES;
+}
+
+@end


### PR DESCRIPTION
This commit include the changes to extend existing ADAL framework to work on WatchOS platform (Supporting WatchOS 2.0). There are several key changes to achieve the goal:

- A new ALDAL framework targeting at WatchOS. This include necessary source files to cover most ADAL functionality working properly on WatchOS. It doesn't support sign in interactively through ADAL as WatchOS doesn't support WebView. It doesn't support NTLM authentication either;

- Several new APIs to support WatchOS authenticate user by using existing authentication cache information stored on companion iOS. As long as iOS has authenticated user successfully, watchOS could ask for the stored cache and then calling the new APIs to authenticate locally on Watch;

- Replaced the NSURLConnection with NSURLSession on WatchOS since NSURLConnection is deprecated and forbidded on WatchOS.