### PR TITLE
Add more robust parsing of broker response messages

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		8BB8346D1807C5F5007F9F0D /* ADAuthenticationParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BB8346C1807C5F5007F9F0D /* ADAuthenticationParametersTests.m */; };
 		8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF678518358544004E0F4D /* ADUserInformationTests.m */; };
 		8BBF6788183588EC004E0F4D /* ADTokenCacheItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8BBF6787183588EC004E0F4D /* ADTokenCacheItemTests.m */; };
+		940CC8881D8A34610087E9EA /* ADBrokerMessageTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 940CC8871D8A34610087E9EA /* ADBrokerMessageTests.m */; };
 		9424B6841CDD39E400729698 /* ADTokenCacheAccessor.m in Sources */ = {isa = PBXBuildFile; fileRef = 9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */; };
 		9430C3411C4631C200D6506D /* ADTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9430C3401C4631C200D6506D /* ADTokenCacheTests.m */; };
 		9430C34E1C54320400D6506D /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9430C34D1C54320400D6506D /* ADAuthenticationContextTests.m */; };
@@ -393,6 +394,7 @@
 		8BFEF065182DA57800122C0C /* ADALiOSBundle-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ADALiOSBundle-Info.plist"; sourceTree = "<group>"; };
 		8BFEF067182DA57800122C0C /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		8BFEF069182DA57800122C0C /* ADALiOSBundle-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALiOSBundle-Prefix.pch"; sourceTree = "<group>"; };
+		940CC8871D8A34610087E9EA /* ADBrokerMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADBrokerMessageTests.m; sourceTree = "<group>"; };
 		941674431C9CCCAF00D8D52A /* ADAuthenticationError+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationError+Internal.h"; sourceTree = "<group>"; };
 		9424B6811CDD1B2B00729698 /* ADTokenCacheAccessor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheAccessor.m; sourceTree = "<group>"; };
 		9424B6831CDD1B4600729698 /* ADTokenCacheDataSource.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTokenCacheDataSource.h; sourceTree = "<group>"; };
@@ -1012,6 +1014,7 @@
 				94DD19021C5AD39A00F80C62 /* ADBrokerKeyHelperTests.m */,
 				94DD19031C5AD39A00F80C62 /* ADKeychainTokenCacheTests.m */,
 				94DD19041C5AD39A00F80C62 /* InfoPlist.strings */,
+				940CC8871D8A34610087E9EA /* ADBrokerMessageTests.m */,
 			);
 			path = ios;
 			sourceTree = "<group>";
@@ -1387,6 +1390,7 @@
 				D6F999801D235ACF004E682C /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				D60D8FE81D25C8D400F3E6C9 /* ADHelpersTests.m in Sources */,
 				601BEE341C6DCB0B004AA8C1 /* ADWebAuthControllerTests.m in Sources */,
+				940CC8881D8A34610087E9EA /* ADBrokerMessageTests.m in Sources */,
 				6071B5E41C14C0B0006F6CC2 /* ADTestURLConnection.m in Sources */,
 				8BBF678618358544004E0F4D /* ADUserInformationTests.m in Sources */,
 				94DD19081C5AD3A600F80C62 /* ADKeychainTokenCacheTests.m in Sources */,

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -56,7 +56,7 @@
 
 /*! The completion block declaration. */
 typedef void(^ADAuthenticationCallback)(ADAuthenticationResult* result);
-
+typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
 #if TARGET_OS_IPHONE
 //iOS:
@@ -67,6 +67,7 @@ typedef UIWebView WebViewType;
 #   include <WebKit/WebKit.h>
 typedef WebView   WebViewType;
 #endif
+
 
 #import "ADAuthenticationRequest.h"
 

--- a/ADAL/src/ADAuthenticationContext+Internal.h
+++ b/ADAL/src/ADAuthenticationContext+Internal.h
@@ -45,8 +45,6 @@
 #import "ADOAuth2Constants.h"
 #import "ADTokenCacheAccessor.h"
 
-typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
-
 extern NSString* const ADUnknownError;
 extern NSString* const ADCredentialsNeeded;
 extern NSString* const ADInteractionNotSupportedInExtension;

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -259,9 +259,9 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [NSString adSame:sourceApplication toString:@"com.microsoft.azureauthenticator"];
 }
 
-+ (void)handleBrokerResponse:(NSURL*)response
++ (BOOL)handleBrokerResponse:(NSURL*)response
 {
-    [ADAuthenticationRequest internalHandleBrokerResponse:response];
+    return [ADAuthenticationRequest internalHandleBrokerResponse:response];
 }
 
 #define REQUEST_WITH_REDIRECT_STRING(_redirect, _clientId, _resource) \

--- a/ADAL/src/broker/ios/ADBrokerHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerHelper.m
@@ -48,8 +48,7 @@ BOOL __swizzle_ApplicationOpenURL(id self, SEL _cmd, UIApplication* application,
         }
     }
     
-    [ADAuthenticationContext handleBrokerResponse:url];
-    return YES;
+    return [ADAuthenticationContext handleBrokerResponse:url];
 }
 
 typedef BOOL (*applicationOpenURLiOS9Ptr)(id, SEL, UIApplication*, NSURL*, NSDictionary<NSString*, id>*);

--- a/ADAL/src/broker/ios/ADBrokerKeyHelper.h
+++ b/ADAL/src/broker/ios/ADBrokerKeyHelper.h
@@ -47,6 +47,6 @@
                            error:(ADAuthenticationError *__autoreleasing *)error;
 
 // NOTE: Used for testing purposes only. Does not change keychain entries.
-- (void)setSymmetricKey:(NSData *)symmetricKey;
++ (void)setSymmetricKey:(NSString *)base64Key;
 
 @end

--- a/ADAL/src/broker/ios/ADBrokerKeyHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerKeyHelper.m
@@ -30,6 +30,8 @@
 #import <Security/Security.h>
 #import "ADLogger+Internal.h"
 
+static NSData* s_symmetricKeyOverride = nil;
+
 @implementation ADBrokerKeyHelper
 
 enum {
@@ -165,6 +167,11 @@ static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
         return _symmetricKey;
     }
     
+    if (s_symmetricKeyOverride)
+    {
+        return s_symmetricKeyOverride;
+    }
+    
     NSDictionary* symmetricKeyQuery =
     @{
       (id)kSecClass : (id)kSecClassKey,
@@ -279,4 +286,17 @@ static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
     SAFE_ARC_RETAIN(_symmetricKey);
 }
 
-@end;
++ (void)setSymmetricKey:(NSString *)base64Key
+{
+    SAFE_ARC_RELEASE(s_symmetricKeyOverride);
+    if (base64Key)
+    {
+        s_symmetricKeyOverride = [[NSData alloc] initWithBase64EncodedString:base64Key options:0];
+    }
+    else
+    {
+        s_symmetricKeyOverride = nil;
+    }
+}
+
+@end

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -240,7 +240,7 @@ typedef enum
 
 /*!
  */
-+ (void)handleBrokerResponse:(NSURL*)response;
++ (BOOL)handleBrokerResponse:(NSURL*)response;
 
 /*! Represents the authority used by the context. */
 @property (readonly) NSString* authority;

--- a/ADAL/src/public/ADErrorCodes.h
+++ b/ADAL/src/public/ADErrorCodes.h
@@ -158,6 +158,9 @@ typedef enum
     /*! Failed to decrypt the message we received from Azure Authenticator */
     AD_ERROR_TOKENBROKER_DECRYPTION_FAILED = 505,
     
+    /*! We were launched with a URL, however that URL did not come from the broker app, or was
+        not a broker response. */
+    AD_ERROR_TOKENBROKER_NOT_A_BROKER_RESPONSE = 506,
     
 } ADErrorCode;
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -30,8 +30,6 @@
 #import "ADTokenCacheKey.h"
 #import "ADAcquireTokenSilentHandler.h"
 
-static ADAuthenticationRequest* s_modalRequest = nil;
-
 @implementation ADAuthenticationRequest (AcquireToken)
 
 #pragma mark -

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.h
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.h
@@ -23,9 +23,11 @@
 
 typedef void(^ADAuthorizationCodeCallback)(NSString*, ADAuthenticationError*);
 
+extern NSString* kAdalResumeDictionaryKey;
+
 @interface ADAuthenticationRequest (Broker)
 
-+ (void)internalHandleBrokerResponse:(NSURL*)response;
++ (BOOL)internalHandleBrokerResponse:(NSURL*)response;
 
 + (BOOL)validBrokerRedirectUri:(NSString*)url;
 

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.h
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.h
@@ -35,7 +35,4 @@ extern NSString* kAdalResumeDictionaryKey;
 
 - (void)callBroker:(ADAuthenticationCallback)completionBlock;
 
-- (void)handleBrokerFromWebiewResponse:(NSString*)urlString
-                       completionBlock:(ADAuthenticationCallback)completionBlock;
-
 @end

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -327,13 +327,13 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
       @"extra_qp"       : _queryParams ? _queryParams : @"",
       };
     
-    NSDictionary* resumeDictionary =
+    NSDictionary<NSString *, NSString *>* resumeDictionary =
   @{
     @"authority"        : _context.authority,
     @"resource"         : _resource,
     @"client_id"        : _clientId,
     @"redirect_uri"     : _redirectUri,
-    @"correlation_id"   : _correlationId,
+    @"correlation_id"   : _correlationId.UUIDString,
     };
     
     [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -85,8 +85,8 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     ADAuthenticationResult* result = [self processBrokerResponse:response];
     
     [[NSUserDefaults standardUserDefaults] removeObjectForKey:kAdalResumeDictionaryKey];
-    // If we didn't a authentication result then assume it wasn't actually a broker message. This
-    // allows the message to pass through to other handlers
+    // If we didn't get an authentication result then assume it wasn't actually a broker
+    // message. This allows the message to pass through to other handlers
     if (!result)
     {
         if (completionBlock)

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.h
@@ -23,10 +23,6 @@
 
 @interface ADAuthenticationRequest (WebRequest)
 
-// If ADAL is curently in the middle of a modal Authentication request (ie. a webview is being displayed)
-// this method will return the matching request
-+ (ADAuthenticationRequest*)currentModalRequest;
-
 - (void)executeRequest:(NSDictionary *)request_data
             completion:(ADAuthenticationCallback)completionBlock;
 

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -97,9 +97,6 @@
 // This message is sent before any stage of processing is done, it marks all the fields as un-editable and grabs the
 // correlation ID from the logger
 - (void)ensureRequest;
-// This exclusion lock should be obtained before launching webview/broker for interaction
-- (BOOL)takeUserInterationLock;
-- (BOOL)releaseUserInterationLock;
 
 // These can only be set before the request gets sent out.
 - (void)setScope:(NSString*)scope;
@@ -118,6 +115,27 @@
 #endif
 - (void)setSamlAssertion:(NSString*)samlAssertion;
 - (void)setAssertionType:(ADAssertionType)assertionType;
+
+/*!
+    Takes the UI interaction lock for the current request, will send an error
+    to completionBlock if it fails.
+ 
+    @param copmletionBlock  the ADAuthenticationCallback to send an error to if
+                            one occurs.
+ 
+    @return NO if we fail to take the exclusion lock
+ */
+- (BOOL)takeExclusionLock:(ADAuthenticationCallback)completionBlock;
+
+/*!
+    Releases the exclusion lock
+ */
++ (void)releaseExclusionLock;
+
+/*!
+    The current interactive request ADAL is displaying UI for (if any)
+ */
++ (ADAuthenticationRequest*)currentModalRequest;
 
 @end
 

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -40,9 +40,8 @@
 
 #include <libkern/OSAtomic.h>
 
-// Used to make sure one interactive request is going on at a time,
-// either launching webview or broker
-static dispatch_semaphore_t sInteractionInProgress = nil;
+static ADAuthenticationRequest* s_modalRequest = nil;
+static dispatch_semaphore_t s_interactionLock = nil;
 
 @implementation ADAuthenticationRequest
 
@@ -60,7 +59,7 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
 
 + (void)initialize
 {
-    sInteractionInProgress = dispatch_semaphore_create(1);
+    s_interactionLock = dispatch_semaphore_create(1);
 }
 
 + (ADAuthenticationRequest *)requestWithAuthority:(NSString *)authority
@@ -302,15 +301,45 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
     return _correlationId;
 }
 
-- (BOOL)takeUserInterationLock
+/*!
+    Takes the UI interaction lock for the current request, will send an error
+    to completionBlock if it fails.
+ 
+    @param copmletionBlock  the ADAuthenticationCallback to send an error to if
+                            one occurs.
+ 
+    @return NO if we fail to take the exclusion lock
+ */
+- (BOOL)takeExclusionLock:(ADAuthenticationCallback)completionBlock
 {
-    return !dispatch_semaphore_wait(sInteractionInProgress, DISPATCH_TIME_NOW);
+    THROW_ON_NIL_ARGUMENT(completionBlock);
+    if (dispatch_semaphore_wait(s_interactionLock, DISPATCH_TIME_NOW) != 0)
+    {
+        NSString* message = @"The user is currently prompted for credentials as result of another acquireToken request. Please retry the acquireToken call later.";
+        ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_UI_MULTLIPLE_INTERACTIVE_REQUESTS
+                                                                              protocolCode:nil
+                                                                              errorDetails:message
+                                                                             correlationId:_correlationId];
+        completionBlock([ADAuthenticationResult resultFromError:error]);
+        return NO;
+    }
+    
+    s_modalRequest = self;
+    return YES;
 }
 
-- (BOOL)releaseUserInterationLock
+/*!
+    Releases the exclusion lock
+ */
++ (void)releaseExclusionLock
 {
-    dispatch_semaphore_signal(sInteractionInProgress);
-    return YES;
+    dispatch_semaphore_signal(s_interactionLock);
+    s_modalRequest = nil;
+}
+
++ (ADAuthenticationRequest*)currentModalRequest
+{
+    return s_modalRequest;
 }
 
 @end

--- a/ADAL/tests/ios/ADBrokerKeyHelperTests.m
+++ b/ADAL/tests/ios/ADBrokerKeyHelperTests.m
@@ -49,18 +49,15 @@ enum {
 
 - (void)tearDown {
     // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [ADBrokerKeyHelper setSymmetricKey:nil];
     [super tearDown];
 }
 
 - (void)testv1Decrypt
 {
-    NSString* base64Key = @"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U=";
-    NSData* key = [[NSData alloc] initWithBase64EncodedString:base64Key options:0];
+    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
     ADBrokerKeyHelper* keyHelper = [[ADBrokerKeyHelper alloc] init];
     ADAuthenticationError* error = nil;
-     
-    [keyHelper setSymmetricKey:key];
-    XCTAssertNil(error);
     
     NSString* v1EncryptedPayload = @"OxDgUethOjve95lfr1OIFjv9ExbhxTTESae11KZChY2SAsDBZCyRI87/HCutimLfIpvqWHJ7P6ygVGJlnr1yHZf4aguJ4zq1auczsXeTPPYoNVxHNGbbMJgAkjcnCI6SJG9JqXlS8IjVNFDTZvVswlLWzwsQLL5O36/gGM77eONyhMkRexN36wMMgSkrtTzov1OOn2od9ErutVTyBNZ+bNbAhzYQgNzkvbgERFdBMlDN7EIuFO4TMgizcYhbvaGY+jNb8Ktwbk0hXxKfMKm8HL332ub3RbRrW0BWPJACPtyzN3X9pnxncZHg8hZJzYh3";
     
@@ -76,13 +73,9 @@ enum {
 
 - (void)testv2Decrypt
 {
-    NSString* base64Key = @"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U=";
-    NSData* key = [[NSData alloc] initWithBase64EncodedString:base64Key options:0];
+    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
     ADBrokerKeyHelper* keyHelper = [[ADBrokerKeyHelper alloc] init];
     ADAuthenticationError* error = nil;
-    
-    [keyHelper setSymmetricKey:key];
-    XCTAssertNil(error);
     
     NSString* v2EncryptedPayload = @"OwkUbeZ63OlLI1xsNUXOJKmJgjhApcV6bEzFI6cdtE4UtsboGnJLjUtJRySO8ol97W431BdpwnuFD8tImkjUx++oNAMU483Q1xpuc5mCNVZcpDpnMoW2EC9oM5slGTPvvmDBxu3MHbLVVKWB616eKUdSKGOBnBUWDZp6QJJXpwEzwZuoycmmbQBF2SI1Ur5bluma8d23hANpV1c0qCGtPvEcLXWp7vNp5gkIsd6rGAkuuk31GJ3E8j+gfd8XymUEFc8g9ikx4JG0JnRwmRkzgVVKgszDPlPJrqlGlCZqa0SiF8V0pT3CqM6HURkqmCvK";
     

--- a/ADAL/tests/ios/ADBrokerMessageTests.m
+++ b/ADAL/tests/ios/ADBrokerMessageTests.m
@@ -1,0 +1,184 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import <Security/Security.h>
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonHMAC.h>
+#import <CommonCrypto/CommonDigest.h>
+#import "ADBrokerNotificationManager.h"
+#import "ADBrokerKeyHelper.h"
+#import "NSDictionary+ADExtensions.h"
+#import "ADPkeyAuthHelper.h"
+#import "XCTestCase+TestHelperMethods.h"
+#import "ADUserInformation.h"
+#import "ADTokenCacheItem.h"
+
+static NSString* s_kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
+
+@interface ADBrokerMessageTests : XCTestCase
+
+@end
+
+@implementation ADBrokerMessageTests
+
++ (NSString*) computeHash:(NSData*) inputData{
+    
+    //compute SHA-1 thumbprint
+    unsigned char sha256Buffer[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256(inputData.bytes, (CC_LONG)inputData.length, sha256Buffer);
+    
+    NSMutableString *fingerprint = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 3];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; ++i)
+    {
+        [fingerprint appendFormat:@"%02x ",sha256Buffer[i]];
+    }
+    NSString* thumbprint = [fingerprint stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceCharacterSet]];
+    thumbprint = [thumbprint uppercaseString];
+    return [thumbprint stringByReplacingOccurrencesOfString:@" " withString:@""];
+}
+
+- (void)setUp {
+    [super setUp];
+    
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+    
+    // In UI tests it is usually best to stop immediately when a failure occurs.
+    //self.continueAfterFailure = NO;
+    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
+    //[[[XCUIApplication alloc] init] launch];
+
+    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [ADBrokerKeyHelper setSymmetricKey:nil];
+    [super tearDown];
+}
+
+- (void)testNonBrokerResponse
+{
+    // Set a redirect in the resume dictionary to make sure we at least try to process this message
+    NSDictionary* resumeDictionary =
+    @{
+      @"redirect_uri" : @"ms-outlook://",
+      };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+    
+    __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+    {
+        XCTAssertNotNil(result);
+        XCTAssertNotNil(result.error);
+        XCTAssertEqual(result.error.code, AD_ERROR_TOKENBROKER_NOT_A_BROKER_RESPONSE);
+        
+        dispatch_semaphore_signal(sem);
+        
+    }];
+    
+    // This should not crash and return NO
+    XCTAssertFalse([ADAuthenticationContext handleBrokerResponse:[NSURL URLWithString:@"ms-outlook://settings/help/intunediagnostics?source=authenticator"]]);
+    ;
+    
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+}
+
+- (void)testNonBrokerResponseMismatchedRedirectUri
+{
+    // Set a redirect in the resume dictionary to make sure we at least try to process this message
+    NSDictionary* resumeDictionary =
+    @{
+      @"redirect_uri" : @"different-redirect-uri://",
+      };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+    
+    __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_TOKENBROKER_NOT_A_BROKER_RESPONSE);
+         
+         dispatch_semaphore_signal(sem);
+         
+     }];
+    
+    // This should not crash and return NO
+    XCTAssertFalse([ADAuthenticationContext handleBrokerResponse:[NSURL URLWithString:@"ms-outlook://settings/help/intunediagnostics?source=authenticator"]]);
+    ;
+    
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+}
+
+- (void)testBrokerv2Message
+{
+    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
+    ADAuthenticationError* error = nil;
+    
+    XCTAssertNil(error);
+    
+    NSString* v2Base64UrlEncryptedPayload = @"TKQ6mTbSf_FgBnb5mvtnSQXQ4_LajVjSNPjymF1wI2ZQWzGSvut3mWziWV0Xvti_ULCFD39BwuFJykXxrtsHZeuynfHRdpUXnhm4qZoAiRfjgY37HBbYbXW3FLzQWvUTCBFz3S9MWpPQE1bJmgke8NisoZ7jlj_gJh-nkfL_Kqg_q7f-AGHvF_TKZoZajosKjbSXzSrW5jLVEA8evIezJS_mIAIUTxxtyoDr1XnQmL2obbi2xLsdbfUDQYpRM2fVLQchO3P_J0TlJrTlR7NAuGnjRUckQHXRsR0-qSK0zF_4rxlClrQgJOudWKpZCVVeUhHMNYzhehLNfABphLeAc_Vxbo7yf0pgKo482ThT86Zb438eSqHivrB8f3VGSx8jRd6MusubxG6VAE5iaHC3xzDumwxAC95QNzv4CspKl5Q";
+     
+    NSString* hash = @"922B2C67F3F8BEA82A3E3F5DD3DC8D7EA0CB2FED159A324C610E4AE07634C022";
+    NSDictionary* resumeDictionary =
+    @{
+      @"redirect_uri" : @"ms-outlook://",
+      };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+
+    
+    NSDictionary* brokerMessage =
+    @{
+      @"msg_protocol_ver" : @"2",
+      @"response" : v2Base64UrlEncryptedPayload,
+      @"hash" : hash,
+      };
+    
+    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    
+    __block dispatch_semaphore_t sem = dispatch_semaphore_create(0);
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertNil(result.error);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         
+         XCTAssertEqualObjects(result.tokenCacheItem.resource, @"myfakeresource");
+         XCTAssertEqualObjects(result.tokenCacheItem.accessToken, @"MyFakeAccessToken");
+         XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, @"MyFakeRefreshToken");
+         XCTAssertEqualObjects(result.tokenCacheItem.accessTokenType, @"Bearer");
+         
+         dispatch_semaphore_signal(sem);
+         
+     }];
+    
+    XCTAssertTrue([ADAuthenticationContext handleBrokerResponse:brokerUrl]);
+    dispatch_semaphore_wait(sem, DISPATCH_TIME_FOREVER);
+    
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kAdalResumeDictionaryKey]);
+}
+
+
+@end

--- a/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
+++ b/Samples/MyTestiOSApp/MyTestiOSApp.xcodeproj/project.pbxproj
@@ -399,6 +399,7 @@
 				ORGANIZATIONNAME = MS;
 				TargetAttributes = {
 					8BA42AF517E3C150002D206E = {
+						DevelopmentTeam = UBF8T346G9;
 						SystemCapabilities = {
 							com.apple.Keychain = {
 								enabled = 1;
@@ -410,6 +411,7 @@
 					};
 					D6EA53A61D541011008A0BC3 = {
 						CreatedOnToolsVersion = 7.3.1;
+						DevelopmentTeam = UBF8T346G9;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -653,6 +655,7 @@
 				CODE_SIGN_ENTITLEMENTS = MyTestiOSApp/MyTestiOSApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -786,6 +789,7 @@
 				CODE_SIGN_ENTITLEMENTS = MyTestiOSApp/MyTestiOSApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
@@ -809,6 +813,7 @@
 				CODE_SIGN_ENTITLEMENTS = MyTestiOSApp/MyTestiOSApp.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "MyTestiOSApp/MyTestiOSApp-Prefix.pch";
 				INFOPLIST_FILE = "MyTestiOSApp/MyTestiOSApp-Info.plist";
@@ -872,6 +877,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/extension-safe";
@@ -896,6 +902,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/extension-safe";
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -919,6 +926,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(BUILT_PRODUCTS_DIR)/extension-safe";
 				GCC_NO_COMMON_BLOCKS = YES;

--- a/Samples/MyTestiOSApp/MyTestiOSApp/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -29,6 +39,16 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
     },
     {
       "idiom" : "ipad",

--- a/build.py
+++ b/build.py
@@ -97,7 +97,7 @@ def do_ios_build(target, operation) :
 
 	print_operation_start(name, operation)
 
-	command = "xcbuild " + operation + " -workspace " + default_workspace + " -scheme \"" + scheme + "\" -configuration CodeCoverage " + ios_sim_flags + " " + ios_sim_dest + " | xcpretty"
+	command = "xcodebuild " + operation + " -workspace " + default_workspace + " -scheme \"" + scheme + "\" -configuration CodeCoverage " + ios_sim_flags + " " + ios_sim_dest + " | xcpretty"
 	print command
 	exit_code = subprocess.call("set -o pipefail;" + command, shell = True)
 
@@ -111,7 +111,7 @@ def do_mac_build(target, operation) :
 
 	print_operation_start(name, operation)
 
-	command = "xcbuild " + operation + " -workspace " + default_workspace + " -scheme \"" + scheme + "\""
+	command = "xcodebuild " + operation + " -workspace " + default_workspace + " -scheme \"" + scheme + "\""
 
 	if (arch != None) :
 		command = command + " -destination 'arch=" + arch + "'"


### PR DESCRIPTION
- Remove the usage of completionBlock while parsing the broker's response. This lead to some incorrect usage of error checking macros that assumed that completionBlock could never be nil.
- Retain state from the initial broker request that can persist across app launches so that we can use that in the validation code, and in the future better support for caching results when we receive a broker response on a fresh app launch (the app was killed during the broker request)
- If the URL is not a proper broker response then fall through to the app's original URL handler to allow them to process it.
- Add test coverage of handleBrokerResponse to cover these scenarios and a valid broker response
- Modifications to ADBrokerKeyHelper to wrangle the key used for crypto in the tests.