### PR TITLE
#800 Fix auth window position, when using multiple monitors

### DIFF
--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -34,9 +34,6 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     CGFloat x = rect1.origin.x + ((rect1.size.width - rect2.size.width) / 2);
     CGFloat y = rect1.origin.y + ((rect1.size.height - rect2.size.height) / 2);
     
-    x = x < 0 ? 0 : x;
-    y = y < 0 ? 0 : y;
-    
     rect2.origin.x = x;
     rect2.origin.y = y;
     


### PR DESCRIPTION
The coordinates of secondary screen might be negative. This check breaks window positioning, when the last active window is on the other screen.