### PR TITLE
Add +[ADTokenCache defaultTokenCache] convenience method

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -144,8 +144,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
         return nil;
     }
 #else
-    tokenCache = [ADTokenCache new];
-    [(ADTokenCache*)tokenCache setDelegate:[ADAuthenticationSettings sharedInstance].defaultStorageDelegate];
+    tokenCache = [ADTokenCache defaultCache];
 #endif
     
     return [self initWithAuthority:authority

--- a/ADAL/src/ADAuthenticationSettings.m
+++ b/ADAL/src/ADAuthenticationSettings.m
@@ -25,16 +25,15 @@
 
 #if TARGET_OS_IPHONE
 #import "ADKeychainTokenCache.h"
+#else
+#import "ADTokenCache+Internal.h"
 #endif // TARGET_OS_IPHONE
+
 
 @implementation ADAuthenticationSettings
 
 @synthesize requestTimeOut = _requestTimeOut;
 @synthesize expirationBuffer = _expirationBuffer;
-
-#if !TARGET_OS_IPHONE
-@synthesize defaultStorageDelegate = _defaultStorageDelegate;
-#endif // !TARGET_OS_IPHONE
 
 /*!
  An internal initializer used from the static creation function.
@@ -57,7 +56,7 @@
 +(ADAuthenticationSettings*)sharedInstance
 {
     /* Below is a standard objective C singleton pattern*/
-    static ADAuthenticationSettings* instance;
+    static ADAuthenticationSettings* instance = nil;
     static dispatch_once_t onceToken;
     @synchronized(self)
     {
@@ -77,6 +76,16 @@
 - (void)setDefaultKeychainGroup:(NSString*)keychainGroup
 {
     [ADKeychainTokenCache setDefaultKeychainGroup:keychainGroup];
+}
+#elif !TARGET_OS_IPHONE
+- (id<ADTokenCacheDelegate>)defaultStorageDelegate
+{
+    return [[ADTokenCache defaultCache] delegate];
+}
+
+- (void)setDefaultStorageDelegate:(id<ADTokenCacheDelegate>)defaultStorageDelegate
+{
+    [[ADTokenCache defaultCache] setDelegate:defaultStorageDelegate];
 }
 #endif
 

--- a/ADAL/src/cache/ADTokenCache+Internal.h
+++ b/ADAL/src/cache/ADTokenCache+Internal.h
@@ -29,5 +29,7 @@
 - (BOOL)validateCache:(nullable NSDictionary *)dict
                 error:(ADAuthenticationError * __nullable  __autoreleasing * __nullable)error;
 
+- (nullable id<ADTokenCacheDelegate>)delegate;
+
 @end
 

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -48,6 +48,7 @@
 #import "ADUserInformation.h"
 #import "ADTokenCache+Internal.h"
 #import "ADTokenCacheKey.h"
+#import "ADAuthenticationSettings.h"
 
 #include <pthread.h>
 
@@ -60,6 +61,18 @@
 }
 
 @implementation ADTokenCache
+
++ (ADTokenCache *)defaultCache
+{
+    static dispatch_once_t once;
+    static ADTokenCache * cache = nil;
+    
+    dispatch_once(&once, ^{
+        cache = [ADTokenCache new];
+    });
+    
+    return cache;
+}
 
 - (id)init
 {
@@ -421,6 +434,11 @@
 
 
 @implementation ADTokenCache (Internal)
+
+- (id<ADTokenCacheDelegate>)delegate
+{
+    return _delegate;
+}
 
 - (BOOL)validateCache:(NSDictionary*)dict
                 error:(ADAuthenticationError * __autoreleasing *)error

--- a/ADAL/src/public/mac/ADTokenCache.h
+++ b/ADAL/src/public/mac/ADTokenCache.h
@@ -46,6 +46,10 @@
     pthread_rwlock_t _lock;
 }
 
+/*! Returns the default cache object using the ADTokenCacheDelegate set in
+    ADAuthenticationSettings */
++ (nonnull ADTokenCache *)defaultCache;
+
 - (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate;
 
 - (nullable NSData *)serialize;


### PR DESCRIPTION
This method returns a singleton for the default token cache using the default storage delegate. This should make it a little easier for application developers to discover how to manipulate the cache on MacOS.