### PR TITLE
[Fix] Automation Test App - Tapping Clear/Read Cache causes app to crash

### DIFF
--- a/ADAL/ADALAutomation/ADAutoMainViewController.m
+++ b/ADAL/ADALAutomation/ADAutoMainViewController.m
@@ -365,8 +365,8 @@
 
 - (void)displayResultJson:(NSString *)resultJson logs:(NSString *)resultLogs
 {
-    [self performSegueWithIdentifier:@"showResult" sender:@{@"resultInfo":resultJson,
-                                                            @"resultLogs":resultLogs}];
+    [self performSegueWithIdentifier:@"showResult" sender:@{@"resultInfo":resultJson ? resultJson : @"",
+                                                            @"resultLogs":resultLogs ? resultLogs : @""}];
 }
 
 - (NSString *)createJsonFromResult:(ADAuthenticationResult *)result


### PR DESCRIPTION
In case of no logs or result, app will crash. This fix will take care of this issue.
Addresses #920 

