### PR TITLE
Override NSAlert default keyviewloop after showing it

### DIFF
--- a/ADAL/src/ui/mac/ADNTLMUIPrompt.m
+++ b/ADAL/src/ui/mac/ADNTLMUIPrompt.m
@@ -61,14 +61,6 @@ __weak static NSAlert *_presentedPrompt = nil;
         [view.passwordLabel setStringValue:NSLocalizedString(@"Password", nil)];
         [alert setAccessoryView:view.customView];
         
-        [view.usernameField setNextKeyView:view.passwordField];
-        [view.passwordField setNextKeyView:cancelButton];
-        [cancelButton setNextKeyView:loginButton];
-        [loginButton setNextKeyView:view.usernameField];
-        
-        // TODO: NSAlert some time after this overides the keyview loop so that
-        // it gets stuck between loginButton and cancel button.To fix this bug
-        // we'll have to ditch NSAlert entirely. (#851)
         [[alert window] setInitialFirstResponder:view.usernameField];
         
         [alert beginSheetModalForWindow:[NSApp keyWindow] completionHandler:^(NSModalResponse returnCode)
@@ -87,6 +79,11 @@ __weak static NSAlert *_presentedPrompt = nil;
          }];
         
         _presentedPrompt = alert;
+        
+        [view.usernameField setNextKeyView:view.passwordField];
+        [view.passwordField setNextKeyView:cancelButton];
+        [cancelButton setNextKeyView:loginButton];
+        [loginButton setNextKeyView:view.usernameField];
     });
 }
 


### PR DESCRIPTION
#851 I don’t think we should get rid of NSAlert all together, since it lays out UI in a generic well known way (e.g showing app icon, button positions etc). Trying to copy that UI would be a little bit strange. I personally don’t see any reason why we cannot modify keyviewloop after showing the alert, which would solve that issue without getting rid of NSAlert. Please let me know if I’m missing something. 