### PR TITLE
Fix thread safety issues in -[ADTokenCache serialize]

### DIFF
--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -71,10 +71,12 @@
 
 - (id)cacheObjectForKey:(id<NSCopying>)key
 {
+    id object = nil;
     @synchronized(self)
     {
-        return _cache[key];
+        object = _cache[key];
     }
+    return object;
 }
 
 - (void)setCache:(NSMutableDictionary *)newCache
@@ -89,10 +91,13 @@
 
 - (NSMutableDictionary *)cacheCopy
 {
+    NSMutableDictionary *copy = nil;
     @synchronized(self)
     {
-        return [_cache mutableCopy];
+        copy = [_cache mutableCopy];
     }
+    SAFE_ARC_AUTORELEASE(copy);
+    return copy;
 }
 
 - (BOOL)hasCache

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -69,6 +69,40 @@
     SAFE_ARC_SUPER_DEALLOC();
 }
 
+- (id)cacheObjectForKey:(id<NSCopying>)key
+{
+    @synchronized(self)
+    {
+        return _cache[key];
+    }
+}
+
+- (void)setCache:(NSMutableDictionary *)newCache
+{
+    @synchronized(self)
+    {
+        SAFE_ARC_RELEASE(_cache);
+        _cache = newCache;
+        SAFE_ARC_RETAIN(_cache);
+    }
+}
+
+- (NSMutableDictionary *)cacheCopy
+{
+    @synchronized(self)
+    {
+        return [_cache mutableCopy];
+    }
+}
+
+- (BOOL)hasCache
+{
+    @synchronized(self)
+    {
+        return _cache != nil;
+    }
+}
+
 - (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate
 {
     if (_delegate == delegate)

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -275,36 +275,34 @@
     }
 }
 
+// This call is synchronized in the calling method, getItemsWithKey:userId:correlationId:error:
 - (NSArray<ADTokenCacheItem *> *)getItemsImplKey:(nullable ADTokenCacheKey *)key
                                           userId:(nullable NSString *)userId
 {
-    @synchronized(self)
+    NSDictionary* tokens = [_cache objectForKey:@"tokens"];
+    if (!tokens)
     {
-        NSDictionary* tokens = [_cache objectForKey:@"tokens"];
-        if (!tokens)
-        {
-            return nil;
-        }
+        return nil;
+    }
 
-        NSMutableArray* items = [NSMutableArray new];
-        SAFE_ARC_AUTORELEASE(items);
+    NSMutableArray* items = [NSMutableArray new];
+    SAFE_ARC_AUTORELEASE(items);
 
-        if (userId)
+    if (userId)
+    {
+        // If we have a specified userId then we only look for that one
+        [self addToItems:items forUserId:userId tokens:tokens key:key];
+    }
+    else
+    {
+        // Otherwise we have to traverse all of the users in the cache
+        for (NSString* userId in tokens)
         {
-            // If we have a specified userId then we only look for that one
             [self addToItems:items forUserId:userId tokens:tokens key:key];
         }
-        else
-        {
-            // Otherwise we have to traverse all of the users in the cache
-            for (NSString* userId in tokens)
-            {
-                [self addToItems:items forUserId:userId tokens:tokens key:key];
-            }
-        }
-        
-        return items;
     }
+    
+    return items;
 }
 
 


### PR DESCRIPTION
ADTokenCache accesses its _cache instance variable, which is an NSMutableDictionary, in an unsafe manner. This pull request naively synchronizes all access to the _cache. See https://github.com/AzureAD/azure-activedirectory-library-for-objc/issues/710