### PR TITLE
Mac and iOS Test App Consistency Changes

### DIFF
--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
@@ -305,7 +305,14 @@
 {
     OSStatus status = [[ADTestAppCache sharedCache] deleteFromKeychain];
     
-    [_resultView setString:[NSString stringWithFormat:@"Cache cleared (%d)", (int)status]];
+    if (status == errSecSuccess || status == errSecItemNotFound)
+    {
+        _resultView.string = @"Successfully cleared cache.";
+    }
+    else
+    {
+        _resultView.string = [NSString stringWithFormat:@"Failed to clear cache, error = %d", (int)status];
+    }
 }
 
 - (IBAction)clearCookies:(id)sender

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireLayoutBuilder.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireLayoutBuilder.m
@@ -32,7 +32,7 @@
     
     _screenRect = UIScreen.mainScreen.bounds;
     _contentView = [[UIView alloc] initWithFrame:_screenRect];
-    _contentView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
+    _contentView.translatesAutoresizingMaskIntoConstraints = NO;
     
     _views = [NSMutableDictionary new];
     _keys = [NSMutableArray new];
@@ -108,7 +108,7 @@
     }
     
     NSMutableString* verticalConstraint = [NSMutableString new];
-    [verticalConstraint appendString:@"V:|-24-"];
+    [verticalConstraint appendString:@"V:|"];
     
     for (int i = 0; i < _keys.count - 1; i++)
     {
@@ -119,7 +119,6 @@
     NSString* lastKey = _keys.lastObject;
     [verticalConstraint appendFormat:@"[%@(>=200)]-36-|", lastKey];
     
-    //[verticalConstraint appendString:@"-|"];
     NSArray* verticalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:verticalConstraint options:0 metrics:NULL views:_views];
     [_contentView addConstraints:verticalConstraints];
     

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -25,6 +25,7 @@
 #import "ADTestAppSettings.h"
 #import "ADKeychainTokenCache+Internal.h"
 #import "ADTestAppAcquireLayoutBuilder.h"
+#import "ADTestAppProfileViewController.h"
 
 @interface ADTestAppAcquireTokenViewController ()
 
@@ -32,21 +33,23 @@
 
 @implementation ADTestAppAcquireTokenViewController
 {
-    IBOutlet UIView* _acquireSettingsView;
-    IBOutlet UITextField* _userIdField;
-    IBOutlet UISegmentedControl* _userIdType;
+    UIView* _acquireSettingsView;
+    UITextField* _userIdField;
+    UISegmentedControl* _userIdType;
     
     UISegmentedControl* _promptBehavior;
+    
+    UIButton* _profileButton;
 
-    IBOutlet UISegmentedControl* _brokerEnabled;
-    IBOutlet UISegmentedControl* _webViewType;
-    IBOutlet UISegmentedControl* _fullScreen;
-    IBOutlet UISegmentedControl* _validateAuthority;
+    UISegmentedControl* _brokerEnabled;
+    UISegmentedControl* _webViewType;
+    UISegmentedControl* _fullScreen;
+    UISegmentedControl* _validateAuthority;
     
-    IBOutlet UITextView* _resultView;
+    UITextView* _resultView;
     
-    IBOutlet UIView* _authView;
-    IBOutlet UIWebView* _webView;
+    UIView* _authView;
+    UIWebView* _webView;
     
     NSLayoutConstraint* _bottomConstraint;
     NSLayoutConstraint* _bottomConstraint2;
@@ -60,7 +63,6 @@
     {
         return nil;
     }
-    
     UITabBarItem* tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Acquire" image:nil tag:0];
     [self setTabBarItem:tabBarItem];
     
@@ -115,6 +117,12 @@
     _promptBehavior.selectedSegmentIndex = 0;
     [layout addControl:_promptBehavior title:@"prompt"];
     
+    _profileButton = [UIButton buttonWithType:UIButtonTypeSystem];
+    [_profileButton setTitle:ADTestAppSettings.currentProfileTitle forState:UIControlStateNormal];
+    [_profileButton addTarget:self action:@selector(changeProfile:) forControlEvents:UIControlEventTouchUpInside];
+    _profileButton.contentHorizontalAlignment = UIControlContentHorizontalAlignmentLeft;
+    [layout addControl:_profileButton title:@"profile"];
+    
     _webViewType = [[UISegmentedControl alloc] initWithItems:@[@"Passed In", @"ADAL"]];
     _webViewType.selectedSegmentIndex = 1;
     [layout addControl:_webViewType title:@"webView"];
@@ -151,7 +159,11 @@
     
     UIView* contentView = [layout contentView];
     [scrollView addSubview:contentView];
-    scrollView.contentSize = contentView.bounds.size;
+    
+    NSDictionary* views = @{ @"contentView" : contentView, @"scrollView" : scrollView };
+    [scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"H:|[contentView]|" options:0 metrics:nil views:views]];
+    [scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:|[contentView]|" options:0 metrics:nil views:views]];
+    [scrollView addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"[contentView(==scrollView)]" options:0 metrics:nil views:views]];
     
     return scrollView;
 }
@@ -159,11 +171,11 @@
 - (UIView *)createAcquireButtonsView
 {
     UIButton* acquireButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [acquireButton setTitle:@"acquire" forState:UIControlStateNormal];
+    [acquireButton setTitle:@"acquireToken" forState:UIControlStateNormal];
     [acquireButton addTarget:self action:@selector(acquireTokenInteractive:) forControlEvents:UIControlEventTouchUpInside];
     
     UIButton* acquireSilentButton = [UIButton buttonWithType:UIButtonTypeSystem];
-    [acquireSilentButton setTitle:@"acquireSilent" forState:UIControlStateNormal];
+    [acquireSilentButton setTitle:@"acquireTokenSilent" forState:UIControlStateNormal];
     [acquireSilentButton addTarget:self action:@selector(acquireTokenSilent:) forControlEvents:UIControlEventTouchUpInside];
     
     UIView* acquireButtonsView = [self createTwoItemLayoutView:acquireButton item2:acquireSilentButton];
@@ -324,13 +336,17 @@
 - (void)viewWillAppear:(BOOL)animated
 {
     ADTestAppSettings* settings = [ADTestAppSettings settings];
-    if (!_userIdEdited)
+    NSString* defaultUser = settings.defaultUser;
+    if (![NSString adIsStringNilOrBlank:defaultUser])
     {
-        [_userIdField setText:settings.defaultUser];
+        _userIdField.text = defaultUser;
     }
     
-    [_validateAuthority setSelectedSegmentIndex:settings.validateAuthority ? 0 : 1];
-    [_brokerEnabled setSelectedSegmentIndex:settings.enableBroker ? 1 : 0];
+    self.navigationController.navigationBarHidden = YES;
+    _validateAuthority.selectedSegmentIndex = settings.validateAuthority ? 0 : 1;
+    _brokerEnabled.selectedSegmentIndex = settings.enableBroker ? 1 : 0;
+    [_profileButton setTitle:[ADTestAppSettings currentProfileTitle] forState:UIControlStateNormal];
+    
 }
 
 - (void)didReceiveMemoryWarning {
@@ -570,7 +586,14 @@
     NSDictionary* query = [[ADKeychainTokenCache defaultKeychainCache] defaultKeychainQuery];
     OSStatus status = SecItemDelete((CFDictionaryRef)query);
     
-    _resultView.text = [NSString stringWithFormat:@"Deleted keychain items (%d)", (int)status];
+    if (status == errSecSuccess || status == errSecItemNotFound)
+    {
+        _resultView.text = @"Successfully cleared cache.";
+    }
+    else
+    {
+        _resultView.text = [NSString stringWithFormat:@"Failed to clear cache, error = %d", (int)status];
+    }
 }
 
 - (IBAction)clearCookies:(id)sender
@@ -583,6 +606,11 @@
     }
     
     _resultView.text = [NSString stringWithFormat:@"Cleared %lu cookies.", (unsigned long)cookies.count];
+}
+
+- (IBAction)changeProfile:(id)sender
+{
+    [self.navigationController pushViewController:[ADTestAppProfileViewController sharedProfileViewController] animated:YES];
 }
 
 @end

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppDelegate.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppDelegate.m
@@ -53,14 +53,18 @@
     
     _tabBar = [UITabBarController new];
     
+    
     ADTestAppAcquireTokenViewController* tokenController = [ADTestAppAcquireTokenViewController new];
-    [_tabBar addChildViewController:tokenController];
+    UINavigationController* tokenNavController = [[UINavigationController alloc] initWithRootViewController:tokenController];
+    tokenNavController.tabBarItem = tokenController.tabBarItem;
+    tokenNavController.navigationBar.hidden = YES;
+    [_tabBar addChildViewController:tokenNavController];
     
     // Settings controller is contained in a navigation controller
     ADTestAppSettingsViewController* settingsController = [ADTestAppSettingsViewController new];
     
     UINavigationController* navController = [[UINavigationController alloc] initWithRootViewController:settingsController];
-    navController.navigationBar.hidden = NO;
+    navController.navigationBar.hidden = YES;
     navController.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings"
                                                              image:[UIImage imageNamed:@"Settings"]
                                                                tag:0];

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppProfileViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppProfileViewController.m
@@ -49,8 +49,6 @@
 {
     [super viewDidLoad];
     // Do any additional setup after loading the view.
-    
-    self.navigationController.navigationBarHidden = NO;
     self.navigationItem.hidesBackButton = NO;
     self.navigationItem.title = @"Select Application Profile";
     
@@ -69,6 +67,13 @@
     [rootView addSubview:_profileTable];
     
     self.view = rootView;
+}
+
+- (void)viewWillAppear:(BOOL)animated
+{
+    (void)animated;
+    
+     self.navigationController.navigationBarHidden = NO;
 }
 
 - (void)didReceiveMemoryWarning {

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettingsViewController.m
@@ -88,8 +88,6 @@ static NSArray* s_deviceRows = nil;
     {
         return nil;
     }
-    
-    self.navigationController.navigationBarHidden = YES;
     self.tabBarItem = [[UITabBarItem alloc] initWithTitle:@"Settings"
                                                     image:[UIImage imageNamed:@"Settings"]
                                                       tag:0];
@@ -152,6 +150,8 @@ static NSArray* s_deviceRows = nil;
     }
     
     _wpjState = wpjLabel;
+    
+    self.navigationController.navigationBarHidden = YES;
     
     [_tableView reloadData];
 }


### PR DESCRIPTION
- Name buttons "acquireToken" and "acquireTokenSilent" on both platforms
- Added a profile chooser button on the acquire page of the iOS test app
- Consistent result strings for clearing the cache on iOS and Mac
- Removed IBOutlets from code no longer using XIBs
- Fixed a minor bug in scrollview caused by not using autolayout through the entire view heirarchy.