### PR TITLE
Removed mac web view Yosemite crash workaround

### DIFF
--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -47,7 +47,6 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
 @interface ADAuthenticationViewController ( ) <WebResourceLoadDelegate, WebPolicyDelegate, WebFrameLoadDelegate, NSWindowDelegate>
 {
     NSProgressIndicator* _progressIndicator;
-    BOOL _embeddedWebview;
 }
 
 @end
@@ -135,14 +134,6 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     [_webView setFrameLoadDelegate:nil];
     [_webView setResourceLoadDelegate:nil];
     [_webView setPolicyDelegate:nil];
-    
-    if (!_embeddedWebview)
-    {
-        // Cleanup webview only if a new one was created
-        // If one was provided by the application, it might be reused
-        [_webView close];
-    }
-    
     _webView = nil;
 }
 
@@ -235,14 +226,6 @@ decisionListener:(id<WebPolicyDecisionListener>)listener
     (void)sender;
     (void)frame;
     [_delegate webAuthDidFailWithError:error];
-}
-
-#pragma mark - Overriden properties
-
-- (void)setWebView:(WebView *)webView
-{
-    _embeddedWebview = webView ? YES : NO;
-    _webView = webView;
 }
 
 @end


### PR DESCRIPTION
After additional testing it looks like this workaround doesn’t fix all possible cases. Looks like it really depends on what webpage is doing and how it’s handled by WebKit. 
Because it’s caused by a WebKit bug, which has already been fixed in 10.11+, and workaround works only for some cases, removing the workaround for now. 