### PR TITLE
Improve token logging

### DIFF
--- a/ADAL/src/ADLogger+Internal.h
+++ b/ADAL/src/ADLogger+Internal.h
@@ -124,10 +124,11 @@ correlationId:(NSUUID *)correlationId
  @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
  This parameter can be nil.
  */
-+ (void)logToken:(NSString*)token
-       tokenType:(NSString*)tokenType
-       expiresOn:(NSDate*)expiresOn
-   correlationId:(NSUUID*)correlationId;
++ (void)logToken:(NSString *)token
+       tokenType:(NSString *)tokenType
+       expiresOn:(NSDate *)expiresOn
+         context:(NSString *)context
+   correlationId:(NSUUID *)correlationId;
 
 + (void)setIdValue:(NSString*)value
             forKey:(NSString*)key;

--- a/ADAL/src/ADLogger.m
+++ b/ADAL/src/ADLogger.m
@@ -277,7 +277,9 @@ correlationId:(NSUUID*)correlationId
     {
         [toReturn appendFormat:@"%02x", hash[i]];
     }
-    return toReturn;
+    
+    // 7 characters is sufficient to differentiate tokens in the log, otherwise the hashes start making log lines hard to read
+    return [toReturn substringToIndex:7];
 }
 
 + (NSString*) getAdalVersion
@@ -285,12 +287,28 @@ correlationId:(NSUUID*)correlationId
     return ADAL_VERSION_NSSTRING;
 }
 
-+ (void)logToken:(NSString*)token
-       tokenType:(NSString*)tokenType
-       expiresOn:(NSDate*)expiresOn
-   correlationId:(NSUUID*)correlationId
++ (void)logToken:(NSString *)token
+       tokenType:(NSString *)tokenType
+       expiresOn:(NSDate *)expiresOn
+         context:(NSString *)context
+   correlationId:(NSUUID *)correlationId
 {
-    AD_LOG_VERBOSE_F(@"Token returned", nil, @"Obtained %@ with hash %@, expiring on %@ and correlationId: %@", tokenType, [self getHash:token], expiresOn, [correlationId UUIDString]);
+    
+    NSMutableString* logString = nil;
+    
+    if (context)
+    {
+        [logString appendFormat:@"%@ ", context];
+    }
+    
+    [logString appendFormat:@"%@ (%@)", tokenType, [self getHash:token]];
+    
+    if (expiresOn)
+    {
+        [logString appendFormat:@" expires on %@", expiresOn];
+    }
+    
+    AD_LOG_INFO(logString, correlationId, nil);
 }
 
 + (void)setIdValue:(NSString*)value

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.m
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.m
@@ -172,15 +172,16 @@
     }
 }
 
-- (void)logWithCorrelationId:(NSString*)correlationId
-                        mrrt:(BOOL)isMRRT
+- (void)logMessage:(NSString *)message
+     correlationId:(NSString *)correlationId
+              mrrt:(BOOL)isMRRT
 {
     (void)isMRRT;
     
     NSUUID* correlationUUID = [[NSUUID alloc] initWithUUIDString:correlationId];
     
-    [self logMessage:nil
-               level:ADAL_LOG_LEVEL_VERBOSE
+    [self logMessage:message
+               level:ADAL_LOG_LEVEL_INFO
        correlationId:correlationUUID];
     
     SAFE_ARC_RELEASE(correlationUUID);
@@ -221,7 +222,9 @@
     
     [self fillExpiration:responseDictionary];
     
-    [self logWithCorrelationId:[responseDictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE] mrrt:isMRRT];
+    [self logMessage:@"Received"
+       correlationId:[responseDictionary objectForKey:OAUTH2_CORRELATION_ID_RESPONSE]
+                mrrt:isMRRT];
     
     // Store what we haven't cached to _additionalServer
     SAFE_ARC_RELEASE(_additionalServer);

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -75,8 +75,9 @@
              
              // give the stale token as result
              [ADLogger logToken:handler->_extendedLifetimeAccessTokenItem.accessToken
-                      tokenType:@"access token (extended lifetime)"
+                      tokenType:@"AT (extended lifetime)"
                       expiresOn:handler->_extendedLifetimeAccessTokenItem.expiresOn
+                        context:@"Returning"
                   correlationId:handler->_correlationId];
              
              result = [ADAuthenticationResult resultFromTokenCacheItem:handler->_extendedLifetimeAccessTokenItem
@@ -133,9 +134,11 @@
                          cacheItem:(ADTokenCacheItem*)cacheItem
                    completionBlock:(ADAuthenticationCallback)completionBlock
 {
-    AD_LOG_VERBOSE_F(@"Attempting to acquire an access token from refresh token.", _correlationId, @"Resource: %@", _resource);
-
-    [ADLogger logToken:refreshToken tokenType:@"refresh token" expiresOn:nil correlationId:_correlationId];
+    [ADLogger logToken:refreshToken
+             tokenType:@"RT"
+             expiresOn:nil
+               context:[NSString stringWithFormat:@"Attempting to acquire for %@ using", _resource]
+         correlationId:_correlationId];
     //Fill the data for the token refreshing:
     NSMutableDictionary *request_data = nil;
     
@@ -323,7 +326,11 @@
     // If we have a good (non-expired) access token then return it right away
     if (item.accessToken && !item.isExpired)
     {
-        [ADLogger logToken:item.accessToken tokenType:@"access token" expiresOn:item.expiresOn correlationId:_correlationId];
+        [ADLogger logToken:item.accessToken
+                 tokenType:@"AT"
+                 expiresOn:item.expiresOn
+                   context:@"Returning"
+             correlationId:_correlationId];
         ADAuthenticationResult* result = [ADAuthenticationResult resultFromTokenCacheItem:item multiResourceRefreshToken:NO correlationId:_correlationId];
         completionBlock(result);
         return;


### PR DESCRIPTION
A number of the token log statements don't provide useful context for what that line is for, and often are being logged at verbose, instead of info. Also, shorten the hashes we use to log. 40 character hashes aren't needed for logging purposes, the first 7 characters will be more then sufficient.