### PR TITLE
Fix bracket that causes Authenticator SDK build to fail

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -207,6 +207,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
     if (_refreshTokenCredential == refreshTokenCredential)
     {
         return;
+    }
     _refreshTokenCredential = [refreshTokenCredential copy];
 }
 #endif


### PR DESCRIPTION
A bracket is missing.