### PR TITLE
Add check for end URL in the webview delegate

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
@@ -215,6 +215,19 @@ NSTimer *timer;
         return;
     }
     
+    // If we failed on an invalid URL check to see if it matches our end URL
+    if ([error.domain isEqualToString:@"NSURLErrorDomain"] && (error.code == -1002 || error.code == -1003))
+    {
+        NSURL* url = [error.userInfo objectForKey:NSURLErrorFailingURLErrorKey];
+        NSString* urlString = [url absoluteString];
+        if ([[urlString lowercaseString] hasPrefix:_endURL.lowercaseString])
+        {
+            _complete = YES;
+            dispatch_async( dispatch_get_main_queue(), ^{ [_delegate webAuthenticationDidCompleteWithURL:url]; } );
+            return;
+        }
+    }
+    
     // Prior to iOS 10 the WebView trapped out this error code and didn't pass it along to us
     // now we have to trap it out ourselves.
     if ([error.domain isEqualToString:NSCocoaErrorDomain] && error.code == NSUserCancelledError)

--- a/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationWebViewController.m
@@ -216,7 +216,7 @@ NSTimer *timer;
     }
     
     // If we failed on an invalid URL check to see if it matches our end URL
-    if ([error.domain isEqualToString:@"NSURLErrorDomain"] && (error.code == -1002 || error.code == -1003))
+    if ([error.domain isEqualToString:NSURLErrorDomain] && (error.code == NSURLErrorUnsupportedURL || error.code == NSURLErrorCannotFindHost))
     {
         NSURL* url = [error.userInfo objectForKey:NSURLErrorFailingURLErrorKey];
         NSString* urlString = [url absoluteString];

--- a/ADALiOS/ADALiOS/ADURLProtocol.m
+++ b/ADALiOS/ADALiOS/ADURLProtocol.m
@@ -133,7 +133,7 @@ willSendRequestForAuthenticationChallenge:(NSURLAuthenticationChallenge *)challe
             // OS sends if it's unable to connect to the host
             [connection cancel];
             NSError* failingError = [NSError errorWithDomain:NSURLErrorDomain
-                                                        code:-1003
+                                                        code:NSURLErrorCannotFindHost
                                                     userInfo:@{ NSURLErrorFailingURLErrorKey : request.URL }];
             [self.client URLProtocol:self didFailWithError:failingError];
         }


### PR DESCRIPTION
We do still hit this when the redirect URI is an "http://" URL