### PR TITLE
Push 1.2.x updates onto the ADAL cocoapod

### DIFF
--- a/ADAL.podspec
+++ b/ADAL.podspec
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name         = "ADALiOS"
+  s.name         = "ADAL"
   s.version      = "1.2.9"
   s.summary      = "The ADAL SDK for iOS gives you the ability to add Azure Identity authentication to your application"
 
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
   }
   s.authors      = { "Microsoft" => "nugetaad@microsoft.com" }
   s.social_media_url   = "https://twitter.com/azuread"
-  s.platform     = :ios, "7.0"
+  s.platform     = :ios, "8.0"
   s.source       = { 
     :git => "https://github.com/AzureAD/azure-activedirectory-library-for-objc.git", 
     :tag => s.version.to_s

--- a/README.md
+++ b/README.md
@@ -1,12 +1,8 @@
 
-#Microsoft Azure Active Directory Authentication Library (ADAL) for iOS and OSX
+#Microsoft Azure Active Directory Authentication Library (ADAL) for iOS
 =====================================
 
-## URGENT: iOS 10 NOTICE
-
-**If you are using ADAL versions <= 1.2.8 or <= 2.2.4 you need to immediately upgrade your application to the latest version of our SDKs. Without this step, your users will not be able to sign-in once iOS 10 is released.** If a user is already signed in to your application it will continue to work temporarily, but the next time they need to sign in again they will experience this issue. 
-
-To update your application, you may use cocoapods or manually download the SDK from source on GitHub. Once you’ve update your SDK to the latest version your application will continue to work, there is no further code changes required for your application to continue working. 
+## NOTE: ADAL 1.x is in maintenance mode. We recommend updating to 2.x as soon as possible.
 
 ## How to Update Your Application with Cocoapods (recommended)
 
@@ -18,14 +14,14 @@ pod 'ADAL', '~> 2.2'
 If you are using the 1.2 version of our library, ensure the following line is in your `Podfile` in the root directory of your application:
 
 ```
-pod 'ADALiOS', '~> 1.2'
+pod 'ADAL', '~> 1.2'
 ```
 Once this is complete, run the `pod update` command to update your application. 
 
 
 ## How to Update Your Application with source
 
-1.	Download the latest code from the task you require, either 2.2.5 or 1.2.9
+1.	Download the latest code from the task you require.
 2.	In your XCode 8 or higher project, Click File -> Add Files
 3.	In the Finder that appears, navigate to where you downloaded the ADAL source. Go to the ADAL folder, and select `ADAL.xcodeproj` and click Add.
 4.	You’ll see you have another Project in your Project list to the left called `ADAL.xcodeproj`
@@ -80,11 +76,11 @@ We've made it easy for you to have multiple options to use this library in your 
 
 ###Option 1: Source Zip
 
-To download a copy of the source code, click "Download ZIP" on the right side of the page or click [here](https://github.com/AzureAD/azure-activedirectory-library-for-objc/archive/1.2.5.tar.gz).
+To download a copy of the source code, click "Download ZIP" on the right side of the page or click [here](https://github.com/AzureAD/azure-activedirectory-library-for-objc/archive/1.2.9.tar.gz).
 
 ###Option 2: Cocoapods
 
-    pod 'ADALiOS', '~> 1.2.5'
+    pod 'ADAL', '~> 1.2'
 
 ## Usage
 
@@ -285,6 +281,11 @@ in ADAuthenticationSettings:
 ```Objective-C
     [[ADAuthenticationSettings sharedInstance] setSharedCacheKeychainGroup:@"<your.bundle.id.here>"];
 ```
+
+**ADAL keeps returning SSL errors in iOS 9 and later**
+
+iOS 9 added App Transport Security (ATS). ATS restricts apps from accessing the internet unless they meet several security requirements including TLS 1.2 and SHA-256. It also prevents network traces that rely on self signed certs to crack SSL from working. Disabling ATS must be done in the Application's info.plist file, see [documentation on the NSAppTransport info.plist key](https://developer.apple.com/library/ios/documentation/General/Reference/InfoPlistKeyReference/Articles/CocoaKeys.html#//apple_ref/doc/uid/TP40009251-SW33) for more information.
+
 
 ## License
 


### PR DESCRIPTION
So we can (eventually) deprecate the ADALiOS cocoapod.