### PR TITLE
Fix memory leak of observer by declaring __weak

### DIFF
--- a/ADAL/src/broker/ios/ADBrokerHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerHelper.m
@@ -83,7 +83,7 @@ BOOL __swizzle_ApplicationOpenURLiOS9(id self, SEL _cmd, UIApplication* applicat
         return;
     }
 
-    __block id observer = nil;
+    __block __weak id observer = nil;
     
     observer =
     [[NSNotificationCenter defaultCenter] addObserverForName:UIApplicationDidFinishLaunchingNotification


### PR DESCRIPTION
Otherwise ARC holds a strong reference to observer which creates a retain cycle