### PR TITLE
Fixing two memory leaks in ADWebRequest

### DIFF
--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -105,6 +105,7 @@
             parameters = [self parametersFromResponseHeaders:response.headers error:&adError];
         }
         completion(parameters, adError);
+        [request invalidate];
     }];
 }
 

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -148,6 +148,8 @@
          result = [ADAuthenticationContext updateResult:result toUser:[_requestParams identifier]];//Verify the user (just in case)
          
          completionBlock(result);
+         
+         [webReq invalidate];
      }];
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -60,6 +60,8 @@
                                                          fromRefresh:NO
                                                 requestCorrelationId:[_requestParams correlationId]];
          completionBlock(result);
+         
+         [req invalidate];
      }];
 }
 
@@ -277,6 +279,7 @@
              }
              
              requestCompletion(error, endURL);
+             [req invalidate];
          }];
     }
 }

--- a/ADAL/src/request/ADAuthorityValidationRequest.m
+++ b/ADAL/src/request/ADAuthorityValidationRequest.m
@@ -54,6 +54,8 @@ static NSString* const s_kAuthorizationEndPointKey = @"authorization_endpoint";
         {
             completionBlock(response, nil);
         }
+        
+        [webRequest invalidate];
     }];
 }
 

--- a/ADAL/src/request/ADDrsDiscoveryRequest.m
+++ b/ADAL/src/request/ADDrsDiscoveryRequest.m
@@ -51,6 +51,8 @@
         {
             completionBlock(response, nil);
         }
+        
+        [webRequest invalidate];
     }];
 }
 

--- a/ADAL/src/request/ADWebFingerRequest.m
+++ b/ADAL/src/request/ADWebFingerRequest.m
@@ -51,6 +51,8 @@
         {
             completionBlock(response, nil);
         }
+        
+        [webRequest invalidate];
 
     }];
 }

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -32,7 +32,6 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 {
     NSURLSessionDataTask * _task;
     
-    NSURLSessionConfiguration *_configuration;
     NSURLSession *_session;
     
     NSURL * _requestURL;
@@ -60,7 +59,6 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 @property (readonly) NSUUID *correlationId;
 @property (readonly) NSString *telemetryRequestId;
 
-@property (atomic, copy,   readonly) NSURLSessionConfiguration* configuration;
 @property (atomic, strong, readonly) NSURLSession *session;
 
 - (id)initWithURL:(NSURL *)url
@@ -77,6 +75,13 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
     within the completionHandler block on -send:
  */
 - (void)resend;
+
+/*!
+    Invalidates session object and nils the completionHandler.
+    Caller must invoke this method once it's done with the session.
+    Do not use send or resend after calling invalidate.
+ */
+- (void)invalidate;
 
 @end
 

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -54,7 +54,6 @@
 @synthesize correlationId = _correlationId;
 @synthesize telemetryRequestId = _telemetryRequestId;
 @synthesize session = _session;
-@synthesize configuration = _configuration;
 
 - (NSData *)body
 {
@@ -98,8 +97,8 @@
     
     _telemetryRequestId = context.telemetryRequestId;
     
-    _configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
-    _session = [NSURLSession sessionWithConfiguration:_configuration delegate:self delegateQueue:nil];
+    NSURLSessionConfiguration *configuration = [NSURLSessionConfiguration defaultSessionConfiguration];
+    _session = [NSURLSession sessionWithConfiguration:configuration delegate:self delegateQueue:nil];
     
     return self;
 }
@@ -169,6 +168,11 @@
     [_task resume];
 }
 
+- (void)invalidate
+{
+    [_session finishTasksAndInvalidate];
+    _completionHandler = nil;
+}
 
 #pragma mark - NSURLSession delegates
 - (void)URLSession:(NSURLSession *)session didReceiveChallenge:(NSURLAuthenticationChallenge *)challenge completionHandler:(void (^)(NSURLSessionAuthChallengeDisposition, NSURLCredential * _Nullable))completionHandler

--- a/ADAL/tests/ADTestURLSession.m
+++ b/ADAL/tests/ADTestURLSession.m
@@ -575,6 +575,11 @@ static NSMutableArray* s_responses = nil;
     return NO;
 }
 
+- (void)finishTasksAndInvalidate
+{
+    self.delegate = nil;
+    self.delegateQueue = nil;
+}
 
 
 


### PR DESCRIPTION
Fixing two memory leaks in ADWebRequest (session delegate and completionHandler leaks #794)