### PR TITLE
Fix issue in ADURLProtocol when URLs get canonicalized

### DIFF
--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -417,6 +417,19 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
     {
         return;
     }
+    
+    // If we failed on an invalid URL check to see if it matches our end URL
+    if ([error.domain isEqualToString:@"NSURLErrorDomain"] && error.code == -1002)
+    {
+        NSURL* url = [error.userInfo objectForKey:NSURLErrorFailingURLErrorKey];
+        if ([[[url absoluteString] lowercaseString] hasPrefix:_endURL])
+        {
+            _complete = YES;
+            [self webAuthDidCompleteWithURL:url];
+            return;
+        }
+        
+    }
 
     if (error)
     {


### PR DESCRIPTION
Remove  [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:response] call. This would cause multiple requests to the same endpoint that could break some configurations.

Replace the @"ADURLProtocol" string with a constant.