### PR TITLE
Make headers field of ADWebRequest public

### DIFF
--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -54,6 +54,7 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 }
 
 @property (strong, readonly, nonatomic) NSURL               *URL;
+@property (copy, nonatomic)             NSMutableDictionary *headers;
 @property (strong)                      NSData              *body;
 @property (nonatomic)                   NSUInteger           timeout;
 @property BOOL isGetRequest;

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -54,7 +54,6 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 }
 
 @property (strong, readonly, nonatomic) NSURL               *URL;
-@property (copy, nonatomic)             NSMutableDictionary *headers;
 @property (strong)                      NSData              *body;
 @property (nonatomic)                   NSUInteger           timeout;
 @property BOOL isGetRequest;
@@ -69,7 +68,7 @@ typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 
 - (void)send:( void (^)( NSError *, ADWebResponse *) )completionHandler;
 
-
+- (void)addToHeadersFromDictionary:(NSDictionary *)headers;
 - (void)setAuthorizationHeader:(NSString *)header;
 
 /*!

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -49,6 +49,7 @@
 #pragma mark - Properties
 
 @synthesize URL      = _requestURL;
+@synthesize headers  = _requestHeaders;
 @synthesize timeout  = _timeout;
 @synthesize isGetRequest = _isGetRequest;
 @synthesize correlationId = _correlationId;

--- a/ADAL/src/request/ADWebRequest.m
+++ b/ADAL/src/request/ADWebRequest.m
@@ -49,7 +49,6 @@
 #pragma mark - Properties
 
 @synthesize URL      = _requestURL;
-@synthesize headers  = _requestHeaders;
 @synthesize timeout  = _timeout;
 @synthesize isGetRequest = _isGetRequest;
 @synthesize correlationId = _correlationId;
@@ -265,6 +264,11 @@
     [event setHttpRequestQueryParams:_requestURL.query];
     
     [[ADTelemetry sharedInstance] stopEvent:_telemetryRequestId event:event];
+}
+
+- (void)addToHeadersFromDictionary:(NSDictionary *)headers
+{
+    [_requestHeaders addEntriesFromDictionary:headers];
 }
 
 - (void) setAuthorizationHeader:(NSString *)header


### PR DESCRIPTION
fixes #974 

Since broker SDK needs to modify the headers, it is made as a property.