### PR TITLE
Allow broker app to acquire tokens

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -239,9 +239,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 + (BOOL)isResponseFromBroker:(NSString*)sourceApplication
                     response:(NSURL*)response
 {
-    return //sourceApplication && [NSString adSame:sourceApplication toString:brokerAppIdentifier];
-    response &&
-    [NSString adSame:sourceApplication toString:@"com.microsoft.azureauthenticator"];
+    return response && [sourceApplication isEqualToString:ADAL_BROKER_APP_BUNDLE_ID];
 }
 
 + (BOOL)handleBrokerResponse:(NSURL*)response

--- a/ADAL/src/ADOAuth2Constants.h
+++ b/ADAL/src/ADOAuth2Constants.h
@@ -91,3 +91,5 @@ extern NSString *const AUTH_FAILED_BUSY;
 extern NSString *const AAD_SECURECONVERSATION_LABEL;
 
 extern NSString* const ADAL_BROKER_SCHEME;
+extern NSString* const ADAL_BROKER_APP_REDIRECT_URI;
+extern NSString* const ADAL_BROKER_APP_BUNDLE_ID;

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -94,4 +94,6 @@ NSString *const AAD_SECURECONVERSATION_LABEL = @"AzureAD-SecureConversation";
 
 //application constants
 NSString* const ADAL_BROKER_SCHEME = @"msauth";
+NSString* const ADAL_BROKER_APP_REDIRECT_URI = @"urn:ietf:wg:oauth:2.0:oob";
+NSString* const ADAL_BROKER_APP_BUNDLE_ID = @"com.microsoft.azureauthenticator";
 

--- a/ADAL/src/broker/ios/ADBrokerHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerHelper.m
@@ -92,6 +92,8 @@ BOOL __swizzle_ApplicationOpenURLiOS9(id self, SEL _cmd, UIApplication* applicat
 
 @implementation ADBrokerHelper
 
+// If we are in the broker, do not intercept openURL calls
+#if !AD_BROKER
 + (void)load
 {
     if ([ADAppExtensionUtil isExecutingInAppExtension])
@@ -161,6 +163,7 @@ BOOL __swizzle_ApplicationOpenURLiOS9(id self, SEL _cmd, UIApplication* applicat
          }
      }];
 }
+#endif
 
 + (BOOL)canUseBroker
 {

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -187,7 +187,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     
     // NSURLComponents resolves some URLs which can't get resolved by NSURL
     NSURLComponents* components = [NSURLComponents componentsWithURL:response resolvingAgainstBaseURL:NO];
-    NSString *qp = [components query];
+    NSString *qp = [components percentEncodedQuery];
     //expect to either response or error and description, AND correlation_id AND hash.
     NSDictionary* queryParamsMap = [NSDictionary adURLFormDecode:qp];
 

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -60,6 +60,11 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     (void)s_brokerAppVersion;
     (void)s_brokerProtocolVersion;
     
+    if ([url isEqualToString:ADAL_BROKER_APP_REDIRECT_URI])
+    {
+        return YES;
+    }
+    
     NSArray* urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
     
     NSURL* redirectURI = [NSURL URLWithString:url];
@@ -177,7 +182,9 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
         return nil;
     }
     
-    NSString *qp = [response query];
+    // NSURLComponents resolves some URLs which can't get resolved by NSURL
+    NSURLComponents* components = [NSURLComponents componentsWithURL:response resolvingAgainstBaseURL:NO];
+    NSString *qp = [components query];
     //expect to either response or error and description, AND correlation_id AND hash.
     NSDictionary* queryParamsMap = [NSDictionary adURLFormDecode:qp];
 

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -60,10 +60,13 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     (void)s_brokerAppVersion;
     (void)s_brokerProtocolVersion;
     
+#ifdef AD_BROKER
+    // Allow the broker app to use a special redirect URI when acquiring tokens
     if ([url isEqualToString:ADAL_BROKER_APP_REDIRECT_URI])
     {
         return YES;
     }
+#endif
     
     NSArray* urlTypes = [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleURLTypes"];
     

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -60,7 +60,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     (void)s_brokerAppVersion;
     (void)s_brokerProtocolVersion;
     
-#ifdef AD_BROKER
+#if AD_BROKER
     // Allow the broker app to use a special redirect URI when acquiring tokens
     if ([url isEqualToString:ADAL_BROKER_APP_REDIRECT_URI])
     {

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -190,7 +190,7 @@ const int sAsyncContextTimeout = 10;
     [context setCredentialsType:AD_CREDENTIALS_AUTO];
     [context acquireTokenWithResource:TEST_RESOURCE
                              clientId:TEST_CLIENT_ID
-                          redirectUri:[NSURL URLWithString:@"urn:ietf:wg:oauth:2.0:oob"]
+                          redirectUri:[NSURL URLWithString:@"invalid://redirect_uri"]
                       completionBlock:^(ADAuthenticationResult *result)
      {
          XCTAssertNotNil(result);

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -190,7 +190,7 @@ const int sAsyncContextTimeout = 10;
     [context setCredentialsType:AD_CREDENTIALS_AUTO];
     [context acquireTokenWithResource:TEST_RESOURCE
                              clientId:TEST_CLIENT_ID
-                          redirectUri:[NSURL URLWithString:@"invalid://redirect_uri"]
+                          redirectUri:[NSURL URLWithString:@"urn:ietf:wg:oauth:2.0:oob"]
                       completionBlock:^(ADAuthenticationResult *result)
      {
          XCTAssertNotNil(result);


### PR DESCRIPTION
 * Stop the exclusion lock from being taken twice when in the broker app

 * Allow the broker app to use a dummy redirect URI to request tokens

 * Prevent ADAL from swizzling openURL when in the broker app