### PR TITLE
Add back if check on RedirectUri error

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -267,7 +267,11 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     ARG_RETURN_IF_NIL(_requestParams.clientId, _requestParams.correlationId);
     ARG_RETURN_IF_NIL(_requestParams.correlationId, _requestParams.correlationId);
     
-    AUTH_ERROR(AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI, ADRedirectUriInvalidError, _requestParams.correlationId);
+    if(![ADAuthenticationRequest validBrokerRedirectUri:_redirectUri])
+    {
+        AUTH_ERROR(AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI, ADRedirectUriInvalidError, _requestParams.correlationId);
+        return nil;
+    }
     
     AD_LOG_INFO(@"Invoking broker for authentication", _requestParams.correlationId, nil);
 #if TARGET_OS_IPHONE // Broker Message Encryption

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -267,7 +267,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     ARG_RETURN_IF_NIL(_requestParams.clientId, _requestParams.correlationId);
     ARG_RETURN_IF_NIL(_requestParams.correlationId, _requestParams.correlationId);
     
-    if(![ADAuthenticationRequest validBrokerRedirectUri:_redirectUri])
+    if(![ADAuthenticationRequest validBrokerRedirectUri:_requestParams.redirectUri])
     {
         AUTH_ERROR(AD_ERROR_TOKENBROKER_INVALID_REDIRECT_URI, ADRedirectUriInvalidError, _requestParams.correlationId);
         return nil;


### PR DESCRIPTION
In the broker refactor this if check was removed, however we didn't error out, so the code path still worked, we just got an extraneous (and erroneous) error message. This condition is checked very early on in the request so we fail reliably early, instead of late, which is why this wasn't caught, nor caused any run time issues. The erroneous log message though is obnoxious enough that it's worth fixing now.

Fixes #869 