### PR TITLE
Add CBA Support on Mac

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		29DBF6D61E36D5A600D5B690 /* NSMutableDictionary+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 29DBF6D41E36CD1E00D5B690 /* NSMutableDictionary+ADExtensions.m */; };
 		29DBF6D71E36D5A900D5B690 /* NSMutableDictionary+ADExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = 29DBF6D41E36CD1E00D5B690 /* NSMutableDictionary+ADExtensions.m */; };
 		3889BE201E5C929600743037 /* ADClientCertAuthHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 3889BE1E1E5C929600743037 /* ADClientCertAuthHandler.h */; };
-		3889BE211E5C929600743037 /* ADClientCertAuthHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3889BE1F1E5C929600743037 /* ADClientCertAuthHandler.m */; };
 		3889BE221E5C929600743037 /* ADClientCertAuthHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 3889BE1F1E5C929600743037 /* ADClientCertAuthHandler.m */; };
 		600401A51D3421480020EAAB /* ADTelemetry.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401A31D3421480020EAAB /* ADTelemetry.m */; };
 		600401A71D3426250020EAAB /* ADTelemetry+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 600401A61D3426250020EAAB /* ADTelemetry+Internal.h */; };
@@ -1732,7 +1731,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				3889BE211E5C929600743037 /* ADClientCertAuthHandler.m in Sources */,
 				60C351BA1DA0D588006C8435 /* ADAL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		D69A721A1D4FF68300E91DB3 /* ADDefaultDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401BC1D377E9F0020EAAB /* ADDefaultDispatcher.m */; };
 		D69A721B1D4FF68300E91DB3 /* ADAggregatedDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401B51D37658C0020EAAB /* ADAggregatedDispatcher.m */; };
 		D69A721C1D4FF68300E91DB3 /* ADTelemetryDefaultEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401AA1D3443D30020EAAB /* ADTelemetryDefaultEvent.m */; };
+		D6B658861EF8AB5B006CB0C6 /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6B658851EF8AB5B006CB0C6 /* SecurityInterface.framework */; };
 		D6D8A8401D4FD14E00D20DE6 /* ADKeychainUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D8A83F1D4FD14E00D20DE6 /* ADKeychainUtil.m */; };
 		D6F095151CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = D6F095131CDC072200D28FC2 /* ADAcquireTokenSilentHandler.h */; };
 		D6F095171CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D6F095141CDC072200D28FC2 /* ADAcquireTokenSilentHandler.m */; };
@@ -664,6 +665,7 @@
 		D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoinUtil.m; sourceTree = "<group>"; };
 		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
 		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
+		D6B658851EF8AB5B006CB0C6 /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/SecurityInterface.framework; sourceTree = DEVELOPER_DIR; };
 		D6D8A83E1D4FD14100D20DE6 /* ADKeychainUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADKeychainUtil.h; sourceTree = "<group>"; };
 		D6D8A83F1D4FD14E00D20DE6 /* ADKeychainUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADKeychainUtil.m; sourceTree = "<group>"; };
 		D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADAuthenticationContext+Internal.h"; sourceTree = "<group>"; };
@@ -720,6 +722,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D6B658861EF8AB5B006CB0C6 /* SecurityInterface.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -841,6 +844,7 @@
 		8B0965AC17F25770002BDFB8 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				D6B658851EF8AB5B006CB0C6 /* SecurityInterface.framework */,
 				97EEE7B41A4C0D6000D003F8 /* QuartzCore.framework */,
 				8BA729B017FE0BDA00CACB46 /* UIKit.framework */,
 				8B0965AD17F25770002BDFB8 /* Foundation.framework */,

--- a/ADAL/src/ui/ADAuthenticationViewController.h
+++ b/ADAL/src/ui/ADAuthenticationViewController.h
@@ -48,4 +48,8 @@ NSWindowController
 - (void)startSpinner;
 - (void)stopSpinner;
 
+#if !TARGET_OS_IPHONE
+- (NSWindow *)webviewWindow;
+#endif
+
 @end

--- a/ADAL/src/ui/mac/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/mac/ADAuthenticationViewController.m
@@ -177,6 +177,11 @@ static NSRect _CenterRect(NSRect rect1, NSRect rect2)
     [self.window.contentView setNeedsDisplay:YES];
 }
 
+- (NSWindow *)webviewWindow
+{
+    return _webView.window;
+}
+
 - (void)webView:(WebView *)webView
 decidePolicyForNavigationAction:(NSDictionary *)actionInformation
         request:(NSURLRequest *)request

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -202,9 +202,10 @@
 - (void)beginSheet:(NSArray *)identities
            message:(NSString *)message
 {
+    [_panel setAlternateButtonTitle:NSLocalizedString(@"Cancel", "Cancel button on cert selection sheet")];
     [_panel beginSheetForWindow:[[[ADWebAuthController sharedInstance] viewController] webviewWindow]
                   modalDelegate:self
-                 didEndSelector:@selector(sheetDidEnd:)
+                 didEndSelector:@selector(sheetDidEnd:returnCode:contextInfo:)
                     contextInfo:NULL
                      identities:identities
                         message:message];
@@ -232,8 +233,13 @@
     return _panel.identity;
 }
 
-- (void)sheetDidEnd:(NSInteger)returnCode
+- (void)sheetDidEnd:(NSWindow *)window
+         returnCode:(NSInteger)returnCode
+        contextInfo:(void *)contextInfo
 {
+    (void)window;
+    (void)contextInfo;
+    
     _returnCode = returnCode;
     dispatch_semaphore_signal(_sem);
 }

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -156,6 +156,7 @@
         identity = [self promptUserForIdentity:distinguishedNames host:host correlationId:correlationId];
         if (identity == NULL)
         {
+            AD_LOG_INFO(@"No identity returned from cert chooser", correlationId, nil);
             // If no identity comes back then we can't handle the request
             completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
             return YES;
@@ -211,7 +212,7 @@
            message:(NSString *)message
 {
     _window = [[[ADWebAuthController sharedInstance] viewController] webviewWindow];
-    _panel = [SFChooseIdentityPanel sharedChooseIdentityPanel];
+    _panel = [SFChooseIdentityPanel new];
     [_panel setAlternateButtonTitle:NSLocalizedString(@"Cancel", "Cancel button on cert selection sheet")];
     [_panel beginSheetForWindow:_window
                   modalDelegate:self
@@ -241,7 +242,9 @@
         return NULL;
     }
     
-    return _panel.identity;
+    SecIdentityRef identity = _panel.identity;
+    _panel = nil;
+    return identity;
 }
 
 - (void)sheetDidEnd:(NSWindow *)window
@@ -252,7 +255,6 @@
     (void)contextInfo;
     
     _returnCode = returnCode;
-    _panel = nil;
     _window = nil;
     [[NSNotificationCenter defaultCenter] removeObserver:self name:ADWebAuthDidFailNotification object:nil];
     dispatch_semaphore_signal(_sem);

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -76,7 +76,8 @@
     if (!info || ![info isWorkPlaceJoined])
     {
         AD_LOG_INFO_F(@"Device is not workplace joined.", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
-        return NO;
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+        return YES;
     }
     
     AD_LOG_INFO_F(@"Responding to WPJ cert challenge", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
@@ -152,7 +153,8 @@
         if (identity == NULL)
         {
             // If no identity comes back then we can't handle the request
-            return NO;
+            completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+            return YES;
         }
         
         // Adding a retain count to match the retain count from SecIdentityCopyPreferred
@@ -166,7 +168,8 @@
     {
         CFRelease(identity);
         AD_LOG_ERROR(@"Failed to copy certificate from identity", AD_ERROR_UNEXPECTED, correlationId, nil);
-        return NO;
+        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
+        return YES;
     }
     
     AD_LOG_INFO(@"Responding to cert auth challenge with certicate", correlationId, nil);

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -95,12 +95,16 @@
                                    host:(NSString *)host
                           correlationId:(NSUUID *)correlationId
 {
-    NSDictionary *query =
-    @{
+    NSMutableDictionary *query =
+    [@{
       (id)kSecClass : (id)kSecClassIdentity,
-      (id)kSecMatchIssuers : issuers,
       (id)kSecMatchLimit : (id)kSecMatchLimitAll,
-      };
+      } mutableCopy];
+    
+    if (issuers.count > 0)
+    {
+        [query setObject:issuers forKey:(id)kSecMatchIssuers];
+    }
     
     CFTypeRef result = NULL;
     

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -21,6 +21,9 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#import <Security/Security.h>
+#import <SecurityInterface/SFChooseIdentityPanel.h>
+
 #import "ADClientCertAuthHandler.h"
 #import "ADWorkPlaceJoinUtil.h"
 #import "ADRegistrationInformation.h"
@@ -38,36 +41,26 @@
 {
 }
 
-+ (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
-                session:(NSURLSession *)session
-                   task:(NSURLSessionTask *)task
-               protocol:(ADURLProtocol *)protocol
-      completionHandler:(ChallengeCompletionHandler)completionHandler;
+
++ (BOOL)isWPJChallenge:(NSArray *)distinguishedNames
 {
-#pragma unused(session)
-#pragma unused(task)
     
-    AD_LOG_INFO_F(@"Attempting to handle client certificate challenge", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
-    
-    // See if this is a challenge for the WPJ cert.
-    BOOL isWPJChallenge = NO;
-    NSArray<NSData*> *distinguishedNames = challenge.protectionSpace.distinguishedNames;
     for (NSData *distinguishedName in distinguishedNames)
     {
         NSString *distinguishedNameString = [[[NSString alloc] initWithData:distinguishedName encoding:NSISOLatin1StringEncoding] lowercaseString];
         if ([distinguishedNameString containsString:[kADALProtectionSpaceDistinguishedName lowercaseString]])
         {
-            isWPJChallenge = YES;
-            break;
+            return YES;
         }
     }
     
-    if (!isWPJChallenge)
-    {
-        AD_LOG_INFO_F(@"Protection space distinguished names not recognized. Not handling client certificate challenge.", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
-        return NO;
-    }
-    
+    return NO;
+}
+
++ (BOOL)handleWPJChallenge:(NSURLAuthenticationChallenge *)challenge
+                  protocol:(ADURLProtocol *)protocol
+         completionHandler:(ChallengeCompletionHandler)completionHandler
+{
     ADAuthenticationError *adError = nil;
     ADRegistrationInformation *info = [ADWorkPlaceJoinUtil getRegistrationInformation:protocol.context error:&adError];
     if (!info || ![info isWorkPlaceJoined])
@@ -75,6 +68,8 @@
         AD_LOG_INFO_F(@"Device is not workplace joined.", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
         return NO;
     }
+    
+    AD_LOG_INFO_F(@"Responding to WPJ cert challenge", protocol.context.correlationId, @"host: %@", challenge.protectionSpace.host);
     
     NSURLCredential *creds = [NSURLCredential credentialWithIdentity:info.securityIdentity
                                                         certificates:@[(__bridge id)info.certificate]
@@ -84,5 +79,129 @@
     
     return YES;
 }
+
++ (SecIdentityRef)showCertSelectionDialog:(NSArray *)identities
+                                     host:(NSString *)host
+                            correlationId:(NSUUID *)correlationId
+{
+    SFChooseIdentityPanel *panel = [SFChooseIdentityPanel sharedChooseIdentityPanel];
+    
+    NSString *localizedTemplate = NSLocalizedString(@"Please select a certificate for %1", @"certificate dialog selection prompt \"%1\" will be replaced with the URL host");
+    NSString *message = [localizedTemplate stringByReplacingOccurrencesOfString:@"%1" withString:host];
+    
+    NSInteger result = [panel runModalForIdentities:identities message:message];
+    if (result == NSModalResponseCancel)
+    {
+        AD_LOG_INFO(@"User canceled cert selection dialog", correlationId, nil);
+        return NULL;
+    }
+    
+    return panel.identity;
+}
+
++ (SecIdentityRef)promptUserForIdentity:(NSArray *)issuers
+                                   host:(NSString *)host
+                          correlationId:(NSUUID *)correlationId
+{
+    NSDictionary *query =
+    @{
+      (id)kSecClass : (id)kSecClassIdentity,
+      (id)kSecMatchIssuers : issuers,
+      (id)kSecMatchLimit : (id)kSecMatchLimitAll,
+      };
+    
+    CFTypeRef result = NULL;
+    
+    OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, &result);
+    if (status == errSecItemNotFound)
+    {
+        AD_LOG_INFO(@"No certificate found matching challenge", correlationId, nil);
+        return nil;
+    }
+    else if (status != errSecSuccess)
+    {
+        AD_LOG_ERROR(([NSString stringWithFormat:@"Failed to find identity matching issuers with %d error.", status]), status, correlationId, nil);
+        return nil;
+    }
+    
+    if (![NSThread isMainThread])
+    {
+        __block dispatch_semaphore_t dsem = dispatch_semaphore_create(0);
+        __block SecIdentityRef certResult = NULL;
+        dispatch_async(dispatch_get_main_queue(), ^{
+            certResult = [self showCertSelectionDialog:(__bridge NSArray *)result host:host correlationId:correlationId];
+            CFRetain(certResult);
+            dispatch_semaphore_signal(dsem);
+        });
+        
+        dispatch_semaphore_wait(dsem, DISPATCH_TIME_FOREVER);
+        CFAutorelease(certResult);
+        return certResult;
+    }
+    else
+    {
+        return [self showCertSelectionDialog:(__bridge NSArray *)result host:host correlationId:correlationId];
+    }
+}
+
+
++ (BOOL)handleChallenge:(NSURLAuthenticationChallenge *)challenge
+                session:(NSURLSession *)session
+                   task:(NSURLSessionTask *)task
+               protocol:(ADURLProtocol *)protocol
+      completionHandler:(ChallengeCompletionHandler)completionHandler;
+{
+#pragma unused(session)
+#pragma unused(task)
+    
+    NSUUID *correlationId = protocol.context.correlationId;
+    NSString *host = challenge.protectionSpace.host;
+    AD_LOG_INFO_F(@"Attempting to handle client certificate challenge", correlationId, @"host: %@", host);
+    
+    // See if this is a challenge for the WPJ cert.
+    NSArray<NSData*> *distinguishedNames = challenge.protectionSpace.distinguishedNames;
+    if ([self isWPJChallenge:distinguishedNames])
+    {
+        return [self handleWPJChallenge:challenge protocol:protocol completionHandler:completionHandler];
+    }
+    
+    // Otherwise check if a preferred identity is set for this host
+    SecIdentityRef identity = SecIdentityCopyPreferred((CFStringRef)host, NULL, (CFArrayRef)distinguishedNames);
+    if (identity != NULL)
+    {
+        AD_LOG_INFO(@"Using preferred identity", correlationId, nil);
+    }
+    else
+    {
+        // If not prompt the user to select an identity
+        identity = [self promptUserForIdentity:distinguishedNames host:host correlationId:correlationId];
+        if (identity == NULL)
+        {
+            // If no identity comes back then we can't handle the request
+            return NO;
+        }
+        
+        CFRetain(identity);
+        AD_LOG_INFO(@"Using user selected certificate", correlationId, nil);
+    }
+    
+    SecCertificateRef cert = NULL;
+    OSStatus status = SecIdentityCopyCertificate(identity, &cert);
+    if (status != errSecSuccess)
+    {
+        CFRelease(identity);
+        AD_LOG_ERROR(@"Failed to copy certificate from identity", AD_ERROR_UNEXPECTED, correlationId, nil);
+        return NO;
+    }
+    
+    AD_LOG_INFO(@"Responding to cert auth challenge with certicate", correlationId, nil);
+    NSURLCredential *credential = [[NSURLCredential alloc] initWithIdentity:identity certificates:@[(__bridge id)cert] persistence:NSURLCredentialPersistenceForSession];
+    completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
+    CFRelease(cert);
+    CFRelease(identity);
+    return YES;
+}
+    
+
 
 @end

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppDelegate.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppDelegate.m
@@ -27,6 +27,7 @@
 #import "ADTokenCache.h"
 #import "ADTestAppAcquireTokenWindowController.h"
 #import "ADTestAppCacheWindowController.h"
+#import "ADWebAuthController.h"
 
 // These are not public APIs, however the test app is pulling
 // in things that can't be done with public APIs and shouldn't
@@ -38,7 +39,6 @@
 
 
 @implementation ADTestAppDelegate
-
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
@@ -68,6 +68,11 @@
 - (IBAction)writeCacheToFile:(id)sender
 {
     
+}
+
+- (IBAction)cancelCurrentSession:(id)sender
+{
+    [ADWebAuthController cancelCurrentWebAuthSession];
 }
 
 @end

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/Base.lproj/MainMenu.xib
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="11201" systemVersion="16A322" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="12121" systemVersion="16F73" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="11201"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="12121"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -604,6 +604,18 @@
                             <menuItem title="Customize Toolbar…" id="298">
                                 <connections>
                                     <action selector="runToolbarCustomizationPalette:" target="-1" id="365"/>
+                                </connections>
+                            </menuItem>
+                        </items>
+                    </menu>
+                </menuItem>
+                <menuItem title="Debug" id="3rU-w7-AhB">
+                    <menu key="submenu" title="Debug" id="zda-N2-Eoa">
+                        <items>
+                            <menuItem title="Cancel Current WebAuth Session" id="ZTh-24-6Ka">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <connections>
+                                    <action selector="cancelCurrentSession:" target="-1" id="6cD-NN-y5g"/>
                                 </connections>
                             </menuItem>
                         </items>

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/main.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/main.m
@@ -23,7 +23,14 @@
 
 #import <Cocoa/Cocoa.h>
 
+#import <ADAL/ADAL.h>
+
 int main(int argc, const char * argv[])
 {
+    [ADLogger setLevel:ADAL_LOG_LEVEL_INFO];
+    [ADLogger setLogCallBack:^(ADAL_LOG_LEVEL logLevel, NSString *message, NSString *additionalInfo, NSInteger errorCode, NSDictionary *userInfo) {
+        NSLog(@"%@ - %@", message, additionalInfo);
+    }];
+    
     return NSApplicationMain(argc, argv);
 }


### PR DESCRIPTION
Fixes #922

- Adds support to respond to Client TLS challenges by displaying the certificate picker prompt on the auth window and respond with the chosen credential.