### PR TITLE
Add a rwlock to protect the _cache dictionary

### DIFF
--- a/ADAL/src/public/mac/ADTokenCache.h
+++ b/ADAL/src/public/mac/ADTokenCache.h
@@ -43,6 +43,7 @@
 {
     NSMutableDictionary* _cache;
     id<ADTokenCacheDelegate> _delegate;
+    pthread_rwlock_t _lock;
 }
 
 - (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate;


### PR DESCRIPTION
Bad things can happen if the cache dictionary gets modified while we're trying to serialize it. Protect it with a rw lock.