### PR TITLE
bug fix for broker sdk refactoring

### DIFF
--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -106,6 +106,7 @@
                 [_responseDictionary setObject:rawResponse
                                         forKey:@"raw_response"];
                 SAFE_ARC_RELEASE(rawResponse);
+                completionBlock(_responseDictionary);
                 break;
             }
         case 400:

--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -107,7 +107,7 @@
                                         forKey:@"raw_response"];
                 SAFE_ARC_RELEASE(rawResponse);
                 completionBlock(_responseDictionary);
-                break;
+                return;
             }
         case 400:
         case 401:

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -258,6 +258,8 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
         ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error errorDetails:@"WebView timed out" correlationId:_requestParams.correlationId];
         [self dispatchCompletionBlock:adError URL:nil];
     }];
+    SAFE_ARC_RELEASE(_authenticationViewController);
+    _authenticationViewController = nil;
 }
 
 #pragma mark - ADWebAuthDelegate


### PR DESCRIPTION
- copy over the fixes from #828 to dev
- fix a bug where completionBlock is not executed when `returnRawResponse=YES`