### PR TITLE
Release completionHandler after calling it

### DIFF
--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -143,6 +143,9 @@
     _connection     = nil;
     
     _completionHandler(error, response);
+
+    SAFE_ARC_RELEASE(_completionHandler);
+    _completionHandler = nil;
 }
 
 - (void)send:(void (^)(NSError *, ADWebResponse *))completionHandler


### PR DESCRIPTION
This fixes retain cycles that can happen when the completionHandler references `self`.

Fixes #794

FYI @RPangrle
