### PR TITLE
Object Model changes for broker refactor

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -537,6 +537,7 @@
 		946818A41C59B7EE00CA0378 /* ADWebAuthController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthController.m; sourceTree = "<group>"; };
 		946818A51C59B7EE00CA0378 /* ADWebAuthController+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADWebAuthController+Internal.h"; sourceTree = "<group>"; };
 		946818A81C59B80800CA0378 /* ADAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewController.m; sourceTree = "<group>"; };
+		94A0BDE61D779AB0007BEB63 /* ADRequestContext.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADRequestContext.h; sourceTree = "<group>"; };
 		94DD18C91C5A00BC00F80C62 /* ADAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationViewController.m; sourceTree = "<group>"; };
 		94DD18E11C5ACFBF00F80C62 /* ADAL Mac Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "ADAL Mac Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		94DD19011C5AD39A00F80C62 /* ADALiOSTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "ADALiOSTests-Info.plist"; sourceTree = "<group>"; };
@@ -720,6 +721,7 @@
 				97A522481A1A752D001D77CE /* ADClientMetrics.m */,
 				97A522511A1A89C4001D77CE /* ADClientMetrics.h */,
 				D6FB3E3B1B30D3630032F883 /* ADUserIdentifier.m */,
+				94A0BDE61D779AB0007BEB63 /* ADRequestContext.h */,
 				60D2F3FE1D524F7A008725D9 /* ADRequestParameters.h */,
 				60D2F4001D531F16008725D9 /* ADRequestParameters.m */,
 				9453C3771C58017F006B9E79 /* broker */,

--- a/ADAL/src/ADAuthenticationContext+Internal.h
+++ b/ADAL/src/ADAuthenticationContext+Internal.h
@@ -70,6 +70,11 @@ extern NSString* const ADRedirectUriInvalidError;
                                     errorCode:(ADErrorCode)errorCode;
 
 
+- (id)initWithAuthority:(NSString *)authority
+      validateAuthority:(BOOL)validateAuthority
+             tokenCache:(id<ADTokenCacheDataSource>)tokenCache
+                  error:(ADAuthenticationError *__autoreleasing *)error;
+
 + (BOOL)isFinalResult:(ADAuthenticationResult *)result;
 
 + (NSString*)getPromptParameter:(ADPromptBehavior)prompt;

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -87,33 +87,6 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
 - (id)initWithAuthority:(NSString *)authority
       validateAuthority:(BOOL)validateAuthority
-             tokenCache:(id<ADTokenCacheDataSource>)tokenCache
-                  error:(ADAuthenticationError *__autoreleasing *)error
-{
-    API_ENTRY;
-    if (!(self = [super init]))
-    {
-        return nil;
-    }
-    
-    NSString* extractedAuthority = [ADInstanceDiscovery canonicalizeAuthority:authority];
-    if (!extractedAuthority)
-    {
-        SAFE_ARC_RELEASE(self);
-        RETURN_ON_INVALID_ARGUMENT(!extractedAuthority, authority, nil);
-    }
-    
-    _authority = extractedAuthority;
-    _validateAuthority = validateAuthority;
-    _credentialsType = AD_CREDENTIALS_EMBEDDED;
-    _extendedLifetimeEnabled = NO;
-    [self setTokenCacheStore:tokenCache];
-
-    return self;
-}
-
-- (id)initWithAuthority:(NSString *)authority
-      validateAuthority:(BOOL)validateAuthority
           cacheDelegate:(id<ADTokenCacheDelegate>) delegate
                   error:(ADAuthenticationError * __autoreleasing *)error
 {

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -90,7 +90,7 @@
         return;
     }
 
-    ADWebRequest* request = [[ADWebRequest alloc] initWithURL:resourceUrl requestParams:nil];
+    ADWebRequest* request = [[ADWebRequest alloc] initWithURL:resourceUrl context:nil];
     [request setIsGetRequest:YES];
     AD_LOG_VERBOSE_F(@"Starting authorization challenge request", nil, @"Resource: %@", resourceUrl);
     

--- a/ADAL/src/ADInstanceDiscovery.m
+++ b/ADAL/src/ADInstanceDiscovery.m
@@ -291,7 +291,7 @@ static NSString* const sValidationServerError = @"The authority validation serve
     
     AD_LOG_VERBOSE(@"Authority Validation Request", correlationId, endPoint);
     ADWebRequest *webRequest = [[ADWebRequest alloc] initWithURL:[NSURL URLWithString:endPoint]
-                                                   requestParams:requestParams];
+                                                         context:requestParams];
     
     [webRequest setIsGetRequest:YES];
     [webRequest.headers setObject:@"application/json" forKey:@"Accept"];

--- a/ADAL/src/ADLogger+Internal.h
+++ b/ADAL/src/ADLogger+Internal.h
@@ -87,6 +87,8 @@
  the actual contents, but still want to log something that can be correlated. */
 + (NSString*)getHash:(NSString*)input;
 
++ (void)setAdalVersion:(NSString*)version;
+
 + (NSString*)getAdalVersion;
 
 + (NSString*)getCPUInfo;

--- a/ADAL/src/ADLogger.m
+++ b/ADAL/src/ADLogger.m
@@ -245,7 +245,7 @@ correlationId:(NSUUID*)correlationId
         NSMutableDictionary* result = [NSMutableDictionary dictionaryWithDictionary:
                                        @{
                                          ADAL_ID_PLATFORM:@"OSX",
-                                         ADAL_ID_VERSION:[NSString stringWithFormat:@"%d.%d", ADAL_VER_HIGH, ADAL_VER_LOW],
+                                         ADAL_ID_VERSION:[NSString stringWithFormat:@"%d.%d.%d", ADAL_VER_HIGH, ADAL_VER_LOW, ADAL_VER_PATCH],
                                          ADAL_ID_OS_VER:[NSString stringWithFormat:@"%ld.%ld.%ld", (long)osVersion.majorVersion, (long)osVersion.minorVersion, (long)osVersion.patchVersion],
                                          }];
 #endif
@@ -260,6 +260,11 @@ correlationId:(NSUUID*)correlationId
     });
     
     return s_adalId;
+}
+
++ (void)setAdalVersion:(NSString*)version
+{
+    [s_adalId setObject:version forKey:ADAL_ID_VERSION];
 }
 
 + (NSString*)getHash:(NSString*)input
@@ -280,7 +285,7 @@ correlationId:(NSUUID*)correlationId
     return toReturn;
 }
 
-+ (NSString*) getAdalVersion
++ (NSString*)getAdalVersion
 {
     return ADAL_VERSION_NSSTRING;
 }

--- a/ADAL/src/ADRequestContext.h
+++ b/ADAL/src/ADRequestContext.h
@@ -21,28 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import "ADWebRequest.h"
 
-@interface ADWebAuthRequest : ADWebRequest
-{
-    NSDate* _startTime;
-    BOOL _retryIfServerError;
-    BOOL _handledPkeyAuthChallenge;
-    BOOL _returnRawResponse;
-    
-    NSMutableDictionary* _responseDictionary;
-    
-    // A dictionary of key/value pairs that is either included as the query parameters on a GET
-    // request or serialized into JSON for a POST request
-    NSDictionary<NSString*,NSString*> * _requestDictionary;
-}
+#import <Foundation/Foundation.h>
 
-@property BOOL returnRawResponse;
-@property BOOL retryIfServerError;
-@property BOOL handledPkeyAuthChallenge;
-@property (readonly) NSDate* startTime;
+@protocol ADRequestContext <NSObject>
 
-- (void)setRequestDictionary:(NSDictionary<NSString*, NSString*> *)requestDictionary;
-- (void)sendRequest:(ADWebResponseCallback)completionBlock;
+- (NSUUID *)correlationId;
+- (NSString *)telemetryRequestId;
 
 @end

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -21,7 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-@interface ADRequestParameters : NSObject
+#import "ADTokenCacheDataSource.h"
+#import "ADRequestContext.h"
+
+@class ADTokenCacheAccessor;
+
+@interface ADRequestParameters : NSObject <ADRequestContext>
 {
     NSString* _authority;
     NSString* _resource;

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -22,6 +22,8 @@
 // THE SOFTWARE.
 
 #import "ADRequestParameters.h"
+#import "ADUserIdentifier.h"
+#import "ADTokenCacheAccessor.h"
 
 @implementation ADRequestParameters
 
@@ -45,6 +47,7 @@
           correlationId:(NSUUID *)correlationId
      telemetryRequestId:(NSString *)telemetryRequestId
 {
+    (void)tokenCache;
     if (!(self = [super init]))
     {
         return nil;
@@ -61,6 +64,26 @@
     [self setTelemetryRequestId:telemetryRequestId];
     
     return self;
+}
+
+- (id)copyWithZone:(NSZone*)zone
+{
+    ADRequestParameters* parameters = [[ADRequestParameters allocWithZone:zone] init];
+    
+    parameters->_authority = [_authority copyWithZone:zone];
+    parameters->_resource = [_resource copyWithZone:zone];
+    parameters->_clientId = [_clientId copyWithZone:zone];
+    parameters->_redirectUri = [_redirectUri copyWithZone:zone];
+    parameters->_identifier = [_identifier copyWithZone:zone];
+    
+    // "copy" doesn't make much sense on the token cache object, as it's just a proxy around a data source
+    parameters->_tokenCache = _tokenCache;
+    SAFE_ARC_RETAIN(parameters->_tokenCache);
+    parameters->_correlationId = [_correlationId copyWithZone:zone];
+    parameters->_extendedLifetime = _extendedLifetime;
+    parameters->_telemetryRequestId = [_telemetryRequestId copyWithZone:zone];
+    
+    return parameters;
 }
 
 - (void)setResource:(NSString *)resource

--- a/ADAL/src/ADUserIdentifier.m
+++ b/ADAL/src/ADUserIdentifier.m
@@ -112,6 +112,20 @@
     return NO;
 }
 
+- (id)copyWithZone:(NSZone*)zone
+{
+    ADUserIdentifier* identifier = [[ADUserIdentifier allocWithZone:zone] init];
+    if (!identifier)
+    {
+        return nil;
+    }
+    
+    identifier->_type = _type;
+    identifier->_userId = [_userId copyWithZone:zone];
+    
+    return identifier;
+}
+
 - (NSString*)userIdMatchString:(ADUserInformation*)info
 {
     switch(_type)

--- a/ADAL/src/cache/ADTokenCacheAccessor.h
+++ b/ADAL/src/cache/ADTokenCacheAccessor.h
@@ -23,6 +23,7 @@
 
 #import <Foundation/Foundation.h>
 #import "ADTokenCacheDataSource.h"
+#import "ADRequestContext.h"
 
 @interface ADTokenCacheAccessor : NSObject
 {
@@ -43,7 +44,7 @@
 - (ADTokenCacheItem *)getATRTItemForUser:(ADUserIdentifier *)identifier
                                 resource:(NSString *)resource
                                 clientId:(NSString *)clientId
-                           requestParams:(ADRequestParameters*)requestParams
+                                 context:(id<ADRequestContext>)context
                                    error:(ADAuthenticationError * __autoreleasing *)error;
 
 /*!
@@ -52,7 +53,7 @@
  */
 - (ADTokenCacheItem *)getMRRTItemForUser:(ADUserIdentifier *)identifier
                                 clientId:(NSString *)clientId
-                           requestParams:(ADRequestParameters*)requestParams
+                                 context:(id<ADRequestContext>)context
                                    error:(ADAuthenticationError * __autoreleasing *)error;
 
 /*!
@@ -61,7 +62,7 @@
  */
 - (ADTokenCacheItem *)getFRTItemForUser:(ADUserIdentifier *)identifier
                                familyId:(NSString *)familyId
-                          requestParams:(ADRequestParameters*)requestParams
+                                context:(id<ADRequestContext>)context
                                   error:(ADAuthenticationError * __autoreleasing *)error;
 
 /*!
@@ -70,7 +71,7 @@
  */
 - (ADTokenCacheItem*)getADFSUserTokenForResource:(NSString *)resource
                                         clientId:(NSString *)clientId
-                                   requestParams:(ADRequestParameters*)requestParams
+                                         context:(id<ADRequestContext>)context
                                            error:(ADAuthenticationError * __autoreleasing *)error;
 
 /*!
@@ -83,6 +84,6 @@
 - (void)updateCacheToResult:(ADAuthenticationResult *)result
                   cacheItem:(ADTokenCacheItem *)cacheItem
                refreshToken:(NSString *)refreshToken
-              requestParams:(ADRequestParameters*)requestParams;
+                    context:(id<ADRequestContext>)context;
 
 @end

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -79,7 +79,7 @@
     if (!response)
     {
         ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_UNEXPECTED
-                                                                              protocolCode:@"adal cachce"
+                                                                              protocolCode:nil
                                                                               errorDetails:@"processTokenResponse called without a response dictionary"
                                                                              correlationId:requestCorrelationId];
         return [ADAuthenticationResult resultFromError:error];

--- a/ADAL/src/public/ADAuthenticationResult.h
+++ b/ADAL/src/public/ADAuthenticationResult.h
@@ -46,7 +46,7 @@ typedef enum
 {
 @protected
     //See the corresponding properties for details.
-    ADTokenCacheItem*          _tokenCacheItem;
+    ADTokenCacheItem*               _tokenCacheItem;
     ADAuthenticationResultStatus    _status;
     ADAuthenticationError*          _error;
     NSUUID*                         _correlationId;

--- a/ADAL/src/public/ADUserIdentifier.h
+++ b/ADAL/src/public/ADUserIdentifier.h
@@ -51,7 +51,7 @@ typedef enum ADUserIdentifierType
 
 @class ADUserInformation;
 
-@interface ADUserIdentifier : NSObject
+@interface ADUserIdentifier : NSObject <NSCopying>
 {
     NSString* _userId;
     ADUserIdentifierType _type;

--- a/ADAL/src/public/ios/ADKeychainTokenCache.h
+++ b/ADAL/src/public/ios/ADKeychainTokenCache.h
@@ -79,7 +79,7 @@
                        error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
 - (BOOL)removeAllForUserId:(NSString * __nonnull)userId
-                      clientId:(NSString * __nonnull)clientId
-                         error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+                  clientId:(NSString * __nonnull)clientId
+                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
 @end

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.h
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.h
@@ -41,7 +41,8 @@
     BOOL _attemptedFRT;
 }
 
-+ (void)acquireTokenSilentForRequestParams:(ADRequestParameters*)requestParams
-                           completionBlock:(ADAuthenticationCallback)completionBlock;
++ (ADAcquireTokenSilentHandler *)requestWithParams:(ADRequestParameters*)requestParams;
+
+- (void)getToken:(ADAuthenticationCallback)completionBlock;
 
 @end

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -118,8 +118,8 @@
 #if AD_TELEMETRY
         [[ADTelemetry sharedInstance] startEvent:[self telemetryRequestId] eventName:@"acquire_token_silent_handler"];
 #endif
-        [ADAcquireTokenSilentHandler acquireTokenSilentForRequestParams:_requestParams
-                                                        completionBlock:^(ADAuthenticationResult *result)
+        ADAcquireTokenSilentHandler* request = [ADAcquireTokenSilentHandler requestWithParams:_requestParams];
+        [request getToken:^(ADAuthenticationResult *result)
         {
 #if AD_TELEMETRY
             ADTelemetryAPIEvent* event = [[ADTelemetryAPIEvent alloc] initWithName:@"acquire_token_silent_handler"
@@ -271,7 +271,10 @@
 #endif
                       if (AD_SUCCEEDED == result.status)
                       {
-                          [[_requestParams tokenCache] updateCacheToResult:result cacheItem:nil refreshToken:nil requestParams:_requestParams];
+                          [[_requestParams tokenCache] updateCacheToResult:result
+                                                                 cacheItem:nil
+                                                              refreshToken:nil
+                                                                   context:_requestParams];
                           result = [ADAuthenticationContext updateResult:result toUser:[_requestParams identifier]];
                       }
                       completionBlock(result);

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -164,7 +164,7 @@ static NSString* s_brokerProtocolVersion = nil;
         ADTokenCacheAccessor* cache = [[ADTokenCacheAccessor alloc] initWithDataSource:[ADKeychainTokenCache defaultKeychainCache]
                                                                              authority:result.tokenCacheItem.authority];
         
-        [cache updateCacheToResult:result cacheItem:nil refreshToken:nil requestParams:nil];
+        [cache updateCacheToResult:result cacheItem:nil refreshToken:nil context:nil];
         
         NSString* userId = [[[result tokenCacheItem] userInformation] userId];
         [ADAuthenticationContext updateResult:result

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -57,7 +57,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
 {
     NSString* urlString = [_context.authority stringByAppendingString:OAUTH2_TOKEN_SUFFIX];
     ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:urlString]
-                                                    requestParams:_requestParams];
+                                                          context:_requestParams];
     [req setRequestDictionary:request_data];
     [req sendRequest:^(NSDictionary *response)
      {
@@ -244,7 +244,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
                      NSError* err = [NSError errorWithDomain:ADAuthenticationErrorDomain
                                                         code:AD_ERROR_SERVER_WPJ_REQUIRED
                                                     userInfo:userInfo];
-                     error = [ADAuthenticationError errorFromNSError:err errorDetails:@"work place join is required"];
+                     error = [ADAuthenticationError errorFromNSError:err errorDetails:@"work place join is required" correlationId:_requestParams.correlationId];
                  }
 #else
                  code = end.absoluteString;
@@ -304,7 +304,7 @@ static ADAuthenticationRequest* s_modalRequest = nil;
         
         NSURL* reqURL = [NSURL URLWithString:[_context.authority stringByAppendingString:OAUTH2_AUTHORIZE_SUFFIX]];
         ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:reqURL
-                                                        requestParams:_requestParams];
+                                                              context:_requestParams];
         [req setIsGetRequest:YES];
         [req setRequestDictionary:requestData];
         [req sendRequest:^(NSDictionary * parameters)

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -204,19 +204,14 @@ static dispatch_semaphore_t sInteractionInProgress = nil;
 
 - (NSString*)redirectUri
 {
-    return _redirectUri;
+    return _requestParams.redirectUri;
 }
 
 - (void)setRedirectUri:(NSString *)redirectUri
 {
     // We knowingly do this mid-request when we have to change auth types
     // Thus no CHECK_REQUEST_STARTED
-    if (_redirectUri == redirectUri)
-    {
-        return;
-    }
-    SAFE_ARC_RELEASE(_redirectUri);
-    _redirectUri = [redirectUri copy];
+    [_requestParams setRedirectUri:redirectUri];
 }
 
 - (void)setAllowSilentRequests:(BOOL)allowSilent

--- a/ADAL/src/request/ADWebAuthRequest.m
+++ b/ADAL/src/request/ADWebAuthRequest.m
@@ -38,9 +38,9 @@
 @synthesize handledPkeyAuthChallenge = _handledPkeyAuthChallenge;
 
 - (id)initWithURL:(NSURL *)url
-    requestParams:(ADRequestParameters*)requestParams
+          context:(id<ADRequestContext>)context
 {
-    self = [super initWithURL:url requestParams:requestParams];
+    self = [super initWithURL:url context:context];
     if (!self)
     {
         return nil;
@@ -66,7 +66,7 @@
     _requestDictionary = [requestDictionary copy];
 }
 
-- (void)sendRequest:(void (^)(NSDictionary *))completionBlock
+- (void)sendRequest:(ADWebResponseCallback)completionBlock
 {
     if ([self isGetRequest])
     {

--- a/ADAL/src/request/ADWebAuthResponse.h
+++ b/ADAL/src/request/ADWebAuthResponse.h
@@ -26,6 +26,8 @@
 @class ADWebResponse;
 @class ADWebAuthRequest;
 
+typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
+
 @interface ADWebAuthResponse : NSObject
 {
     NSMutableDictionary* _responseDictionary;
@@ -36,10 +38,10 @@
 
 + (void)processError:(NSError *)error
        correlationId:(NSUUID *)correlationId
-          completion:(void (^)(NSDictionary *))completionBlock;
+          completion:(ADWebResponseCallback)completionBlock;
 
 + (void)processResponse:(ADWebResponse *)webResponse
                 request:(ADWebAuthRequest *)request
-             completion:(void (^)(NSDictionary *))completionBlock;
+             completion:(ADWebResponseCallback)completionBlock;
 
 @end

--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -34,7 +34,7 @@
 
 + (void)processError:(NSError *)error
        correlationId:(NSUUID *)correlationId
-          completion:(void (^)(NSDictionary *))completionBlock
+          completion:(ADWebResponseCallback)completionBlock
 {
     ADWebAuthResponse* response = [ADWebAuthResponse new];
     response->_correlationId = correlationId;
@@ -46,7 +46,7 @@
 
 + (void)processResponse:(ADWebResponse *)webResponse
                 request:(ADWebAuthRequest *)request
-             completion:(void (^)(NSDictionary *))completionBlock
+             completion:(ADWebResponseCallback)completionBlock
 {
     ADWebAuthResponse* response = [ADWebAuthResponse new];
     response->_request = request;
@@ -92,7 +92,7 @@
 }
 
 - (void)handleResponse:(ADWebResponse *)webResponse
-       completionBlock:(void (^)(NSDictionary *))completionBlock
+       completionBlock:(ADWebResponseCallback)completionBlock
 {
     [self checkCorrelationId:webResponse];
     [_responseDictionary setObject:webResponse.URL forKey:@"url"];
@@ -162,7 +162,7 @@
 }
 
 - (void)handleJSONResponse:(ADWebResponse*)webResponse
-           completionBlock:(void (^)(NSDictionary *))completionBlock
+           completionBlock:(ADWebResponseCallback)completionBlock
 {
     NSError   *jsonError  = nil;
     id         jsonObject = [NSJSONSerialization JSONObjectWithData:webResponse.body options:0 error:&jsonError];
@@ -189,7 +189,7 @@
 }
 
 - (void)handlePKeyAuthChallenge:(NSString *)wwwAuthHeaderValue
-                     completion:(void (^)(NSDictionary *))completionBlock
+                     completion:(ADWebResponseCallback)completionBlock
 {
     //pkeyauth word length=8 + 1 whitespace
     wwwAuthHeaderValue = [wwwAuthHeaderValue substringFromIndex:[pKeyAuthName length] + 1];
@@ -219,7 +219,7 @@
     [_request resend];
 }
 
-- (void)handleSuccess:(void (^)(NSDictionary *))completionBlock
+- (void)handleSuccess:(ADWebResponseCallback)completionBlock
 {
     [[ADClientMetrics getInstance] endClientMetricsRecord:[[_request URL] absoluteString]
                                                 startTime:[_request startTime]
@@ -234,7 +234,7 @@
 
 - (void)handleJSONError:(NSError*)jsonError
                    body:(NSData*)body
-        completionBlock:(void (^)(NSDictionary *))completionBlock
+        completionBlock:(ADWebResponseCallback)completionBlock
 {
     
     // Unrecognized JSON response
@@ -268,7 +268,8 @@
     [self handleNSError:jsonError completionBlock:completionBlock];
 }
 
-- (void)handleNSError:(NSError*)error completionBlock:(void (^)(NSDictionary*))completionBlock
+- (void)handleNSError:(NSError*)error
+      completionBlock:(ADWebResponseCallback)completionBlock
 {
     if ([[error domain] isEqualToString:@"NSURLErrorDomain"] && [error code] == -1002)
     {
@@ -289,7 +290,8 @@
     [self handleADError:adError completionBlock:completionBlock];
 }
 
-- (void)handleADError:(ADAuthenticationError*)adError completionBlock:(void (^)(NSDictionary*))completionBlock
+- (void)handleADError:(ADAuthenticationError*)adError
+      completionBlock:(ADWebResponseCallback)completionBlock
 {
     [_responseDictionary setObject:adError
                             forKey:AUTH_NON_PROTOCOL_ERROR];

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -24,6 +24,8 @@
 @class ADWebRequest;
 @class ADWebResponse;
 
+typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
+
 @interface ADWebRequest : NSObject <NSURLConnectionDelegate>
 {
     NSURLConnection * _connection;
@@ -55,8 +57,8 @@
 @property BOOL isGetRequest;
 @property (readonly) NSUUID* correlationId;
 
-- (id)initWithURL: (NSURL*)url
-    requestParams:(ADRequestParameters*)requestParams;
+- (id)initWithURL:(NSURL *)url
+          context:(id<ADRequestContext>)context;
 
 - (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
 

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -80,7 +80,7 @@
 #pragma mark - Initialization
 
 - (id)initWithURL:(NSURL *)requestURL
-    requestParams:(ADRequestParameters*)requestParams
+          context:(id<ADRequestContext>)context
 {
     if (!(self = [super init]))
     {
@@ -93,10 +93,10 @@
     // Default timeout for ADWebRequest is 30 seconds
     _timeout           = [[ADAuthenticationSettings sharedInstance] requestTimeOut];
     
-    _correlationId     = [requestParams correlationId];
+    _correlationId     = context.correlationId;
     SAFE_ARC_RETAIN(_correlationId);
     
-    _telemetryRequestId = [requestParams telemetryRequestId];
+    _telemetryRequestId = context.telemetryRequestId;
     SAFE_ARC_RETAIN(_telemetryRequestId);
     
     _operationQueue = [[NSOperationQueue alloc] init];

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -359,7 +359,7 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
         // client cert auth flow
         if ([[[request.URL scheme] lowercaseString] isEqualToString:@"msauth"])
         {
-            dispatch_async( dispatch_get_main_queue(), ^{ [_delegate webAuthDidCompleteWithURL:request.URL]; } );
+            [self webAuthDidCompleteWithURL:request.URL];
             return NO;
         }
 #endif


### PR DESCRIPTION
Typedef the completionBlock type for ADWebAuthRequest
Define an ADRequestContext protocol for passing through the correlation ID and telemetry ID into internal ADAL APIs
Change many internal ADAL APIs to accept a id<ADRequestContext>
Fix ADUserIdentifier to conform to NSCopying