### PR TITLE
Add login_hint for allowSilent request

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -245,6 +245,11 @@
             [requestData setObject:_scope forKey:OAUTH2_SCOPE];
         }
         
+        if ([_requestParams identifier] && [[_requestParams identifier] isDisplayable] && ![NSString adIsStringNilOrBlank:[_requestParams identifier].userId])
+        {
+            [requestData setObject:_requestParams.identifier.userId forKey:OAUTH2_LOGIN_HINT];
+        }
+        
         NSURL* reqURL = [NSURL URLWithString:[_context.authority stringByAppendingString:OAUTH2_AUTHORIZE_SUFFIX]];
         ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:reqURL
                                                               context:_requestParams];

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -1691,7 +1691,7 @@ const int sAsyncContextTimeout = 10;
                                                      dictionaryAsJSON:@{}];
     [ADTestURLConnection addResponse:response];
     
-    // We send send the actual silent network request
+    // We send the actual silent network request
     [req requestToken:^(ADAuthenticationResult *result)
      {
          // if request url is not expected,


### PR DESCRIPTION
Such that server won't return a different user just based on the cookies.

The if condition is copied over from line 109 from the same file.

(authenticator-hotfix-2.3.x branch is now the same as 2.3.1)
