### PR TITLE
Add custom headers in start loading

### DIFF
--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -173,6 +173,8 @@ static NSUUID *_reqCorId(NSURLRequest* request)
         [ADURLProtocol addCorrelationId:_correlationId toRequest:request];
     }
     
+    [ADCustomHeaderHandler applyCustomHeadersTo:request];
+    
     [NSURLProtocol setProperty:@YES forKey:s_kADURLProtocolPropertyKey inRequest:request];
     
     _dataTask = [[[self class] sharedDemux] dataTaskWithRequest:request delegate:self];
@@ -221,10 +223,6 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
     
     if (!response)
     {
-        // If there wasn't a redirect response that means that we're canonicalizing
-        // the URL and don't need to cancel the connection or worry about an infinite
-        // loop happening so we can just return the response now.
-        
         completionHandler(mutableRequest);
         return;
     }


### PR DESCRIPTION
NSURLConnection’s connection:willSendRequest:redirectResponse: was hit at the beginning of the request as well as redirects, while NSURLSession’s HTTP redirect is only hit on redirects. This was causing the initial request to not have a pkeyauth header, and thus, no pkeyauth challenge.