### PR TITLE
Don't break, when default test user is nil

### DIFF
--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
@@ -87,7 +87,7 @@
     _clientId.stringValue = settings.clientId;
     _redirectUri.stringValue = settings.redirectUri.absoluteString;
     _resource.stringValue = settings.resource;
-    _userIdField.stringValue = settings.defaultUser;
+    _userIdField.stringValue = settings.defaultUser ? settings.defaultUser : @"";
 }
 
 - (IBAction)selectedProfileChanged:(id)sender


### PR DESCRIPTION
When defaultUser == nil, setting stringValue will breakpoint and print assertion failure to the console. Fixing it, because it's a little bit distracting during testing. 