### PR TITLE
Fix xcconfig assignments

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -2569,7 +2569,7 @@
 		};
 		D61001021D3984F00087AB81 /* CodeCoverage */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347841C644E13000A6DA1 /* adal__ios__framework.xcconfig */;
+			baseConfigurationReference = D61001581D398A560087AB81 /* adal__ios__app_extension__framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
@@ -2601,7 +2601,7 @@
 		};
 		D61001031D3984F00087AB81 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347841C644E13000A6DA1 /* adal__ios__framework.xcconfig */;
+			baseConfigurationReference = D61001581D398A560087AB81 /* adal__ios__app_extension__framework.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;


### PR DESCRIPTION
Fix xcconfig assignments in `ADAL (Project) > Info`

The `CodeCoverage > ADAL > ADAL (extension safe)` and `Release > ADAL > ADAL (extension safe)` needed to be pointed to `adal__ios__app_extension__framework.xcconfig` instead of `adal__ios__framework`.

This should have impacted consumers of the ADAL (extension safe) framework if they built it with CodeCoverage or Release Mode. I guess it could've gone as far as running code intended for main app only in app extension contexts.