### PR TITLE
Bring back the connection canceling and error sending. 

### DIFF
--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -428,6 +428,13 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
         return;
     }
     
+    // Prior to iOS 10 the WebView trapped out this error code and didn't pass it along to us
+    // now we have to trap it out ourselves.
+    if ([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSUserCancelledError)
+    {
+        return;
+    }
+    
     // If we failed on an invalid URL check to see if it matches our end URL
     if ([error.domain isEqualToString:@"NSURLErrorDomain"] && (error.code == -1002 || error.code == -1003))
     {

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -213,7 +213,9 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
 
 #pragma mark - NSURLConnectionDataDelegate Methods
 
-- (NSURLRequest *)connection:(NSURLConnection *)connection willSendRequest:(NSURLRequest *)request redirectResponse:(NSURLResponse *)redirectResponse
+- (NSURLRequest *)connection:(NSURLConnection *)connection
+             willSendRequest:(NSURLRequest *)request
+            redirectResponse:(NSURLResponse *)redirectResponse
 {
     (void)connection;
     
@@ -238,16 +240,43 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
     
     NSMutableURLRequest* mutableRequest = [request mutableCopy];
     SAFE_ARC_AUTORELEASE(mutableRequest);
-     
-    if (redirectResponse)
-    {
-        // If we're being redirected by the server that will create a whole new connection that we still need to observe
-        [NSURLProtocol removePropertyForKey:kADURLProtocolPropertyKey inRequest:mutableRequest];
-    }
     
     [ADCustomHeaderHandler applyCustomHeadersTo:mutableRequest];
     [ADURLProtocol addCorrelationId:_correlationId toRequest:mutableRequest];
+
+    if (!redirectResponse)
+    {
+        // If there wasn't a redirect response that means that we're canonicalizing
+        // the URL and don't need to cancel the connection or worry about an infinite
+        // loop happening so we can just return the response now.
+        
+        return mutableRequest;
+    }
+    
+    // If we don't have this line in the redirectResponse case then we get a HTTP too many redirects
+    // error.
+    [NSURLProtocol removePropertyForKey:kADURLProtocolPropertyKey inRequest:mutableRequest];
+    
     [self.client URLProtocol:self wasRedirectedToRequest:mutableRequest redirectResponse:redirectResponse];
+    
+    // If we don't cancel out the connection in the redirectResponse case then we will end up
+    // with duplicate connections
+    
+    // Here are the comments from Apple's CustomHTTPProtocol demo code:
+    // https://developer.apple.com/library/ios/samplecode/CustomHTTPProtocol/Introduction/Intro.html
+    
+    // Stop our load.  The CFNetwork infrastructure will create a new NSURLProtocol instance to run
+    // the load of the redirect.
+    
+    // The following ends up calling -URLSession:task:didCompleteWithError: with NSURLErrorDomain / NSURLErrorCancelled,
+    // which specificallys traps and ignores the error.
+    
+    [_connection cancel];
+    [self.client URLProtocol:self
+            didFailWithError:[NSError errorWithDomain:NSCocoaErrorDomain
+                                                 code:NSUserCancelledError
+                                             userInfo:nil]];
+    
     return mutableRequest;
 }
 


### PR DESCRIPTION
Trap the error in the webview delegate.

Canceling out the connection solves the double-connection issue while still allowing NTLM to work.