### PR TITLE
Added nullable indicators to ADTokenCacheItem to enable Swift support

### DIFF
--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -78,7 +78,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (copy, nullable) NSDate* expiresOn;
 
 
-@property (retain) ADUserInformation* userInformation;
+@property (retain, nullable) ADUserInformation* userInformation;
 
 /*!
  The item is a tombstone if this property if not nil;

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -55,8 +55,10 @@
     NSMutableDictionary* _additionalClient;
 }
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! Applicable resource. Should be nil, in case the item stores multi-resource refresh token. */
-@property (copy) NSString* resource;
+@property (copy, nullable) NSString* resource;
 
 @property (copy) NSString* authority;
 
@@ -65,15 +67,15 @@
 @property (copy) NSString* familyId;
 
 /*! The access token received. Should be nil, in case the item stores multi-resource refresh token. */
-@property (copy) NSString* accessToken;
+@property (copy, nullable) NSString* accessToken;
 
 @property (copy) NSString* accessTokenType;
 
-@property (copy) NSString* refreshToken;
+@property (copy, nullable) NSString* refreshToken;
 
 @property (copy) NSData* sessionKey;
 
-@property (copy) NSDate* expiresOn;
+@property (copy, nullable) NSDate* expiresOn;
 
 
 @property (retain) ADUserInformation* userInformation;
@@ -91,7 +93,7 @@
 /*! Obtains a key to be used for the internal cache from the full cache item.
  @param error: if a key cannot be extracted, the method will return nil and if this parameter is not nil,
  it will be filled with the appropriate error information.*/
-- (ADTokenCacheKey*) extractKey:(ADAuthenticationError * __autoreleasing *)error;
+- (ADTokenCacheKey*) extractKey:(ADAuthenticationError * _Nullable __autoreleasing * _Nullable)error;
 
 /*! Compares expiresOn with the current time. If expiresOn is not nil, the function returns the
  comparison of expires on and the current time. If expiresOn is nil, the function returns NO,
@@ -110,3 +112,5 @@
 - (BOOL)isMultiResourceRefreshToken;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -62,18 +62,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (copy) NSString* authority;
 
-@property (copy) NSString* clientId;
+@property (copy, nullable) NSString* clientId;
 
-@property (copy) NSString* familyId;
+@property (copy, nullable) NSString* familyId;
 
 /*! The access token received. Should be nil, in case the item stores multi-resource refresh token. */
 @property (copy, nullable) NSString* accessToken;
 
-@property (copy) NSString* accessTokenType;
+@property (copy, nullable) NSString* accessTokenType;
 
 @property (copy, nullable) NSString* refreshToken;
 
-@property (copy) NSData* sessionKey;
+@property (copy, nullable) NSData* sessionKey;
 
 @property (copy, nullable) NSDate* expiresOn;
 

--- a/Samples/SampleSwiftApp/SampleSwiftApp/ViewController.swift
+++ b/Samples/SampleSwiftApp/SampleSwiftApp/ViewController.swift
@@ -57,8 +57,8 @@ class ViewController: UIViewController {
                 self.updateStatusField(result.error.description)
                 return;
             }
-            
-            let status = String(format: "Access token: %@\nexpiration:%@", result.accessToken, result.tokenCacheItem.expiresOn)
+
+            let status = String(format: "Access token: %@\nexpiration:%@", result.accessToken, result.tokenCacheItem.expiresOn ?? "(nil)")
             self.updateStatusField(status)
         }
     }


### PR DESCRIPTION
Resource can be nil as it is specified in the comment therefore it makes sense to add "nullable" in Objective-C layer, which will generate optimal String? type in Swift projection.