### PR TITLE
add quotes to the run script arguments

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -1329,7 +1329,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+			shellScript = "/usr/bin/python \"${PROJECT_DIR}/tools/update_build_version.py\" \"${PROJECT_DIR}/src/ADAL_Internal.h\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"";
 		};
 		6079EB5B1D79558000E95AB1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1342,7 +1342,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+			shellScript = "/usr/bin/python \"${PROJECT_DIR}/tools/update_build_version.py\" \"${PROJECT_DIR}/src/ADAL_Internal.h\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"";
 		};
 		6079EB5C1D79558700E95AB1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1355,7 +1355,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+			shellScript = "/usr/bin/python \"${PROJECT_DIR}/tools/update_build_version.py\" \"${PROJECT_DIR}/src/ADAL_Internal.h\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"";
 		};
 		6079EB5D1D79559500E95AB1 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1368,7 +1368,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "/usr/bin/python ${PROJECT_DIR}/tools/update_build_version.py ${PROJECT_DIR}/src/ADAL_Internal.h ${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}";
+			shellScript = "/usr/bin/python \"${PROJECT_DIR}/tools/update_build_version.py\" \"${PROJECT_DIR}/src/ADAL_Internal.h\" \"${BUILT_PRODUCTS_DIR}/${INFOPLIST_PATH}\"";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
fixes #774 

Now the quotes have been added to the run script arguments. Otherwise it won't run properly when project dir path contains spaces.