### PR TITLE
Cleanup webview only if a new one was created

### DIFF
--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -68,8 +68,6 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     
     if (_webView)
     {
-        _embeddedWebview = YES;
-        
         [_webView setFrameLoadDelegate:self];
         [_webView setResourceLoadDelegate:self];
         [_webView setPolicyDelegate:self];
@@ -237,6 +235,22 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     (void)sender;
     (void)frame;
     [_delegate webAuthDidFailWithError:error];
+}
+
+#pragma mark - Overriden properties
+
+- (void)setWebView:(WebView *)webView
+{
+    if (webView)
+    {
+        _embeddedWebview = YES;
+    }
+    else
+    {
+        _embeddedWebview = NO;
+    }
+    
+    _webView = webView;
 }
 
 @end

--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -47,6 +47,7 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
 @interface ADAuthenticationViewController ( ) <WebResourceLoadDelegate, WebPolicyDelegate, WebFrameLoadDelegate, NSWindowDelegate>
 {
     NSProgressIndicator* _progressIndicator;
+    BOOL _embeddedWebview;
 }
 
 @end
@@ -67,6 +68,8 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     
     if (_webView)
     {
+        _embeddedWebview = YES;
+        
         [_webView setFrameLoadDelegate:self];
         [_webView setResourceLoadDelegate:self];
         [_webView setPolicyDelegate:self];
@@ -135,7 +138,13 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     [_webView setResourceLoadDelegate:nil];
     [_webView setPolicyDelegate:nil];
     
-    [_webView close];
+    if (!_embeddedWebview)
+    {
+        // Cleanup webview only if a new one was created
+        // If one was provided by the application, it might be reused
+        [_webView close];
+    }
+    
     _webView = nil;
 }
 

--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -241,15 +241,7 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
 
 - (void)setWebView:(WebView *)webView
 {
-    if (webView)
-    {
-        _embeddedWebview = YES;
-    }
-    else
-    {
-        _embeddedWebview = NO;
-    }
-    
+    _embeddedWebview = webView ? YES : NO;
     _webView = webView;
 }
 


### PR DESCRIPTION
Cleanup webview only if a new one was created
If one was provided by the application, it might be reused in future requests, so we shouldn't run close on it.