### PR TITLE
Not to set body if it is GET request

### DIFF
--- a/ADAL/src/request/ADWebAuthRequest.m
+++ b/ADAL/src/request/ADWebAuthRequest.m
@@ -75,8 +75,10 @@
         _requestURL = [NSURL URLWithString:newURL];
         SAFE_ARC_RETAIN(_requestURL);
     }
-
-    [self setBody:[[_requestDictionary adURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding]];
+    else
+    {
+        [self setBody:[[_requestDictionary adURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding]];
+    }
     
     _startTime = [NSDate new];
     [[ADClientMetrics getInstance] addClientMetrics:self.headers endpoint:[_requestURL absoluteString]];

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -62,7 +62,7 @@
 {
     if ( body != nil )
     {
-        
+        [self setIsGetRequest:NO];
         if (_requestData == body)
         {
             return;

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -62,7 +62,7 @@
 {
     if ( body != nil )
     {
-        [self setIsGetRequest:NO];
+        
         if (_requestData == body)
         {
             return;


### PR DESCRIPTION
fixes #886 

Broker needs this fix, otherwise there will lead to Get web request with body.
The bug  causes network requests failed to sent out in iOS 10.

For reference here:
ADAL 1.x:
https://github.com/AzureAD/azure-activedirectory-library-for-objc/blob/authenticator-hotfix/ADALiOS/ADALiOS/ADWebRequest.m#L67

ADAL 2.x
https://github.com/AzureAD/azure-activedirectory-library-for-objc/blob/dev/ADAL/src/request/ADWebRequest.m#L61"

---------------------------
Update:
We are taking another approach. We do not set body if a request is GET request