### PR TITLE
Make sure we don't follow redirects for cancelled requests

### DIFF
--- a/ADAL/src/urlprotocol/ADURLProtocol.m
+++ b/ADAL/src/urlprotocol/ADURLProtocol.m
@@ -252,7 +252,7 @@ willPerformHTTPRedirection:(NSHTTPURLResponse *)response
                                                  code:NSUserCancelledError
                                              userInfo:nil]];
     
-    completionHandler(mutableRequest);
+    completionHandler(nil);
 }
 
 - (void)URLSession:(NSURLSession *)session task:(NSURLSessionTask *)task


### PR DESCRIPTION
In ADURLProtocol we’re catching willPerformHTTPRedirection and in the end of the call we rely on multiple things:
1. Calling URLProtocol:wasRedirectedToRequest:redirectResponse, which should create a new NSURLProtocol instance to run the load of the redirect (where we create and run a new data task).
2. Cancelling the previous task to avoid double requests
3. Calling completionHandler with mutableRequest in the end, relying on nr 2 in cancelling the request.

However it seems that nr 3 doesn’t always seem to be true and if we call completionHandler with mutableRequest, cancel might sometimes not cancel the request first and we sometimes end up with double requests, because it tries to do the modified request.