### PR TITLE
"Get the App" crash fix

### DIFF
--- a/ADAL/src/ADAuthenticationError+Internal.h
+++ b/ADAL/src/ADAuthenticationError+Internal.h
@@ -31,6 +31,22 @@
                                           correlationId:_CORRELATION]; \
     if (error) { *error = adError; }
 
+
+
+#define AUTH_ERROR_RETURN_IF_NIL(_VAL, _CODE, _DETAILS, _CORRELATION) \
+    if (_VAL == nil) { \
+        AUTH_ERROR(_CODE, _DETAILS, _CORRELATION); \
+        return nil; \
+    }
+
+#define ARG_RETURN_IF_NIL(_ARG, _CORRELATION) \
+    if (_ARG == nil) { \
+        AUTH_ERROR(AD_ERROR_DEVELOPER_INVALID_ARGUMENT, @#_ARG " should not be nil.", _CORRELATION); \
+        return nil; \
+    }
+
+
+
 #define AUTH_ERROR_UNDERLYING(_CODE, _DETAILS, _UNDERLYING, _CORRELATION) \
     ADAuthenticationError* adError = \
     [ADAuthenticationError errorFromAuthenticationError:_CODE \

--- a/ADAL/src/broker/ADBrokerHelper.h
+++ b/ADAL/src/broker/ADBrokerHelper.h
@@ -26,9 +26,10 @@
 @interface ADBrokerHelper : NSObject
 
 + (BOOL)canUseBroker;
-+ (void)invokeBroker:(NSDictionary *)brokerParams
++ (void)invokeBroker:(NSURL *)brokerURL
    completionHandler:(ADAuthenticationCallback)completion;
-+ (void)promptBrokerInstall:(NSDictionary *)brokerParams
++ (void)promptBrokerInstall:(NSURL *)redirectURL
+              brokerRequest:(NSURL *)brokerURL
           completionHandler:(ADAuthenticationCallback)completion;
 
 + (ADAuthenticationCallback)copyAndClearCompletionBlock;

--- a/ADAL/src/broker/ADBrokerHelper.h
+++ b/ADAL/src/broker/ADBrokerHelper.h
@@ -26,6 +26,8 @@
 @interface ADBrokerHelper : NSObject
 
 + (BOOL)canUseBroker;
+
+#if TARGET_OS_IPHONE
 + (void)invokeBroker:(NSURL *)brokerURL
    completionHandler:(ADAuthenticationCallback)completion;
 + (void)promptBrokerInstall:(NSURL *)redirectURL
@@ -33,5 +35,6 @@
           completionHandler:(ADAuthenticationCallback)completion;
 
 + (ADAuthenticationCallback)copyAndClearCompletionBlock;
+#endif
 
 @end

--- a/ADAL/src/broker/mac/ADBrokerHelper.m
+++ b/ADAL/src/broker/mac/ADBrokerHelper.m
@@ -34,28 +34,4 @@
     return NO;
 }
 
-+ (void)invokeBroker:(NSDictionary *)brokerParams
-   completionHandler:(ADAuthenticationCallback)completion
-{
-    (void)brokerParams;
-    (void)completion;
-    
-    AD_LOG_ERROR(@"invokeBroker is called on Mac! This code should be unreachable.", AD_ERROR_TOKENBROKER_UNKNOWN, nil, nil);
-}
-
-+ (void)promptBrokerInstall:(NSDictionary *)brokerParams
-          completionHandler:(ADAuthenticationCallback)completion
-{
-    (void)brokerParams;
-    (void)completion;
-    
-    AD_LOG_ERROR(@"promptBrokerInstall is called on Mac! This code should be unreachable.", AD_ERROR_TOKENBROKER_UNKNOWN, nil, nil);
-}
-
-+ (ADAuthenticationCallback)copyAndClearCompletionBlock
-{
-    AD_LOG_ERROR(@"copyAndClearCompletionBlock is called on Mac! This code should be unreachable.", AD_ERROR_TOKENBROKER_UNKNOWN, nil, nil);
-    return nil;
-}
-
 @end

--- a/ADAL/src/public/ADErrorCodes.h
+++ b/ADAL/src/public/ADErrorCodes.h
@@ -174,6 +174,9 @@ typedef enum
     /*! The key hash was missing from the response */
     AD_ERROR_TOKENBROKER_HASH_MISSING = 510,
     
+    /*! We can't call out to tokenbroker in an extension */
+    AD_ERROR_TOKENBROKER_NOT_SUPPORTED_IN_EXTENSION = 511,
+    
 } ADErrorCode;
 
 /* HTTP status codes used by the library */

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -207,7 +207,7 @@
 
 - (void)requestTokenImpl:(ADAuthenticationCallback)completionBlock
 {
-#if !AD_BROKER
+#if !AD_BROKER && TARGET_OS_IPHONE
     //call the broker.
     if ([self canUseBroker])
     {
@@ -243,6 +243,7 @@
          }
          else
          {
+#if TARGET_OS_IPHONE
              if([code hasPrefix:@"msauth://"])
              {
                  ADAuthenticationError* error = nil;
@@ -259,6 +260,7 @@
                  return;
              }
              else
+#endif
              {
                  [self requestTokenByCode:code
                           completionBlock:^(ADAuthenticationResult *result)

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.h
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.h
@@ -33,6 +33,6 @@ extern NSString* kAdalResumeDictionaryKey;
 
 - (BOOL)canUseBroker;
 
-- (void)callBroker:(ADAuthenticationCallback)completionBlock;
+- (NSURL *)composeBrokerRequest:(ADAuthenticationError* __autoreleasing *)error;
 
 @end


### PR DESCRIPTION
Rename -callBroker into -composeBrokerRequest so it can be better focused on a single scenario, and then call invokeBroker or promptBrokerInstall as appropriate.

Fixes #818