### PR TITLE
remove 5-min timer; increase web view network timeout interval

### DIFF
--- a/ADAL/src/public/ADWebAuthController.h
+++ b/ADAL/src/public/ADWebAuthController.h
@@ -58,10 +58,6 @@ extern NSString* ADWebAuthDidReceieveResponseFromBroker;
     // Used for managing the activity spinner
     NSTimer* _spinnerTimer;
     
-    // Used for timing out if it's taking too long to load
-    float _timeout;
-    NSTimer * _loadingTimer;
-    
     BOOL _complete;
     
     ADRequestParameters* _requestParams;

--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -28,6 +28,7 @@
 #import "ADCustomHeaderHandler.h"
 #import "ADTelemetryUIEvent.h"
 #import "ADTelemetryEventStrings.h"
+#import "ADAuthenticationSettings.h"
 
 static NSMutableDictionary* s_handlers = nil;
 static NSString* s_endURL = nil;
@@ -141,7 +142,10 @@ static NSUUID * _reqCorId(NSURLRequest* request)
 {
     AD_LOG_VERBOSE_F(@"+[ADURLProtocol canonicalRequestForRequest:]", _reqCorId(request), @"host: %@", [request.URL host] );
     
-    return request;
+    NSMutableURLRequest* mutableRequest = [request mutableCopy];
+    mutableRequest.timeoutInterval = ADAuthenticationSettings.sharedInstance.requestTimeOut;
+    
+    return mutableRequest;
 }
 
 - (void)startLoading


### PR DESCRIPTION
fixes #862, #876

In order to fix the -1001 timeout issue, the following changes have been made:

1. The 5-min timeout timer has been removed before popping up webview.
2. The timeout interval of webview network connection has been increased.

The way to 
verify Change 1: stay at any login page for more than 5 mins.
verify Change 2: pick up the phone auth call, stay on the call for more than 1 min.
