### PR TITLE
Fix documentation warnings

### DIFF
--- a/ADAL/src/ADLogger+Internal.h
+++ b/ADAL/src/ADLogger+Internal.h
@@ -97,10 +97,10 @@
 + (LogCallback)getLogCallBack;
 
 /*! Main logging function. Macros like ADAL_LOG_ERROR are provided on top for convenience
- @param logLevel: The applicable priority of the logged message. Use AD_LOG_LEVEL_NO_LOG to disable all logging.
- @param message: Short text defining the operation/condition.
- @param additionalInformation: Full details. May contain parameter names, stack traces, etc. May be nil.
- @param errorCode: if an explicit error has occurred, this code will contain its code.
+ @param logLevel The applicable priority of the logged message. Use AD_LOG_LEVEL_NO_LOG to disable all logging.
+ @param message Short text defining the operation/condition.
+ @param additionalInformation Full details. May contain parameter names, stack traces, etc. May be nil.
+ @param errorCode if an explicit error has occurred, this code will contain its code.
  */
 + (void)log:(ADAL_LOG_LEVEL)logLevel
     context:(id)context
@@ -120,10 +120,10 @@ correlationId:(NSUUID *)correlationId
      format:(NSString *)format, ... __attribute__((format(__NSString__, 7, 8)));
 
 /*! Logs obtaining of a token. The method does not log the actual token, only its hash.
- @param token: the token to log.
- @param tokenType: "access token", "refresh token", "multi-resource refresh token"
- @param expiresOn: the time when an access token will stop to be valid. Nil for refresh token types.
- @param correlationId: In case the token was just obtained from the server, the correlation id of the call.
+ @param token The token to log.
+ @param tokenType "access token", "refresh token", "multi-resource refresh token"
+ @param expiresOn The time when an access token will stop to be valid. Nil for refresh token types.
+ @param correlationId In case the token was just obtained from the server, the correlation id of the call.
  This parameter can be nil.
  */
 + (void)logToken:(NSString *)token

--- a/ADAL/src/cache/ADTokenCache.m
+++ b/ADAL/src/cache/ADTokenCache.m
@@ -462,10 +462,10 @@
 #pragma mark ADTokenCacheAccessor Protocol Implementation
 
 /*! May return nil, if no cache item corresponds to the requested key
- @param key: The key of the item.
- @param user: The specific user whose item is needed. May be nil, in which
+ @param key The key of the item.
+ @param userId The specific user whose item is needed. May be nil, in which
  case the item for the first user in the cache will be returned.
- @param error: Will be set only in case of ambiguity. E.g. if userId is nil
+ @param error Will be set only in case of ambiguity. E.g. if userId is nil
  and we have tokens from multiple users. If the cache item is not present,
  the error will not be set. */
 - (ADTokenCacheItem *)getItemWithKey:(ADTokenCacheKey *)key
@@ -509,7 +509,7 @@
 /*! Extracts the key from the item and uses it to set the cache details. If another item with the
  same key exists, it will be overriden by the new one. 'getItemWithKey' method can be used to determine
  if an item already exists for the same key.
- @param error: in case of an error, if this parameter is not nil, it will be filled with
+ @param error in case of an error, if this parameter is not nil, it will be filled with
  the error details. */
 - (BOOL)addOrUpdateItem:(ADTokenCacheItem *)item
           correlationId:(NSUUID *)correlationId

--- a/ADAL/src/cache/ADTokenCacheKey.h
+++ b/ADAL/src/cache/ADTokenCacheKey.h
@@ -37,9 +37,9 @@
 }
 
 /*! Creates a key
- @param authority: Required. The authentication authority used.
- @param resource: Optional. The resource used for the token. Multi-resource refresh token items can be extracted by specifying nil.
- @param scope: Optional, can be nil. The OAuth2 scope.
+ @param authority Required. The authentication authority used.
+ @param resource Optional. The resource used for the token. Multi-resource refresh token items can be extracted by specifying nil.
+ @param clientId Optional, can be nil. The client identifier
  */
 + (ADTokenCacheKey *)keyWithAuthority:(NSString *)authority
                              resource:(NSString *)resource

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -194,7 +194,7 @@ typedef enum
     Creates an instance of ADAuthenticationContext with the provided parameters.
  
     @param authority            The AAD or ADFS authority. Example: @"https://login.windows.net/contoso.com"
-    @param validateAuthority    Specifies if the authority should be validated.
+    @param validate             Specifies if the authority should be validated.
     @param error                (Optional) Any extra error details, if the method fails
  
     @return An instance of ADAuthenticationContext, nil if it fails.
@@ -221,7 +221,7 @@ typedef enum
     Creates an instance of ADAuthenticationContext with the provided parameters.
  
     @param authority            The AAD or ADFS authority. Example: @"https://login.windows.net/contoso.com"
-    @param validateAuthority    Specifies if the authority should be validated.
+    @param validate             Specifies if the authority should be validated.
     @param sharedGroup          The keychain sharing group to use for the ADAL token cache (iOS Only)
     @param error                (Optional) Any extra error details, if the method fails
  
@@ -278,12 +278,12 @@ typedef enum
  the function will use the refresh token automatically. If neither of these attempts succeeds, the method will use the provided assertion to get an 
  access token from the service.
  
- @param samlAssertion: the assertion representing the authenticated user.
- @param assertionType: the assertion type of the user assertion.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param userId: the required user id of the authenticated user.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param assertion The assertion representing the authenticated user.
+ @param assertionType The assertion type of the user assertion.
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param userId The required user id of the authenticated user.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenForAssertion:(NSString*)assertion
                    assertionType:(ADAssertionType)assertionType
@@ -299,10 +299,10 @@ typedef enum
  credentials web UI for the user to re-authorize the resource usage. Logon cookie from previous authorization may be
  leveraged by the web UI, so user may not be actuall prompted. Use the other overloads if a more precise control of the
  UI displaying is desired.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
@@ -315,12 +315,12 @@ typedef enum
  credentials web UI for the user to re-authorize the resource usage. Logon cookie from previous authorization may be
  leveraged by the web UI, so user may not be actuall prompted. Use the other overloads if a more precise control of the
  UI displaying is desired.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol
- @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param userId The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
  it may not be used if it belongs to different token. This parameter can be nil.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
@@ -334,13 +334,13 @@ typedef enum
  credentials web UI for the user to re-authorize the resource usage. Logon cookie from previous authorization may be
  leveraged by the web UI, so user may not be actuall prompted. Use the other overloads if a more precise control of the
  UI displaying is desired.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol
- @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param userId The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
  it may not be used if it belongs to different token. This parameter can be nil.
- @param extraQueryParameters: will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
@@ -351,15 +351,14 @@ typedef enum
 
 /*! Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize the
  resource usage (through webview credentials UI) or attempt to use the cached tokens first.
- @param resource: the resource for whom token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol
- @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ @param resource The resource for whom token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param promptBehavior Controls if any credentials UI will be shown
+ @param userId The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
  it may not be used if it belongs to different token. This parameter can be nil.
- @param extraQueryParameters: will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
- @param credentialsType: controls the way of obtaining client credentials if such are needed.
- @param promptBehavior: controls if any credentials UI will be shownt.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
@@ -371,12 +370,12 @@ typedef enum
 
 /*! Follows the OAuth2 protocol (RFC 6749). The behavior is controlled by the promptBehavior parameter on whether to re-authorize the
  resource usage (through webview credentials UI) or attempt to use the cached tokens first.
- @param resource the resource for whom token is needed.
- @param clientId the client identifier
+ @param resource The resource for whom token is needed.
+ @param clientId The client identifier
  @param redirectUri The redirect URI according to OAuth2 protocol
- @param promptBehavior controls if any credentials UI will be shown.
+ @param promptBehavior Controls if any credentials UI will be shown.
  @param userId An ADUserIdentifier object describing the user being authenticated
- @param extraQueryParameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
  @param completionBlock the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString*)resource
@@ -391,10 +390,10 @@ typedef enum
  expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
  the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.
  If reauthorization is needed, the method will return an error with code AD_ERROR_USER_INPUT_NEEDED.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param resource the resource whose token is needed.
+ @param clientId the client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenSilentWithResource:(NSString*)resource
                               clientId:(NSString*)clientId
@@ -405,12 +404,12 @@ typedef enum
  expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
  the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.
  If reauthorization is needed, the method will return an error with code AD_ERROR_USER_INPUT_NEEDED.
- @param resource: the resource whose token is needed.
- @param clientId: the client identifier
- @param redirectUri: The redirect URI according to OAuth2 protocol
- @param userId: The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param userId The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
  it may not be used if it belongs to different token. This parameter can be nil.
- @param completionBlock: the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenSilentWithResource:(NSString*)resource
                               clientId:(NSString*)clientId

--- a/ADAL/src/public/ADAuthenticationParameters.h
+++ b/ADAL/src/public/ADAuthenticationParameters.h
@@ -52,9 +52,9 @@ typedef void (^ADParametersCompletion)(ADAuthenticationParameters* parameters, A
 /*! Creates authentication parameters from the response received from the resource. The method 
  creates an HTTP GET request and expects the resource to have unauthorized status (401) and "WWW-Authenticate" 
  header, containing authentication parameters.
- @param: response: the response received from the server with the requirements above. May return null if
+ @param response The response received from the server with the requirements above. May return null if
  an error has occurred.
- @param: error: Can be nil. If this parameter is not nil and an error occurred, it will be set to
+ @param error Can be nil. If this parameter is not nil and an error occurred, it will be set to
  contain the error
  */
 +(ADAuthenticationParameters*) parametersFromResponse: (NSHTTPURLResponse*) response
@@ -62,8 +62,8 @@ typedef void (^ADParametersCompletion)(ADAuthenticationParameters* parameters, A
 
 /*! Creates authentication parameters from "WWW-Authenticate" header of the response received
  from the resource. The method expects the header to contain authentication parameters.
- @param: authenticateHeader: the http response header, containing the authentication parameters.
- @param: error: Can be nil. If this parameter is not nil and an error occurred, it will be set to
+ @param authenticateHeader The http response header, containing the authentication parameters.
+ @param error Can be nil. If this parameter is not nil and an error occurred, it will be set to
  contain the error
  */
 +(ADAuthenticationParameters*) parametersFromResponseAuthenticateHeader: (NSString*) authenticateHeader
@@ -72,8 +72,8 @@ typedef void (^ADParametersCompletion)(ADAuthenticationParameters* parameters, A
 /*! Extracts the authority from the the error code 401 http error code response. The method
  expects that the resource will respond with a HTTP 401 and "WWW-Authenticate" header, containing the
  authentication parameters.
- @param resourceUrl: address of the resource.
- @param completionBlock: the callback block to be executed upon completion.
+ @param resourceUrl The address of the resource.
+ @param completion The callback block to be executed upon completion.
  */
 +(void) parametersFromResourceUrl: (NSURL*)resourceUrl
                   completionBlock: (ADParametersCompletion) completion;

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSDictionary*)tombstone;
 
 /*! Obtains a key to be used for the internal cache from the full cache item.
- @param error: if a key cannot be extracted, the method will return nil and if this parameter is not nil,
+ @param error If a key cannot be extracted, the method will return nil and if this parameter is not nil,
  it will be filled with the appropriate error information.*/
 - (nullable ADTokenCacheKey*)extractKey:(ADAuthenticationError * _Nullable __autoreleasing * _Nullable)error;
 

--- a/ADAL/src/public/ADUserInformation.h
+++ b/ADAL/src/public/ADUserInformation.h
@@ -34,7 +34,7 @@
 }
 
 /*! Factory method to extract user information from the AAD id_token parameter.
- @param: idToken: The contents of the id_token parameter, as passed by the server. */
+ @param idToken The contents of the id_token parameter, as passed by the server. */
 + (ADUserInformation *) userInformationWithIdToken:(NSString *)idToken
                                              error:(ADAuthenticationError * __autoreleasing *)error;
 

--- a/ADAL/src/public/ios/ADKeychainTokenCache.h
+++ b/ADAL/src/public/ios/ADKeychainTokenCache.h
@@ -61,7 +61,7 @@
 - (nullable instancetype)init;
 
 /*! Initializes the token cache store.
- @param: sharedGroup: Optional. If the application needs to share the cached tokens
+ @param sharedGroup Optional. If the application needs to share the cached tokens
  with other applications from the same vendor, the app will need to specify the 
  shared group here and add the necessary entitlements to the application.
  See Apple's keychain services documentation for details. */

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -114,7 +114,7 @@
     Takes the UI interaction lock for the current request, will send an error
     to completionBlock if it fails.
  
-    @param copmletionBlock  the ADAuthenticationCallback to send an error to if
+    @param completionBlock  the ADAuthenticationCallback to send an error to if
                             one occurs.
  
     @return NO if we fail to take the exclusion lock

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -277,7 +277,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
     Takes the UI interaction lock for the current request, will send an error
     to completionBlock if it fails.
  
-    @param copmletionBlock  the ADAuthenticationCallback to send an error to if
+    @param completionBlock  the ADAuthenticationCallback to send an error to if
                             one occurs.
  
     @return NO if we fail to take the exclusion lock

--- a/ADAL/src/utils/NSString+ADHelperMethods.h
+++ b/ADAL/src/utils/NSString+ADHelperMethods.h
@@ -35,6 +35,7 @@
 
 /*! Returns the same string, but without the leading and trailing whitespace */
 - (NSString *)adTrimmedString;
+
 /*! Decodes a previously URL encoded string. */
 - (NSString *)adUrlFormDecode;
 


### PR DESCRIPTION
This PR fixes Xcode warnings like the following:

> `Parameter 'resource:' not found in the function declaration`