### PR TITLE
Cache Tokens from Assertion

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -269,7 +269,17 @@
     
     if (_samlAssertion)
     {
-        [self requestTokenByAssertion:completionBlock];
+        [self requestTokenByAssertion:^(ADAuthenticationResult *result){
+            if (AD_SUCCEEDED == result.status)
+            {
+                [[_requestParams tokenCache] updateCacheToResult:result
+                                                       cacheItem:nil
+                                                    refreshToken:nil
+                                                         context:_requestParams];
+                result = [ADAuthenticationContext updateResult:result toUser:[_requestParams identifier]];
+            }
+            completionBlock(result);
+        }];
         return;
     }
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -104,7 +104,7 @@
         completionBlock(result);
     };
     
-    if (!_silent && ![NSThread isMainThread])
+    if (_samlAssertion == nil && !_silent && ![NSThread isMainThread])
     {
         ADAuthenticationError* error =
         [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_UI_NOT_ON_MAIN_THREAD

--- a/ADAL/tests/ADAcquireTokenTests.m
+++ b/ADAL/tests/ADAcquireTokenTests.m
@@ -324,6 +324,18 @@ const int sAsyncContextTimeout = 10;
     TEST_WAIT;
     
     XCTAssertTrue([ADTestURLSession noResponsesLeft]);
+    
+    ADAuthenticationError *error = nil;
+    ADTokenCacheAccessor *cache = context.tokenCacheStore;
+    ADTokenCacheItem *item = [cache getATRTItemForUser:nil resource:TEST_RESOURCE clientId:TEST_CLIENT_ID context:nil error:&error];
+    XCTAssertNotNil(item);
+    XCTAssertNil(error);
+    XCTAssertNotNil(item.accessToken);
+    
+    ADTokenCacheItem *mrrtItem = [cache getMRRTItemForUser:nil clientId:TEST_CLIENT_ID context:nil error:&error];
+    XCTAssertNotNil(mrrtItem);
+    XCTAssertNil(error);
+    XCTAssertNotNil(mrrtItem.refreshToken);
 }
 
 


### PR DESCRIPTION
- Cache tokens acquired from an acquireTokenForAssertion call (#971)
- Don't require acquireTokenForAssertion to be called from the main thread (#972)