### PR TITLE
Fix private Apple api name collision

### DIFF
--- a/ADAL/src/telemetry/ADAggregatedDispatcher.m
+++ b/ADAL/src/telemetry/ADAggregatedDispatcher.m
@@ -70,7 +70,7 @@
                 [aggregatedEvent addObject:properties[i]];
             }
         }
-        [_dispatcher dispatch:aggregatedEvent];
+        [_dispatcher dispatchEvent:aggregatedEvent];
     }
     
     SAFE_ARC_RELEASE(objectsToBeDispatched);

--- a/ADAL/src/telemetry/ADDefaultDispatcher.m
+++ b/ADAL/src/telemetry/ADDefaultDispatcher.m
@@ -64,7 +64,7 @@
             NSArray* properties = [event getProperties];
             if (properties)
             {
-                [_dispatcher dispatch:properties];
+                [_dispatcher dispatchEvent:properties];
             }
         }
         

--- a/ADAL/src/telemetry/ADTelemetry.h
+++ b/ADAL/src/telemetry/ADTelemetry.h
@@ -37,7 +37,7 @@
     @param  event        An array of property-value pairs. Each pair is also stored in an array whose size is 2. 
                          So event is a two-dimentional array.
  */
-- (void)dispatch:(NSArray*)event;
+- (void)dispatchEvent:(NSArray*)event;
 
 @end
 

--- a/ADAL/tests/ADTelemetryTests.m
+++ b/ADAL/tests/ADTelemetryTests.m
@@ -43,7 +43,7 @@ typedef void(^TestCallback)(NSArray* event);
     _testCallback = callback;
 }
 
-- (void)dispatch:(NSArray*)event
+- (void)dispatchEvent:(NSArray*)event
 {
     // call _testCallback when it receives telemetry event
     // this is for the purpose of unit test


### PR DESCRIPTION
Fix app submission review because of name collision with private API `dispatch:`