### PR TITLE
Additional cleanup for macOS WebView

### DIFF
--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -134,6 +134,8 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     [_webView setFrameLoadDelegate:nil];
     [_webView setResourceLoadDelegate:nil];
     [_webView setPolicyDelegate:nil];
+    
+    [_webView close];
     _webView = nil;
 }
 


### PR DESCRIPTION
This ensures webview will not do any more loading or fire any delegate methods after authentication window is closed. 

There's currently a crash on macOS Yosemite caused by internal WebView bug (https://bugs.webkit.org/show_bug.cgi?id=138443), which can be avoided by ensuring no web request will be handled after web view object is destroyed. stopLoading: seems to be not enough to ensure that.