### PR TITLE
Add build script to generate version number for info.plist

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -269,6 +269,27 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		60967E131D76B5CC00863853 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 60967E071D76B56D00863853;
+			remoteInfo = "ADAL Preprocessing";
+		};
+		60967E151D76B5D300863853 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 60967E071D76B56D00863853;
+			remoteInfo = "ADAL Preprocessing";
+		};
+		60967E171D76B5E000863853 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 60967E071D76B56D00863853;
+			remoteInfo = "ADAL Preprocessing";
+		};
 		9453C45C1C5866D8006B9E79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
@@ -307,6 +328,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
+		60967E061D76B56D00863853 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B0965A817F25770002BDFB8 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 12;
@@ -349,6 +379,8 @@
 		601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthControllerTests.m; sourceTree = "<group>"; };
 		6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLConnection.h; sourceTree = "<group>"; };
 		6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLConnection.m; sourceTree = "<group>"; };
+		60967E081D76B56D00863853 /* libADAL Preprocessing.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libADAL Preprocessing.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		60967E191D76B62B00863853 /* tools */ = {isa = PBXFileReference; lastKnownFileType = folder; path = tools; sourceTree = SOURCE_ROOT; };
 		8B0965AA17F25770002BDFB8 /* libADALiOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libADALiOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B0965AD17F25770002BDFB8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		8B0965BA17F25770002BDFB8 /* ADALiOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ADALiOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -527,6 +559,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		60967E051D76B56D00863853 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B0965A717F25770002BDFB8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -607,6 +646,7 @@
 				8B0965C317F25770002BDFB8 /* tests */,
 				9453C3151C57EE57006B9E79 /* resouces */,
 				94886EED1C63BE3800503C04 /* xcconfig */,
+				60967E191D76B62B00863853 /* tools */,
 				8B0965AC17F25770002BDFB8 /* Frameworks */,
 				8B0965AB17F25770002BDFB8 /* Products */,
 			);
@@ -623,6 +663,7 @@
 				9453C3FD1C586425006B9E79 /* ADAL.framework */,
 				94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */,
 				D664F1B41D302B9C0017B799 /* libADAL-core.a */,
+				60967E081D76B56D00863853 /* libADAL Preprocessing.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1127,6 +1168,24 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		60967E071D76B56D00863853 /* ADAL Preprocessing */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 60967E111D76B56D00863853 /* Build configuration list for PBXNativeTarget "ADAL Preprocessing" */;
+			buildPhases = (
+				60967E041D76B56D00863853 /* Sources */,
+				60967E051D76B56D00863853 /* Frameworks */,
+				60967E061D76B56D00863853 /* CopyFiles */,
+				60967E121D76B5AC00863853 /* ShellScript */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "ADAL Preprocessing";
+			productName = "ADAL Preprocessing";
+			productReference = 60967E081D76B56D00863853 /* libADAL Preprocessing.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 		8B0965A917F25770002BDFB8 /* ADALiOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B0965CD17F25770002BDFB8 /* Build configuration list for PBXNativeTarget "ADALiOS" */;
@@ -1138,6 +1197,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				60967E141D76B5CC00863853 /* PBXTargetDependency */,
 			);
 			name = ADALiOS;
 			productName = ADALiOS;
@@ -1193,6 +1253,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				60967E181D76B5E000863853 /* PBXTargetDependency */,
 			);
 			name = "ADAL Mac";
 			productName = "ADAL Mac";
@@ -1227,6 +1288,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				60967E161D76B5D300863853 /* PBXTargetDependency */,
 			);
 			name = "ADAL-core";
 			productName = ADALiOS;
@@ -1242,6 +1304,9 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "MS Open Tech";
 				TargetAttributes = {
+					60967E071D76B56D00863853 = {
+						CreatedOnToolsVersion = 7.3.1;
+					};
 					9453C3CB1C583E07006B9E79 = {
 						CreatedOnToolsVersion = 7.2;
 					};
@@ -1268,6 +1333,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
+				60967E071D76B56D00863853 /* ADAL Preprocessing */,
 				8B0965A917F25770002BDFB8 /* ADALiOS */,
 				D664F16A1D302B9C0017B799 /* ADAL-core */,
 				9453C3CB1C583E07006B9E79 /* ADAL */,
@@ -1311,7 +1377,30 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		60967E121D76B5AC00863853 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${PROJECT_DIR}/resources/ios/Framework/Info.plist ${PROJECT_DIR}/resources/ios/ADALiOSBundle/ADALiOSBundle-Info.plist";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
+		60967E041D76B56D00863853 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8B0965A617F25770002BDFB8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1509,6 +1598,21 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		60967E141D76B5CC00863853 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
+			targetProxy = 60967E131D76B5CC00863853 /* PBXContainerItemProxy */;
+		};
+		60967E161D76B5D300863853 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
+			targetProxy = 60967E151D76B5D300863853 /* PBXContainerItemProxy */;
+		};
+		60967E181D76B5E000863853 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
+			targetProxy = 60967E171D76B5E000863853 /* PBXContainerItemProxy */;
+		};
 		9453C45D1C5866D8006B9E79 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9453C3FC1C586425006B9E79 /* ADAL Mac */;
@@ -1556,6 +1660,65 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		60967E0E1D76B56D00863853 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		60967E0F1D76B56D00863853 /* CodeCoverage */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = CodeCoverage;
+		};
+		60967E101D76B56D00863853 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		8B0965CB17F25770002BDFB8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347821C644E13000A6DA1 /* adal__debug.xcconfig */;
@@ -2189,6 +2352,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		60967E111D76B56D00863853 /* Build configuration list for PBXNativeTarget "ADAL Preprocessing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				60967E0E1D76B56D00863853 /* Debug */,
+				60967E0F1D76B56D00863853 /* CodeCoverage */,
+				60967E101D76B56D00863853 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		8B0965A517F25770002BDFB8 /* Build configuration list for PBXProject "ADAL" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -269,27 +269,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		60967E131D76B5CC00863853 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 60967E071D76B56D00863853;
-			remoteInfo = "ADAL Preprocessing";
-		};
-		60967E151D76B5D300863853 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 60967E071D76B56D00863853;
-			remoteInfo = "ADAL Preprocessing";
-		};
-		60967E171D76B5E000863853 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 60967E071D76B56D00863853;
-			remoteInfo = "ADAL Preprocessing";
-		};
 		9453C45C1C5866D8006B9E79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
@@ -328,15 +307,6 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		60967E061D76B56D00863853 /* CopyFiles */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "include/$(PRODUCT_NAME)";
-			dstSubfolderSpec = 16;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8B0965A817F25770002BDFB8 /* Copy Files */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 12;
@@ -379,7 +349,6 @@
 		601BEE331C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthControllerTests.m; sourceTree = "<group>"; };
 		6071B5E21C14C0B0006F6CC2 /* ADTestURLConnection.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLConnection.h; sourceTree = "<group>"; };
 		6071B5E31C14C0B0006F6CC2 /* ADTestURLConnection.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLConnection.m; sourceTree = "<group>"; };
-		60967E081D76B56D00863853 /* libADAL Preprocessing.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libADAL Preprocessing.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		60967E191D76B62B00863853 /* tools */ = {isa = PBXFileReference; lastKnownFileType = folder; path = tools; sourceTree = SOURCE_ROOT; };
 		8B0965AA17F25770002BDFB8 /* libADALiOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libADALiOS.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B0965AD17F25770002BDFB8 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -559,13 +528,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		60967E051D76B56D00863853 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8B0965A717F25770002BDFB8 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -663,7 +625,6 @@
 				9453C3FD1C586425006B9E79 /* ADAL.framework */,
 				94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */,
 				D664F1B41D302B9C0017B799 /* libADAL-core.a */,
-				60967E081D76B56D00863853 /* libADAL Preprocessing.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1168,28 +1129,11 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		60967E071D76B56D00863853 /* ADAL Preprocessing */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 60967E111D76B56D00863853 /* Build configuration list for PBXNativeTarget "ADAL Preprocessing" */;
-			buildPhases = (
-				60967E041D76B56D00863853 /* Sources */,
-				60967E051D76B56D00863853 /* Frameworks */,
-				60967E061D76B56D00863853 /* CopyFiles */,
-				60967E121D76B5AC00863853 /* ShellScript */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "ADAL Preprocessing";
-			productName = "ADAL Preprocessing";
-			productReference = 60967E081D76B56D00863853 /* libADAL Preprocessing.a */;
-			productType = "com.apple.product-type.library.static";
-		};
 		8B0965A917F25770002BDFB8 /* ADALiOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8B0965CD17F25770002BDFB8 /* Build configuration list for PBXNativeTarget "ADALiOS" */;
 			buildPhases = (
+				6079EB5B1D79558000E95AB1 /* ShellScript */,
 				8B0965A817F25770002BDFB8 /* Copy Files */,
 				8B0965A617F25770002BDFB8 /* Sources */,
 				8B0965A717F25770002BDFB8 /* Frameworks */,
@@ -1197,7 +1141,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				60967E141D76B5CC00863853 /* PBXTargetDependency */,
 			);
 			name = ADALiOS;
 			productName = ADALiOS;
@@ -1226,6 +1169,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9453C3D11C583E07006B9E79 /* Build configuration list for PBXNativeTarget "ADAL" */;
 			buildPhases = (
+				6079EB5A1D7954EF00E95AB1 /* ShellScript */,
 				9453C3C71C583E07006B9E79 /* Sources */,
 				9453C3C81C583E07006B9E79 /* Frameworks */,
 				9453C3C91C583E07006B9E79 /* Headers */,
@@ -1245,6 +1189,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 9453C4051C586425006B9E79 /* Build configuration list for PBXNativeTarget "ADAL Mac" */;
 			buildPhases = (
+				6079EB5D1D79559500E95AB1 /* ShellScript */,
 				9453C3F81C586425006B9E79 /* Sources */,
 				9453C3F91C586425006B9E79 /* Frameworks */,
 				9453C3FA1C586425006B9E79 /* Headers */,
@@ -1253,7 +1198,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				60967E181D76B5E000863853 /* PBXTargetDependency */,
 			);
 			name = "ADAL Mac";
 			productName = "ADAL Mac";
@@ -1282,13 +1226,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = D664F1B01D302B9C0017B799 /* Build configuration list for PBXNativeTarget "ADAL-core" */;
 			buildPhases = (
+				6079EB5C1D79558700E95AB1 /* ShellScript */,
 				D664F1791D302B9C0017B799 /* Sources */,
 				D664F1AD1D302B9C0017B799 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				60967E161D76B5D300863853 /* PBXTargetDependency */,
 			);
 			name = "ADAL-core";
 			productName = ADALiOS;
@@ -1304,9 +1248,6 @@
 				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "MS Open Tech";
 				TargetAttributes = {
-					60967E071D76B56D00863853 = {
-						CreatedOnToolsVersion = 7.3.1;
-					};
 					9453C3CB1C583E07006B9E79 = {
 						CreatedOnToolsVersion = 7.2;
 					};
@@ -1333,7 +1274,6 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				60967E071D76B56D00863853 /* ADAL Preprocessing */,
 				8B0965A917F25770002BDFB8 /* ADALiOS */,
 				D664F16A1D302B9C0017B799 /* ADAL-core */,
 				9453C3CB1C583E07006B9E79 /* ADAL */,
@@ -1378,7 +1318,7 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		60967E121D76B5AC00863853 /* ShellScript */ = {
+		6079EB5A1D7954EF00E95AB1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1389,18 +1329,50 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${PROJECT_DIR}/resources/ios/Framework/Info.plist ${PROJECT_DIR}/resources/ios/ADALiOSBundle/ADALiOSBundle-Info.plist";
+			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+		};
+		6079EB5B1D79558000E95AB1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+		};
+		6079EB5C1D79558700E95AB1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+		};
+		6079EB5D1D79559500E95AB1 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
 		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		60967E041D76B56D00863853 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		8B0965A617F25770002BDFB8 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1598,21 +1570,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		60967E141D76B5CC00863853 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
-			targetProxy = 60967E131D76B5CC00863853 /* PBXContainerItemProxy */;
-		};
-		60967E161D76B5D300863853 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
-			targetProxy = 60967E151D76B5D300863853 /* PBXContainerItemProxy */;
-		};
-		60967E181D76B5E000863853 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 60967E071D76B56D00863853 /* ADAL Preprocessing */;
-			targetProxy = 60967E171D76B5E000863853 /* PBXContainerItemProxy */;
-		};
 		9453C45D1C5866D8006B9E79 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 9453C3FC1C586425006B9E79 /* ADAL Mac */;
@@ -1660,65 +1617,6 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
-		60967E0E1D76B56D00863853 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				MTL_ENABLE_DEBUG_INFO = YES;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Debug;
-		};
-		60967E0F1D76B56D00863853 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = CodeCoverage;
-		};
-		60967E101D76B56D00863853 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SKIP_INSTALL = YES;
-			};
-			name = Release;
-		};
 		8B0965CB17F25770002BDFB8 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347821C644E13000A6DA1 /* adal__debug.xcconfig */;
@@ -2352,15 +2250,6 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		60967E111D76B56D00863853 /* Build configuration list for PBXNativeTarget "ADAL Preprocessing" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				60967E0E1D76B56D00863853 /* Debug */,
-				60967E0F1D76B56D00863853 /* CodeCoverage */,
-				60967E101D76B56D00863853 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-		};
 		8B0965A517F25770002BDFB8 /* Build configuration list for PBXProject "ADAL" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -21,26 +21,30 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//iOS does not support resources in client libraries. Hence putting the
-//version in static define until we identify a better place:
+// iOS does not support resources in client libraries. Hence putting the
+// version in static define until we identify a better place.
+// (Note: All Info.plist files read version numbers from the following three lines
+// through build script. Don't change its format unless changing build script as well.)
 #define ADAL_VER_HIGH       2
 #define ADAL_VER_LOW        2
-#define ADAL_VER_PATCH      3
+#define ADAL_VER_PATCH      4
 
-#define STR_ADAL_VER_HIGH   "2"
-#define STR_ADAL_VER_LOW    "2"
-#define STR_ADAL_VER_PATCH  "4"
+#define STR_HELPER(x) #x
+#define STR(x) STR_HELPER(x)
+#define INT_CONCAT_HELPER(x,y) x ## . ## y
+#define INT_CONCAT(x,y) INT_CONCAT_HELPER(x,y)
 
 // Framework versions only support high and low for the double value, sadly.
-#define ADAL_VERSION_NUMBER 2.2
+#define ADAL_VERSION_NUMBER INT_CONCAT(ADAL_VER_HIGH, ADAL_VER_LOW)
 
-#define ADAL_VERSION_STRING     STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
-#define ADAL_VERSION_NSSTRING   @"" STR_ADAL_VER_HIGH "." STR_ADAL_VER_LOW "." STR_ADAL_VER_PATCH
+#define ADAL_VERSION_STRING     STR(ADAL_VER_HIGH) "." STR(ADAL_VER_LOW) "." STR(ADAL_VER_PATCH)
+#define ADAL_VERSION_NSSTRING   @"" STR(ADAL_VER_HIGH) "." STR(ADAL_VER_LOW) "." STR(ADAL_VER_PATCH)
 
-#define ADAL_VERSION_(high, low, patch) adalVersion_ ## high ## _ ## low ## _ ## patch
+#define ADAL_VERSION_HELPER(high, low, patch) adalVersion_ ## high ## _ ## low ## _ ## patch
+#define ADAL_VERSION_(high, low, patch) ADAL_VERSION_HELPER(high, low, patch)
 
 // This is specially crafted so the name of the variable matches the full ADAL version
-#define ADAL_VERSION_VAR ADAL_VERSION_(2, 2, 4)
+#define ADAL_VERSION_VAR ADAL_VERSION_(ADAL_VER_HIGH, ADAL_VER_LOW, ADAL_VER_PATCH)
 
 #import "ADLogger+Internal.h"
 #import "ADErrorCodes.h"

--- a/ADAL/tools/update_build_version.py
+++ b/ADAL/tools/update_build_version.py
@@ -1,0 +1,60 @@
+#!/usr/bin/python
+
+import sys, os, subprocess, re
+
+def read_verfile(name):
+    ver_high = None
+    ver_low = None
+    ver_patch = None
+    verfile = open(name, "r")
+    for line in verfile:
+        match = re.match(r"^#define\s+ADAL_VER_HIGH\s+(\S+)", line)
+        if match:
+            ver_high = match.group(1).rstrip()
+        match = re.match(r"^#define\s+ADAL_VER_LOW\s+(\S+)", line)
+        if match:
+            ver_low = match.group(1).rstrip()
+        match = re.match(r"^#define\s+ADAL_VER_PATCH\s+(\S+)", line)
+        if match:
+            ver_patch = match.group(1).rstrip()
+    verfile.close()
+    return '.'.join([ver_high, ver_low, ver_patch])
+
+def set_plist_version(plistname, version):
+    if not os.path.exists(plistname):
+        print("{0} does not exist".format(plistname))
+        return False
+    
+    plistbuddy = '/usr/libexec/Plistbuddy'
+    if not os.path.exists(plistbuddy):
+        print("{0} does not exist".format(plistbuddy))
+        return False
+    
+    cmdline = [plistbuddy,
+               "-c", "Set CFBundleShortVersionString {0}".format(version),
+               plistname]
+    if subprocess.call(cmdline) != 0:
+        print("Failed to update {0}".format(plistname))
+        return False
+    
+    print("Updated {0} with v{1}".format(plistname, version))
+    return True
+
+if __name__ == "__main__":
+    
+    if len(sys.argv) < 3:
+        print("Command in Run Script not properly set. Usage: {0} version_file Info.plist [... Info.plist]".format(sys.argv[0]))
+        sys.exit(1)
+    vername = sys.argv[1]
+
+    version = read_verfile(vername)
+    if version == None:
+        print("No version has been read.")
+        sys.exit(2)
+
+    for i in range(2, len(sys.argv)):
+        plistname = sys.argv[i]
+        print(plistname)
+        set_plist_version(plistname, version)
+    
+    sys.exit(0)


### PR DESCRIPTION
(address #740)

- A build script has been added, which will read version number from ADAL_Internal.h and add it to each Info.plist file.
(In order to run this script before an Info.plist is processed, i have to create a new build target called "ADAL Preprocessing", and then make other target dependent on it.)

- Changes have been made to the Macro in ADAL_Internal.h, such that version nubmers are defined in a single place.