### PR TITLE
Remove 5-min timeout timer and increase webview connection timeout interval

### DIFF
--- a/ADAL/src/public/ADWebAuthController.h
+++ b/ADAL/src/public/ADWebAuthController.h
@@ -58,10 +58,6 @@ extern NSString* ADWebAuthDidReceieveResponseFromBroker;
     // Used for managing the activity spinner
     NSTimer* _spinnerTimer;
     
-    // Used for timing out if it's taking too long to load
-    float _timeout;
-    NSTimer * _loadingTimer;
-    
     BOOL _complete;
     
     ADRequestParameters* _requestParams;

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -568,7 +568,7 @@ static ADAuthenticationResult* s_result = nil;
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[ADHelpers addClientVersionToURL:startURL]];
     [ADURLProtocol addCorrelationId:_requestParams.correlationId toRequest:request];
-    [request setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
+    request.timeoutInterval = ADAuthenticationSettings.sharedInstance.requestTimeOut;
     
     [_authenticationViewController startRequest:request];
 }

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -568,6 +568,8 @@ static ADAuthenticationResult* s_result = nil;
     
     NSMutableURLRequest* request = [[NSMutableURLRequest alloc] initWithURL:[ADHelpers addClientVersionToURL:startURL]];
     [ADURLProtocol addCorrelationId:_requestParams.correlationId toRequest:request];
+    [request setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
+    
     [_authenticationViewController startRequest:request];
 }
 

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -224,20 +224,6 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
     [_authenticationViewController stopSpinner];
 }
 
-
-- (void)failWithTimeout
-{
-    _loadingTimer = nil;
-    [_authenticationViewController stop:^{
-        NSError* error = [NSError errorWithDomain:NSURLErrorDomain
-                                             code:NSURLErrorTimedOut
-                                         userInfo:nil];
-        ADAuthenticationError* adError = [ADAuthenticationError errorFromNSError:error errorDetails:@"WebView timed out" correlationId:_requestParams.correlationId];
-        [self dispatchCompletionBlock:adError URL:nil];
-    }];
-    _authenticationViewController = nil;
-}
-
 #pragma mark - ADWebAuthDelegate
 
 - (void)webAuthDidStartLoad:(NSURL*)url
@@ -256,21 +242,6 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
                                                         repeats:NO];
         [_spinnerTimer setTolerance:0.3];
     }
-    
-    if (_loadingTimer)
-    {
-        [_loadingTimer invalidate];
-        _loadingTimer = nil;
-    }
-    
-    _loadingTimer = [NSTimer scheduledTimerWithTimeInterval:_timeout
-                                                     target:self
-                                                   selector:@selector(failWithTimeout)
-                                                   userInfo:nil
-                                                    repeats:NO];
-    // Tolerance is how much "float" the system is allowed to use to try to group the timer with other events
-    // on the system.
-    [_loadingTimer setTolerance:4.0];
     
     [[NSNotificationCenter defaultCenter] postNotificationName:ADWebAuthDidStartLoadNotification object:self userInfo:url ? @{ @"url" : url } : nil];
 }
@@ -447,11 +418,6 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
     }
     
     [self stopSpinner];
-    if (_loadingTimer)
-    {
-        [_loadingTimer invalidate];
-        _loadingTimer = nil;
-    }
     
     if (NSURLErrorCancelled == error.code)
     {
@@ -567,8 +533,6 @@ static ADAuthenticationResult* s_result = nil;
     [[ADTelemetry sharedInstance] startEvent:requestParams.telemetryRequestId eventName:@"launch_web_view"];
     _telemetryEvent = [[ADTelemetryUIEvent alloc] initWithName:@"launch_web_view"
                                                                  context:_requestParams];
-    
-    _timeout = [[ADAuthenticationSettings sharedInstance] requestTimeOut];
     
     startURL = [self addToURL:startURL correlationId:requestParams.correlationId];//Append the correlation id
     _endURL = [endURL absoluteString];

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -140,7 +140,10 @@ static NSUUID * _reqCorId(NSURLRequest* request)
 {
     AD_LOG_VERBOSE_F(@"+[ADURLProtocol canonicalRequestForRequest:]", _reqCorId(request), @"host: %@", [request.URL host] );
     
-    return request;
+    NSMutableURLRequest* mutableRequest = [request mutableCopy];
+    [mutableRequest setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
+    
+    return mutableRequest;
 }
 
 - (void)startLoading
@@ -162,7 +165,6 @@ static NSUUID * _reqCorId(NSURLRequest* request)
     }
     
     [NSURLProtocol setProperty:@YES forKey:kADURLProtocolPropertyKey inRequest:request];
-    [request setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
     
     _connection = [[NSURLConnection alloc] initWithRequest:request
                                                   delegate:self

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -28,6 +28,7 @@
 #import "ADCustomHeaderHandler.h"
 #import "ADTelemetryUIEvent.h"
 #import "ADTelemetryEventStrings.h"
+#import "ADAuthenticationSettings.h"
 
 static NSMutableDictionary* s_handlers = nil;
 static NSString* s_endURL = nil;
@@ -161,6 +162,7 @@ static NSUUID * _reqCorId(NSURLRequest* request)
     }
     
     [NSURLProtocol setProperty:@YES forKey:kADURLProtocolPropertyKey inRequest:request];
+    [request setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
     
     _connection = [[NSURLConnection alloc] initWithRequest:request
                                                   delegate:self

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -141,7 +141,7 @@ static NSUUID * _reqCorId(NSURLRequest* request)
     AD_LOG_VERBOSE_F(@"+[ADURLProtocol canonicalRequestForRequest:]", _reqCorId(request), @"host: %@", [request.URL host] );
     
     NSMutableURLRequest* mutableRequest = [request mutableCopy];
-    [mutableRequest setTimeoutInterval:[[ADAuthenticationSettings sharedInstance] requestTimeOut]];
+    mutableRequest.timeoutInterval = ADAuthenticationSettings.sharedInstance.requestTimeOut;
     
     return mutableRequest;
 }


### PR DESCRIPTION
fixes #862, #876

In order to fix the -1001 timeout issue, the following changes have been made:

1. The 5-min timeout timer has been removed before popping up webview.
2. The timeout interval of webview network connection has been increased.

The way to 
verify Change 1: stay at any login page for more than 5 mins.
verify Change 2: pick up the phone auth call, stay on the call for more than 1 min.
