### PR TITLE
NTLM passed-in-webview fix (#892)

### DIFF
--- a/ADAL/src/ui/ios/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/ios/ADNTLMUIPrompt.m
@@ -26,6 +26,7 @@
 #import "ADWebAuthController+Internal.h"
 #import "ADAuthenticationViewController.h"
 #import "ADALFrameworkUtils.h"
+#import "UIApplication+ADExtensions.h"
 
 @implementation ADNTLMUIPrompt
 
@@ -39,7 +40,7 @@
     }
     
     dispatch_async(dispatch_get_main_queue(), ^{
-        UIViewController* viewController = [[ADWebAuthController sharedInstance] viewController];
+        UIViewController* viewController = [UIApplication adCurrentViewController];
         if (!viewController)
         {
             block(nil, nil);


### PR DESCRIPTION
Get view controller by looking for the current top view controller in the view controller heirarchy