### PR TITLE
Mac test app cache view fixes

### DIFF
--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
@@ -304,15 +304,16 @@
 
 - (IBAction)clearCache:(id)sender
 {
-    OSStatus status = [[ADTestAppCache sharedCache] deleteFromKeychain];
+    NSError* error = nil;
+    BOOL result = [[ADTestAppCache sharedCache] clearCacheWithError:&error];
     
-    if (status == errSecSuccess || status == errSecItemNotFound)
+    if (result)
     {
         _resultView.string = @"Successfully cleared cache.";
     }
     else
     {
-        _resultView.string = [NSString stringWithFormat:@"Failed to clear cache, error = %d", (int)status];
+        _resultView.string = [NSString stringWithFormat:@"Failed to clear cache, error = %@", error];
     }
 }
 

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCache.h
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCache.h
@@ -35,6 +35,6 @@
 - (void)readFromFile:(NSString *)filePath;
 - (void)writeToFile:(NSString *)filePath;
 
-- (OSStatus)deleteFromKeychain;
+- (BOOL)clearCacheWithError:(NSError *__autoreleasing *)error;
 
 @end

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCache.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCache.m
@@ -184,11 +184,27 @@
     }
 }
 
-- (OSStatus)deleteFromKeychain
+- (BOOL)clearCacheWithError:(NSError *__autoreleasing *)error
 {
     @synchronized (self)
     {
-        return SecItemDelete((CFDictionaryRef)@{ DEFAULT_KEYCHAIN_ATTRS });
+        if (![[ADTokenCache defaultCache] deserialize:nil error:nil])
+        {
+            return NO;
+        }
+        
+        OSStatus deleteResult = SecItemDelete((CFDictionaryRef)@{ DEFAULT_KEYCHAIN_ATTRS });
+        
+        if (deleteResult == errSecSuccess || deleteResult == errSecItemNotFound)
+        {
+            return YES;
+        }
+        else if (error)
+        {
+            *error = [NSError errorWithDomain:NSOSStatusErrorDomain code:deleteResult userInfo:nil];
+        }
+        
+        return NO;
     }
 }
 

--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCacheWindowController.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppCacheWindowController.m
@@ -64,6 +64,7 @@
 + (void)showWindow
 {
     [[self controller] showWindow:nil];
+    [[self controller] reloadCache];
 }
 
 - (id)init


### PR DESCRIPTION
Mac test app cache fixes:
1. Always reload cache, when showing the cache window (no need to press reload button after opening cache window)
2. Hiding cache clearing OSStatus error from the controller and wrapping it in NSError
3. Clearing in memory test cache when doing clear cache