### PR TITLE
Fix logging error from UI code copy-over

### DIFF
--- a/ADALiOS/ADALiOS/ADLogger.m
+++ b/ADALiOS/ADALiOS/ADLogger.m
@@ -160,10 +160,15 @@ static NSUUID* s_requestCorrelationId;
   errorCode:(NSInteger)code
      format:(NSString*)format, ...
 {
-    va_list args;
-    va_start(args, format);
-    NSString* info = [[NSString alloc] initWithFormat:format arguments:args];
-    va_end(args);
+    NSString* info = nil;
+    
+    if (format)
+    {
+        va_list args;
+        va_start(args, format);
+        NSString* info = [[NSString alloc] initWithFormat:format arguments:args];
+        va_end(args);
+    }
     
     [self log:level message:message errorCode:code info:info];
 }

--- a/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
+++ b/ADALiOS/ADALiOS/ADWorkPlaceJoinUtil.m
@@ -75,7 +75,7 @@ goto _error; \
     
     
     
-    AD_LOG_VERBOSE_F(@"Attempting to get registration information - ", nil, @"%@ shared access Group", sharedAccessGroup);
+    AD_LOG_VERBOSE_F(@"Attempting to get registration information - ", @"%@ shared access Group", sharedAccessGroup);
     
     SecIdentityRef identity = NULL;
     SecCertificateRef certificate = NULL;


### PR DESCRIPTION
Remove an errant 'nil' that should have been removed in the copy-and-paste and guard against any nils that might get passed through to the logged in the future (just in case)