### PR TITLE
Fix percent encoding issue in adQueryParameters (#926)

### DIFF
--- a/ADAL/src/utils/NSURL+ADExtensions.m
+++ b/ADAL/src/utils/NSURL+ADExtensions.m
@@ -41,7 +41,7 @@ const unichar queryStringSeparator = '?';
 {
     NSURLComponents* components = [NSURLComponents componentsWithURL:self resolvingAgainstBaseURL:YES];
     
-    return [NSDictionary adURLFormDecode:components.query];
+    return [NSDictionary adURLFormDecode:[components percentEncodedQuery]];
 }
 
 - (BOOL)isEquivalentAuthority:(NSURL *)aURL

--- a/ADAL/tests/NSURLExtensionsTests.m
+++ b/ADAL/tests/NSURLExtensionsTests.m
@@ -70,20 +70,37 @@
     XCTAssertEqualObjects(simple, ((NSURL*)[NSURL URLWithString:@"https://stuff.com?foo=bar#foo1=bar1&foo2=bar2&foo3=bar3=foo3"]).adFragmentParameters);
 }
 
-- (void)testAdQueryParameters
+- (void)testAdQueryParameters_whenNoQPS
 {
     //Negative:
     XCTAssertNil([[NSURL URLWithString:@"https://stuff.com"] adQueryParameters]);
-    
+}
+
+- (void)testAdQueryParameters_whenSimpleQPs
+{
     //Positive:
-    NSDictionary* simple = @{@"foo1":@"bar1", @"foo2":@"bar2"};
+    NSDictionary *simple = @{@"foo1":@"bar1", @"foo2":@"bar2"};
     XCTAssertEqualObjects(simple, ([[NSURL URLWithString:@"https://stuff.com?foo1=bar1&foo2=bar2"] adQueryParameters]));
-    
+}
+
+- (void)testAdQueryParameters_whenURINotURL
+{
     // Valid redirect url
+    NSDictionary *simple = @{@"foo1":@"bar1", @"foo2":@"bar2"};
     XCTAssertEqualObjects(simple, ([[NSURL URLWithString:@"urn:ietf:wg:oauth:2.0:oob?foo1=bar1&foo2=bar2"] adQueryParameters]));
-    
+}
+
+- (void)testAdQueryParamters_whenMixedQueryFragment
+{
     //Mixed query and fragment parameters:
+    NSDictionary *simple = @{@"foo1":@"bar1", @"foo2":@"bar2"};
     XCTAssertEqualObjects(simple, ([[NSURL URLWithString:@"https://stuff.com?foo1=bar1&foo2=bar2#foo3=bar3"] adQueryParameters]));
+}
+
+- (void)testAdQueryParameters_whenContainsPercentEncoding
+{
+    NSDictionary *withEncoded = @{@"foo1" : @"bar1", @"foo2" : @"bar2", @"foo3=bar3" : @"foo4&bar4=bar5"};
+    XCTAssertEqualObjects(withEncoded, ([[NSURL URLWithString:@"https://contoso.com?foo1=bar1&foo2=bar2&foo3%3Dbar3=foo4%26bar4%3Dbar5"] adQueryParameters]));
 }
 
 @end


### PR DESCRIPTION
* Use -percentEncodedQuery so we don’t trip up on any percent encodings within in the parameters
* Add unit test to catch the issue
* Split up UTs to clarify the case each is testing for

Fixes #926 