### PR TITLE
Stop resetting switches in test app

### DIFF
--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppSettings.h
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppSettings.h
@@ -23,7 +23,8 @@
 
 #import <Foundation/Foundation.h>
 
-extern NSString* ADTestAppCacheChangeNotification;
+extern NSString *ADTestAppCacheChangeNotification;
+extern NSString *ADTestAppProfileChangedNotification;
 
 @interface ADTestAppSettings : NSObject
 {

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppSettings.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppSettings.m
@@ -38,7 +38,8 @@ static NSDictionary* _additionalProfiles()
 static NSDictionary* s_additionalProfiles = nil;
 
 
-NSString* ADTestAppCacheChangeNotification = @"ADTestAppCacheChangeNotification";
+NSString *ADTestAppCacheChangeNotification = @"ADTestAppCacheChangeNotification";
+NSString *ADTestAppProfileChangedNotification = @"ADTestAppProfileChangedNotification";
 
 static NSDictionary* s_profiles = nil;
 static NSArray* s_profileTitles = nil;
@@ -166,6 +167,8 @@ static NSUInteger s_currentProfileIdx = 0;
     self.redirectUri = [NSURL URLWithString:[settings objectForKey:@"redirectUri"]];
     self.resource = [settings objectForKey:@"resource"];
     self.defaultUser = [settings objectForKey:@"defaultUser"];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:ADTestAppProfileChangedNotification object:self];
 }
 
 @end

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -284,6 +284,14 @@
                                                     multiplier:1.0
                                                       constant:0];
     [mainView addConstraint:_bottomConstraint];
+    [self updateSettings];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(profileDidChange:) name:ADTestAppProfileChangedNotification object:nil];
+}
+
+- (void)profileDidChange:(NSNotification *)notification
+{
+    [self updateSettings];
 }
 
 - (BOOL)textFieldShouldReturn:(UITextField *)textField
@@ -342,6 +350,12 @@
 
 - (void)viewWillAppear:(BOOL)animated
 {
+    
+}
+
+- (void)updateSettings
+{
+    [_profileButton setTitle:[ADTestAppSettings currentProfileTitle] forState:UIControlStateNormal];
     ADTestAppSettings* settings = [ADTestAppSettings settings];
     NSString* defaultUser = settings.defaultUser;
     if (![NSString adIsStringNilOrBlank:defaultUser])
@@ -352,8 +366,6 @@
     self.navigationController.navigationBarHidden = YES;
     _validateAuthority.selectedSegmentIndex = settings.validateAuthority ? 0 : 1;
     _brokerEnabled.selectedSegmentIndex = settings.enableBroker ? 1 : 0;
-    [_profileButton setTitle:[ADTestAppSettings currentProfileTitle] forState:UIControlStateNormal];
-    
 }
 
 - (void)didReceiveMemoryWarning {

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.h
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.h
@@ -24,7 +24,8 @@
 #import <Foundation/Foundation.h>
 
 
-extern NSString* ADTestAppCacheChangeNotification;
+extern NSString *ADTestAppCacheChangeNotification;
+extern NSString *ADTestAppProfileChangedNotification;
 
 @interface ADTestAppSettings : NSObject
 

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppSettings.m
@@ -38,7 +38,8 @@ static NSDictionary* _additionalProfiles()
 static NSDictionary* s_additionalProfiles = nil;
 
 
-NSString* ADTestAppCacheChangeNotification = @"ADTestAppCacheChangeNotification";
+NSString *ADTestAppCacheChangeNotification = @"ADTestAppCacheChangeNotification";
+NSString *ADTestAppProfileChangedNotification = @"ADTestAppProfileChangedNotification";
 
 static NSDictionary* s_profiles = nil;
 static NSArray* s_profileTitles = nil;
@@ -167,6 +168,8 @@ static NSUInteger s_currentProfileIdx = 0;
     self.validateAuthority = validate ? [validate boolValue] : YES;
     NSNumber* enableBroker = [settings objectForKey:@"enableBroker"];
     self.enableBroker = [enableBroker boolValue];
+    
+    [[NSNotificationCenter defaultCenter] postNotificationName:ADTestAppProfileChangedNotification object:self];
 }
 
 @end


### PR DESCRIPTION
Setting the controls on -viewWillAppear caused a lot of controls to get flipped when the user did not intend