### PR TITLE
Don't create a WPJ-not-supported error on Mac

### DIFF
--- a/ADAL/src/workplacejoin/mac/ADWorkPlaceJoinUtil.m
+++ b/ADAL/src/workplacejoin/mac/ADWorkPlaceJoinUtil.m
@@ -28,17 +28,8 @@
 + (ADRegistrationInformation*)getRegistrationInformation:(NSUUID *)correlationId
                                                    error:(ADAuthenticationError * __autoreleasing *)error
 {
-    ADAuthenticationError* adError =
-    [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_UNSUPPORTED_REQUEST
-                                           protocolCode:nil
-                                           errorDetails:@"Conditional Access is not supported on macOS."
-                                          correlationId:correlationId];
-    
-    if (error)
-    {
-        *error = adError;
-    }
-    
+    (void)correlationId;
+    (void)error;
     return nil;
 }
 


### PR DESCRIPTION
This causes the authentication flow to error out early whenever we get a pkeyauth challenge on Mac. Some ADFS servers are configured to always send pkeyauth challenges even if they aren't mandatory. Not erroring out here lets us finish the authentication fflow through other methods.