### PR TITLE
whitelist redirect uri that starts with "http://"

### DIFF
--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -555,7 +555,7 @@ correlationId:(NSUUID *)correlationId
     _completionBlock = [completionBlock copy];
     ADAuthenticationError* error = nil;
     
-    [ADURLProtocol registerProtocol];
+    [ADURLProtocol registerProtocol:[endURL absoluteString]];
     
     if(![NSString adIsStringNilOrBlank:refreshCred])
     {

--- a/ADAL/src/urlprotocol/ADURLProtocol.h
+++ b/ADAL/src/urlprotocol/ADURLProtocol.h
@@ -46,7 +46,7 @@
 + (void)registerHandler:(Class<ADAuthMethodHandler>)handler
              authMethod:(NSString *)authMethod;
 
-+ (BOOL)registerProtocol;
++ (BOOL)registerProtocol:(NSString*)endURL;
 + (void)unregisterProtocol;
 
 + (void)addCorrelationId:(NSUUID *)correlationId

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -62,8 +62,11 @@ static NSUUID * _reqCorId(NSURLRequest* request)
 
 + (BOOL)registerProtocol:(NSString*)endURL
 {
-    s_endURL = endURL;
-    SAFE_ARC_RETAIN(s_endURL);
+    if (s_endURL!=endURL)
+    {
+        s_endURL = endURL;
+        SAFE_ARC_RETAIN(s_endURL);
+    }
     return [NSURLProtocol registerClass:self];
 }
 
@@ -208,8 +211,13 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
     // Disallow HTTP for ADURLProtocol
     if ([request.URL.scheme isEqualToString:@"http"])
     {
+        if (!s_endURL)
+        {
+            return nil;
+        }
+        
         // end url is whitelisted regardless of the url format
-        if (s_endURL && ![[request.URL.absoluteString lowercaseString] hasPrefix:[s_endURL lowercaseString]])
+        if (![[request.URL.absoluteString lowercaseString] hasPrefix:[s_endURL lowercaseString]])
         {
             return nil;
         }


### PR DESCRIPTION
Fix #720 

Url loaded in webview will be filtered out if it is a http connection. Now changes have been made to whitelist the redirect uri, which is the end url used to go back to the app, regardless of its uri format.