### PR TITLE
Releases parentViewController in ADAuthenticationBroker

### DIFF
--- a/ADALiOS/ADALiOS/ADAuthenticationBroker.m
+++ b/ADALiOS/ADALiOS/ADAuthenticationBroker.m
@@ -340,8 +340,7 @@ correlationId:(NSUUID *)correlationId
         [self dispatchCompletionBlock:error URL:nil];
     }
     
-    _authenticationViewController    = nil;
-    _authenticationWebViewController = nil;
+    [self resetViewControllers];
 }
 
 // Authentication completed at the end URL
@@ -362,8 +361,7 @@ correlationId:(NSUUID *)correlationId
         [self dispatchCompletionBlock:nil URL:endURL];
     }
     
-    _authenticationViewController    = nil;
-    _authenticationWebViewController = nil;
+    [self resetViewControllers];
 }
 
 // Authentication failed somewhere
@@ -385,6 +383,12 @@ correlationId:(NSUUID *)correlationId
         [self dispatchCompletionBlock:adError URL:nil];
     }
     
+    [self resetViewControllers];
+}
+
+- (void)resetViewControllers
+{
+    parentController = nil;
     _authenticationViewController    = nil;
     _authenticationWebViewController = nil;
 }


### PR DESCRIPTION
Hello! Faced the problem when authViewController's presentingController (the top one in UI hierarchy of my app) is not being dealloced. It happens because ADAuthenticationBroker retains reference to it, but never releases. So I fixed it, not it releases parentViewController in ADAuthenticationBroker on webView success/fail/cancel.

Thank you!