### PR TITLE
Skip cache lookup if claims is passed in

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -394,7 +394,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request setUserIdentifier:userId];
     [request setExtraQueryParameters:queryParams];
     [request setClaims:claims];
-    [request acquireToken:@"130" completionBlock:completionBlock];
+    [request acquireToken:@"133" completionBlock:completionBlock];
 }
 
 @end

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -378,6 +378,25 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:@"130" completionBlock:completionBlock];
 }
 
+- (void)acquireTokenWithResource:(NSString *)resource
+                        clientId:(NSString *)clientId
+                     redirectUri:(NSURL *)redirectUri
+                  promptBehavior:(ADPromptBehavior)promptBehavior
+                  userIdentifier:(ADUserIdentifier *)userId
+            extraQueryParameters:(NSString *)queryParams
+                          claims:(NSString *)claims
+                 completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    API_ENTRY;
+    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
+    
+    [request setPromptBehavior:promptBehavior];
+    [request setUserIdentifier:userId];
+    [request setExtraQueryParameters:queryParams];
+    [request setClaims:claims];
+    [request acquireToken:@"130" completionBlock:completionBlock];
+}
+
 @end
 
 @implementation ADAuthenticationContext (CacheStorage)

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -386,7 +386,7 @@ typedef enum
             extraQueryParameters:(NSString*)queryParams
                  completionBlock:(ADAuthenticationCallback)completionBlock;
 
-/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims parameter which will be sent to authorization endpoint. If claims parameter is not nil/empty, tokens in cache will be skipped and webview credentials UI will be shown.
+/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims challenge returned from middle tier service, which will be sent to authorization endpoint. If claims parameter is not nil/empty, tokens in cache will be skipped and webview credentials UI will be shown. The claims parameter should be URL-encoded.
  @param resource The resource for whom token is needed.
  @param clientId The client identifier
  @param redirectUri The redirect URI according to OAuth2 protocol

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -386,6 +386,25 @@ typedef enum
             extraQueryParameters:(NSString*)queryParams
                  completionBlock:(ADAuthenticationCallback)completionBlock;
 
+/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims parameter which will be sent to authorization endpoint. If claims parameter is not nil/empty, tokens in cache will be skipped and webview credentials UI will be shown.
+ @param resource The resource for whom token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param promptBehavior Controls if any credentials UI will be shown.
+ @param userId An ADUserIdentifier object describing the user being authenticated
+ @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
+ @param claims The claims parameter that needs to be sent to authorization endpoint.
+ @param completionBlock the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+- (void)acquireTokenWithResource:(NSString *)resource
+                        clientId:(NSString *)clientId
+                     redirectUri:(NSURL *)redirectUri
+                  promptBehavior:(ADPromptBehavior)promptBehavior
+                  userIdentifier:(ADUserIdentifier *)userId
+            extraQueryParameters:(NSString *)queryParams
+                          claims:(NSString *)claims
+                 completionBlock:(ADAuthenticationCallback)completionBlock;
+
 /*! Follows the OAuth2 protocol (RFC 6749). The function will first look at the cache and automatically check for token
  expiration. Additionally, if no suitable access token is found in the cache, but refresh token is available,
  the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -386,14 +386,14 @@ typedef enum
             extraQueryParameters:(NSString*)queryParams
                  completionBlock:(ADAuthenticationCallback)completionBlock;
 
-/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims challenge returned from middle tier service, which will be sent to authorization endpoint. If claims parameter is not nil/empty, tokens in cache will be skipped and webview credentials UI will be shown. The claims parameter should be URL-encoded.
+/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims challenge returned from middle tier service, which will be sent to authorization endpoint. If claims parameter is not nil/empty, tokens in cache will be skipped and webview credentials UI will be shown.
  @param resource The resource for whom token is needed.
  @param clientId The client identifier
  @param redirectUri The redirect URI according to OAuth2 protocol
  @param promptBehavior Controls if any credentials UI will be shown.
  @param userId An ADUserIdentifier object describing the user being authenticated
  @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil.
- @param claims The claims parameter that needs to be sent to authorization endpoint.
+ @param claims The claims parameter that needs to be sent to authorization endpoint. It should be URL-encoded.
  @param completionBlock the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithResource:(NSString *)resource

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -308,6 +308,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
       @"username_type"  : _requestParams.identifier ? [_requestParams.identifier typeAsString] : @"",
       @"username"       : _requestParams.identifier.userId ? _requestParams.identifier.userId : @"",
       @"force"          : _promptBehavior == AD_FORCE_PROMPT ? @"YES" : @"NO",
+      @"skip_cache"     : _skipCache ? @"YES" : @"NO",
       @"correlation_id" : _requestParams.correlationId,
 #if TARGET_OS_IPHONE // Broker Message Encryption
       @"broker_key"     : base64UrlKey,

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -316,6 +316,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
       @"client_version" : adalVersion,
       BROKER_MAX_PROTOCOL_VERSION : @"2",
       @"extra_qp"       : _queryParams ? _queryParams : @"",
+      @"claims"         : _claims ? _claims : @"",
       };
     
     NSDictionary<NSString *, NSString *>* resumeDictionary = nil;

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -133,6 +133,12 @@
         }
     }
     
+    if (![NSString adIsStringNilOrBlank:_claims])
+    {
+        NSString *claimsParam = _claims.adTrimmedString;
+        [startUrl appendFormat:@"&claims=%@", claimsParam];
+    }
+    
     return startUrl;
 }
 

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -55,6 +55,7 @@
     
     NSString* _scope;
     NSString* _queryParams;
+    NSString* _claims;
     
     NSString* _refreshTokenCredential;
     
@@ -94,6 +95,7 @@
 // These can only be set before the request gets sent out.
 - (void)setScope:(NSString*)scope;
 - (void)setExtraQueryParameters:(NSString*)queryParams;
+- (void)setClaims:(NSString *)claims;
 - (void)setUserIdentifier:(ADUserIdentifier*)identifier;
 - (void)setUserId:(NSString*)userId;
 - (void)setPromptBehavior:(ADPromptBehavior)promptBehavior;

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -63,6 +63,7 @@
     
     BOOL _silent;
     BOOL _allowSilent;
+    BOOL _skipCache;
     
     NSString* _logComponent;
     
@@ -97,6 +98,7 @@
 - (void)setUserId:(NSString*)userId;
 - (void)setPromptBehavior:(ADPromptBehavior)promptBehavior;
 - (void)setSilent:(BOOL)silent;
+- (void)setSkipCache:(BOOL)skipCache;
 - (void)setCorrelationId:(NSUUID*)correlationId;
 - (NSUUID*)correlationId;
 - (NSString*)telemetryRequestId;

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -111,6 +111,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
     
     // This line is here to suppress a analyzer warning, has no effect
     _allowSilent = NO;
+    _skipCache = NO;
     
     return self;
 }
@@ -169,6 +170,12 @@ static dispatch_semaphore_t s_interactionLock = nil;
 {
     CHECK_REQUEST_STARTED;
     _silent = silent;
+}
+
+- (void)setSkipCache:(BOOL)skipCache
+{
+    CHECK_REQUEST_STARTED;
+    _skipCache = skipCache;
 }
 
 - (void)setCorrelationId:(NSUUID*)correlationId

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -144,6 +144,16 @@ static dispatch_semaphore_t s_interactionLock = nil;
     _queryParams = [queryParams copy];
 }
 
+- (void)setClaims:(NSString *)claims
+{
+    CHECK_REQUEST_STARTED;
+    if (_claims == claims)
+    {
+        return;
+    }
+    _claims = [claims copy];
+}
+
 - (void)setUserIdentifier:(ADUserIdentifier *)identifier
 {
     CHECK_REQUEST_STARTED;

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -1623,7 +1623,7 @@ const int sAsyncContextTimeout = 10;
     TEST_WAIT;
 }
 
-- (void)testSkipCacheRequestParameters_whenSkipCacheIsSet_shouldSkipCache
+- (void)testSkipCacheRequestParameters_whenSkipCacheIsNotSet_shouldNotSkipCache
 {
     ADAuthenticationError* error = nil;
     ADAuthenticationContext *context = [self getTestAuthenticationContext];
@@ -1653,9 +1653,28 @@ const int sAsyncContextTimeout = 10;
      }];
     
     TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE;
+}
+
+- (void)testSkipCacheRequestParameters_whenSkipCacheIsSet_shouldSkipCache
+{
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = [self getTestAuthenticationContext];
+    ADRequestParameters *params = [[ADRequestParameters alloc] initWithAuthority:context.authority
+                                                                        resource:TEST_RESOURCE
+                                                                        clientId:TEST_CLIENT_ID
+                                                                     redirectUri:TEST_REDIRECT_URL.absoluteString
+                                                                      identifier:[ADUserIdentifier identifierWithId:TEST_USER_ID]
+                                                                      tokenCache:context.tokenCacheStore
+                                                                extendedLifetime:NO
+                                                                   correlationId:nil
+                                                              telemetryRequestId:nil];
+    
+    // Add a token item to return in the cache
+    ADTokenCacheItem* item = [self adCreateCacheItem];
+    [context.tokenCacheStore.dataSource addOrUpdateItem:item correlationId:nil error:&error];
     
     // skipCache is set, cache should be skipped and webview controller should be hit
-    req = [ADAuthenticationRequest requestWithContext:context requestParams:params error:nil];
+    ADAuthenticationRequest *req = [ADAuthenticationRequest requestWithContext:context requestParams:params error:nil];
     [req setSkipCache:YES];
     
     // Add a specific error as mock response to webview controller

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -1742,7 +1742,7 @@ const int sAsyncContextTimeout = 10;
                                claims:@"{\"access_token\":{\"polids\":{\"essential\":true,\"values\":[\"5ce770ea-8690-4747-aa73-c5b3cd509cd4\"]}}}"
                       completionBlock:^(ADAuthenticationResult *result)
      {
-         // error code AD_ERROR_DEVELOPER_INVALID_ARGUMENT should be returned
+         // Error code AD_ERROR_DEVELOPER_INVALID_ARGUMENT should be returned
          XCTAssertNotNil(result);
          XCTAssertEqual(result.status, AD_FAILED);
          XCTAssertNotNil(result.error);
@@ -1810,4 +1810,31 @@ const int sAsyncContextTimeout = 10;
     TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE;
 }
 
+- (void)testAcquireToken_whenDuplicateClaimsIsPassedInEQP_shouldReturnError
+{
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    
+    // Add a specific error as mock response to webview controller
+    [ADTestAuthenticationViewController addDelegateCallWebAuthDidFailWithError:[NSError errorWithDomain:ADAuthenticationErrorDomain code:AD_ERROR_UI_NO_MAIN_VIEW_CONTROLLER userInfo:nil]];
+    
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:TEST_REDIRECT_URL
+                       promptBehavior:AD_PROMPT_AUTO
+                       userIdentifier:[ADUserIdentifier identifierWithId:TEST_USER_ID]
+                 extraQueryParameters:@"claims=%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%225ce770ea-8690-4747-aa73-c5b3cd509cd4%22%5D%7D%7D%7D"
+                               claims:@"%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%225ce770ea-8690-4747-aa73-c5b3cd509cd4%22%5D%7D%7D%7D"
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         //Error code AD_ERROR_DEVELOPER_INVALID_ARGUMENT should be returned
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
+         
+         TEST_SIGNAL;
+     }];
+    
+    TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE;
+}
 @end

--- a/ADAL/tests/ADWebAuthControllerTests.m
+++ b/ADAL/tests/ADWebAuthControllerTests.m
@@ -92,10 +92,10 @@
                XCTAssertNil(error);
                XCTAssertNotNil(url);
                XCTAssertEqual(url.absoluteString, TEST_REDIRECT_URL.absoluteString);
-               dispatch_semaphore_signal(_dsem);
+               TEST_SIGNAL;
     }];
     
-    [self waitSemaphoreWithoutBlockingMainQueue:_dsem];
+    TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE;
     
 }
 
@@ -127,19 +127,11 @@
                XCTAssertNotNil(error);
                XCTAssertEqual(error.code, AD_ERROR_SERVER_NON_HTTPS_REDIRECT);
                
-               dispatch_semaphore_signal(_dsem);
+               TEST_SIGNAL;
            }];
                
-    [self waitSemaphoreWithoutBlockingMainQueue:_dsem];
+    TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE;
     
-}
-
-- (void)waitSemaphoreWithoutBlockingMainQueue:(dispatch_semaphore_t)sem
-{
-    while (dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW))
-    {
-        [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate: [NSDate distantFuture]];
-    }
 }
 
 @end

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -40,6 +40,13 @@
 
 #define TEST_SIGNAL dispatch_semaphore_signal(_dsem)
 #define TEST_WAIT dispatch_semaphore_wait(_dsem, DISPATCH_TIME_FOREVER)
+#define TEST_WAIT_NOT_BLOCKING_MAIN_QUEUE \
+{ \
+    while (dispatch_semaphore_wait(_dsem, DISPATCH_TIME_NOW)) \
+    { \
+        [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate: [NSDate distantFuture]]; \
+    } \
+} \
 
 typedef enum
 {


### PR DESCRIPTION
Fixes #996 

To be able to handle claim challenge, client ADAL needs to skip cache lookup and pass claims to authorize endpoint. Besides, if brokered auth is enable, "skip_cache" flag and "claims" both need to be passed to Authenticator.

Changes include:
1) allow ADAuthenticationRequest to be able to skip cache
2) add overloaded `[ADAuthenticationContext acquireTokenWithResource:]` to accept claims parameter
3) pass "skip_cache" flag and "claims" to broker if claims is passed in
4) UTs are added

Since we need the changes for both client ADAL and broker, this PR is now targeting authenticator-hotfix-2.5.x branch. Later we will merge the changes into dev.