### PR TITLE
Fix a telemetry bug regarding thread safety

### DIFF
--- a/ADAL/src/telemetry/ADTelemetryDefaultEvent.m
+++ b/ADAL/src/telemetry/ADTelemetryDefaultEvent.m
@@ -161,9 +161,10 @@
         }
     });
     
-    [s_defaultParameters adSetObjectIfNotNil:[ADIpAddressHelper adDeviceIpAddress] forKey:AD_TELEMETRY_KEY_DEVICE_IP_ADDRESS];
+    NSMutableDictionary *defaultParameters = [s_defaultParameters mutableCopy];
+    [defaultParameters adSetObjectIfNotNil:[ADIpAddressHelper adDeviceIpAddress] forKey:AD_TELEMETRY_KEY_DEVICE_IP_ADDRESS];
     
-    return s_defaultParameters;
+    return defaultParameters;
 }
 
 - (NSInteger)getDefaultPropertyCount


### PR DESCRIPTION
A static NSMutableDictionary in `ADTelemetryDefaultEvent.m` could be modified by multiple threads, which could cause crash.

The bug is now fixed in the PR.