### PR TITLE
fix: Removed NSLog of the ADAL version in ADAuthenticationContext +load method

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -53,14 +53,6 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 @synthesize logComponent = _logComponent;
 @synthesize webView = _webView;
 
-+ (void)load
-{
-    // +load is called by the ObjC runtime before main() as it loads in ObjC symbols and
-    // populates the runtime.
-    
-    NSLog(@"ADAL version %@", ADAL_VERSION_VAR);
-}
-
 - (id)init
 {
     //Ensure that the appropriate init function is called. This will cause the runtime to throw.


### PR DESCRIPTION
Every app launch logs the ADAL version; this is not helpful.  Every real log message coming out of the ADAL includes the ADAL version so there’s no reason to automatically log at app launch.