### PR TITLE
NTLM fix

### DIFF
--- a/ADALiOS/ADALiOS/ADNTLMHandler.m
+++ b/ADALiOS/ADALiOS/ADNTLMHandler.m
@@ -96,7 +96,7 @@ static NSURLConnection *_conn = nil;
             } else {
                 _challengeCancelled = YES;
                 [challenge.sender performDefaultHandlingForAuthenticationChallenge:challenge];
-                [protocol stopLoading];
+                [protocol connection:connection didFailWithError:[NSError errorWithDomain:ADAuthenticationErrorDomain code:AD_ERROR_USER_CANCEL userInfo:nil]];
             }
         }];
         succeeded = YES;

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -219,10 +219,10 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
     {
         // If we're being redirected by the server that will create a whole new connection that we still need to observe
         [NSURLProtocol removePropertyForKey:kADURLProtocolPropertyKey inRequest:mutableRequest];
+        [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:redirectResponse];
     }
     
     [ADCustomHeaderHandler applyCustomHeadersTo:mutableRequest];
-    [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:redirectResponse];
     return mutableRequest;
 }
 


### PR DESCRIPTION
this PR includes fixes for supporting NTLM auth and ensuring the webview is closed when the user presses cancel on the NTLM dialog.