### PR TITLE
Add code coverage report to build script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ ADAL/ObjectiveC.gcda
 ADAL/ObjectiveC.gcno
 ADAL/Security.gcda
 ADAL/Security.gcno
+.DS_Store

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -2283,34 +2283,6 @@
 			};
 			name = Debug;
 		};
-		04AB6D571D9D619B007E9A83 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = UnitTestHostApp/UnitTestHostApp.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = UBF8T346G9;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = UnitTestHostApp/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.MSOpenTech.UnitTestHostApp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = CodeCoverage;
-		};
 		04AB6D581D9D619B007E9A83 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2546,114 +2518,6 @@
 			};
 			name = Release;
 		};
-		8B41A1E81888C6350027EE1E /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347801C644E13000A6DA1 /* adal__codecov.xcconfig */;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				CLANG_ANALYZER_SECURITY_INSECUREAPI_RAND = YES;
-				CLANG_ANALYZER_SECURITY_INSECUREAPI_STRCPY = YES;
-				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
-				CLANG_CXX_LIBRARY = "libc++";
-				CLANG_ENABLE_MODULES = YES;
-				CLANG_WARN_BOOL_CONVERSION = YES;
-				CLANG_WARN_CONSTANT_CONVERSION = YES;
-				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
-				CLANG_WARN_EMPTY_BODY = YES;
-				CLANG_WARN_ENUM_CONVERSION = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_INT_CONVERSION = YES;
-				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
-				CLANG_WARN_SUSPICIOUS_MOVE = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CLANG_WARN__ARC_BRIDGE_CAST_NONARC = NO;
-				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				COPY_PHASE_STRIP = NO;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_C_LANGUAGE_STANDARD = gnu99;
-				GCC_DYNAMIC_NO_PIC = NO;
-				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
-				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
-				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
-				GCC_WARN_UNDECLARED_SELECTOR = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES;
-				GCC_WARN_UNUSED_FUNCTION = YES;
-				GCC_WARN_UNUSED_PARAMETER = YES;
-				GCC_WARN_UNUSED_VARIABLE = YES;
-				ONLY_ACTIVE_ARCH = NO;
-				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
-				RUN_CLANG_STATIC_ANALYZER = YES;
-				SDKROOT = iphoneos;
-			};
-			name = CodeCoverage;
-		};
-		8B41A1E91888C6350027EE1E /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347851C644E13000A6DA1 /* adal__ios__staticlib.xcconfig */;
-			buildSettings = {
-				DEAD_CODE_STRIPPING = NO;
-				DSTROOT = /usr/local/lib;
-				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
-				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "Headers/$(PROJECT_NAME)";
-				RUN_CLANG_STATIC_ANALYZER = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = CodeCoverage;
-		};
-		8B41A1EA1888C6350027EE1E /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347831C644E13000A6DA1 /* adal__ios__common.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_CODE_COVERAGE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
-				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "tests/unit/ios/ADAL_iOS_UTs-Info.plist";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					XCTest,
-					"-ObjC",
-				);
-				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "MS-Open-Tech.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/UnitTestHostApp.app/UnitTestHostApp";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = CodeCoverage;
-		};
 		9453C3D21C583E07006B9E79 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347841C644E13000A6DA1 /* adal__ios__framework.xcconfig */;
@@ -2683,36 +2547,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
-		};
-		9453C3D31C583E07006B9E79 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347841C644E13000A6DA1 /* adal__ios__framework.xcconfig */;
-			buildSettings = {
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = resources/ios/Framework/Info.plist;
-				INSTALL_PATH = "@executable_path/../Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.ADAL;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = CodeCoverage;
 		};
 		9453C3D41C583E07006B9E79 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2772,33 +2606,6 @@
 			};
 			name = Debug;
 		};
-		9453C4031C586425006B9E79 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347871C644E13000A6DA1 /* adal__mac__framework.xcconfig */;
-			buildSettings = {
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "-";
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				FRAMEWORK_VERSION = A;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				SDKROOT = macosx;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = CodeCoverage;
-		};
 		9453C4041C586425006B9E79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347871C644E13000A6DA1 /* adal__mac__framework.xcconfig */;
@@ -2830,13 +2637,6 @@
 			};
 			name = Debug;
 		};
-		9453C45A1C5866D0006B9E79 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				PRODUCT_NAME = "Build All";
-			};
-			name = CodeCoverage;
-		};
 		9453C45B1C5866D0006B9E79 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2865,28 +2665,6 @@
 				SDKROOT = macosx;
 			};
 			name = Debug;
-		};
-		94DD18EB1C5ACFBF00F80C62 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347861C644E13000A6DA1 /* adal__mac__common.xcconfig */;
-			buildSettings = {
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "-";
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "tests/unit/mac/ADAL_Mac_UTs-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.ADAL-Mac-Tests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = CodeCoverage;
 		};
 		94DD18EC1C5ACFBF00F80C62 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2943,39 +2721,6 @@
 			};
 			name = Debug;
 		};
-		B20DC5AB1F0D96A100957806 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347831C644E13000A6DA1 /* adal__ios__common.xcconfig */;
-			buildSettings = {
-				CLANG_ENABLE_CODE_COVERAGE = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-					"$(DEVELOPER_FRAMEWORKS_DIR)",
-				);
-				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
-				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"DEBUG=1",
-					"$(inherited)",
-				);
-				INFOPLIST_FILE = "tests/integration/ios/ADAL_iOS_ITs-Info.plist";
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					XCTest,
-					"-ObjC",
-				);
-				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = "MS-Open-Tech.${PRODUCT_NAME:rfc1034identifier}";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/UnitTestHostApp.app/UnitTestHostApp";
-				WRAPPER_EXTENSION = xctest;
-			};
-			name = CodeCoverage;
-		};
 		B20DC5AC1F0D96A100957806 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347831C644E13000A6DA1 /* adal__ios__common.xcconfig */;
@@ -3027,28 +2772,6 @@
 			};
 			name = Debug;
 		};
-		B20DC5CF1F0D96A700957806 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347861C644E13000A6DA1 /* adal__mac__common.xcconfig */;
-			buildSettings = {
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_IDENTITY = "-";
-				COMBINE_HIDPI_IMAGES = YES;
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = "tests/integration/mac/ADAL_Mac_ITs-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
-				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.microsoft.ADAL-Mac-Tests";
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = macosx;
-			};
-			name = CodeCoverage;
-		};
 		B20DC5D01F0D96A700957806 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347861C644E13000A6DA1 /* adal__mac__common.xcconfig */;
@@ -3099,36 +2822,6 @@
 				USER_HEADER_SEARCH_PATHS = "../src/** $(inherited)";
 			};
 			name = Debug;
-		};
-		D64C1F5D1DB9B05A00850036 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CLANG_ANALYZER_NONNULL = YES;
-				CLANG_ENABLE_OBJC_ARC = YES;
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				CLANG_WARN_INFINITE_RECURSION = YES;
-				CLANG_WARN_SUSPICIOUS_MOVES = YES;
-				CLANG_WARN_UNREACHABLE_CODE = YES;
-				CODE_SIGN_ENTITLEMENTS = ADALAutomation/ADALAutomation.entitlements;
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				COPY_PHASE_STRIP = NO;
-				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = 4XAC8VP2M2;
-				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				GCC_NO_COMMON_BLOCKS = YES;
-				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
-				INFOPLIST_FILE = ADALAutomation/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.adal.automationapp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				TARGETED_DEVICE_FAMILY = "1,2";
-				USER_HEADER_SEARCH_PATHS = "../src/** $(inherited)";
-			};
-			name = CodeCoverage;
 		};
 		D64C1F5E1DB9B05A00850036 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -3187,33 +2880,6 @@
 			};
 			name = Debug;
 		};
-		D664F1B21D302B9C0017B799 /* CodeCoverage */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 946347851C644E13000A6DA1 /* adal__ios__staticlib.xcconfig */;
-			buildSettings = {
-				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
-				DEAD_CODE_STRIPPING = NO;
-				DSTROOT = /usr/local/lib;
-				GCC_GENERATE_TEST_COVERAGE_FILES = YES;
-				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
-				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
-				);
-				LIBRARY_SEARCH_PATHS = "$(inherited)";
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_LDFLAGS = "-ObjC";
-				PRECOMPS_INCLUDE_HEADERS_FROM_BUILT_PRODUCTS_DIR = NO;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				PUBLIC_HEADERS_FOLDER_PATH = "Headers/$(PROJECT_NAME)";
-				RUN_CLANG_STATIC_ANALYZER = YES;
-				STRIP_INSTALLED_PRODUCT = NO;
-				TARGETED_DEVICE_FAMILY = "1,2";
-			};
-			name = CodeCoverage;
-		};
 		D664F1B31D302B9C0017B799 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 946347851C644E13000A6DA1 /* adal__ios__staticlib.xcconfig */;
@@ -3247,7 +2913,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				04AB6D561D9D619B007E9A83 /* Debug */,
-				04AB6D571D9D619B007E9A83 /* CodeCoverage */,
 				04AB6D581D9D619B007E9A83 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3257,7 +2922,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8B0965CB17F25770002BDFB8 /* Debug */,
-				8B41A1E81888C6350027EE1E /* CodeCoverage */,
 				8B0965CC17F25770002BDFB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3267,7 +2931,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8B0965CE17F25770002BDFB8 /* Debug */,
-				8B41A1E91888C6350027EE1E /* CodeCoverage */,
 				8B0965CF17F25770002BDFB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3277,7 +2940,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				8B0965D117F25770002BDFB8 /* Debug */,
-				8B41A1EA1888C6350027EE1E /* CodeCoverage */,
 				8B0965D217F25770002BDFB8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3287,7 +2949,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9453C3D21C583E07006B9E79 /* Debug */,
-				9453C3D31C583E07006B9E79 /* CodeCoverage */,
 				9453C3D41C583E07006B9E79 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3297,7 +2958,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9453C4021C586425006B9E79 /* Debug */,
-				9453C4031C586425006B9E79 /* CodeCoverage */,
 				9453C4041C586425006B9E79 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3307,7 +2967,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				9453C4591C5866D0006B9E79 /* Debug */,
-				9453C45A1C5866D0006B9E79 /* CodeCoverage */,
 				9453C45B1C5866D0006B9E79 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3317,7 +2976,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				94DD18EA1C5ACFBF00F80C62 /* Debug */,
-				94DD18EB1C5ACFBF00F80C62 /* CodeCoverage */,
 				94DD18EC1C5ACFBF00F80C62 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3327,7 +2985,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B20DC5AA1F0D96A100957806 /* Debug */,
-				B20DC5AB1F0D96A100957806 /* CodeCoverage */,
 				B20DC5AC1F0D96A100957806 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3337,7 +2994,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				B20DC5CE1F0D96A700957806 /* Debug */,
-				B20DC5CF1F0D96A700957806 /* CodeCoverage */,
 				B20DC5D01F0D96A700957806 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3347,7 +3003,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D64C1F5C1DB9B05A00850036 /* Debug */,
-				D64C1F5D1DB9B05A00850036 /* CodeCoverage */,
 				D64C1F5E1DB9B05A00850036 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
@@ -3357,7 +3012,6 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				D664F1B11D302B9C0017B799 /* Debug */,
-				D664F1B21D302B9C0017B799 /* CodeCoverage */,
 				D664F1B31D302B9C0017B799 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;

--- a/build.py
+++ b/build.py
@@ -25,11 +25,13 @@
 
 import subprocess
 import sys
+import re
 
 ios_sim_dest = "-destination 'platform=iOS Simulator,name=iPhone 6,OS=latest'"
 ios_sim_flags = "-sdk iphonesimulator CODE_SIGN_IDENTITY=\"\" CODE_SIGNING_REQUIRED=NO"
 
 default_workspace = "ADAL.xcworkspace"
+default_config = "Debug"
 
 use_xcpretty = True
 
@@ -41,11 +43,12 @@ class tclr:
 	SKIP = '\033[96m\033[1m'
 	END = '\033[0m'
 
-build_targets = [
+target_specifiers = [
 	{
 		"name" : "iOS Framework",
 		"scheme" : "ADAL",
-		"operations" : [ "build", "test" ],
+		"operations" : [ "build", "test", "codecov" ],
+		"min_warn_codecov" : 70.0,
 		"platform" : "iOS",
 	},
 	{
@@ -70,7 +73,8 @@ build_targets = [
 	{
 		"name" : "Mac Framework",
 		"scheme" : "ADAL Mac",
-		"operations" : [ "build", "test" ],
+		"operations" : [ "build", "test", "codecov" ],
+		"min_warn_codecov" : 70.0,
 		"platform" : "Mac"
 	},
 	{
@@ -93,75 +97,170 @@ def print_operation_end(name, operation, exit_code) :
 	else :
 		print tclr.FAIL + name + " [" + operation + "] Failed" + tclr.END
 
-def do_ios_build(target, operation) :
-	name = target["name"]
-	scheme = target["scheme"]
-	project = target.get("project")
-	workspace = target.get("workspace")
-
-	if (workspace == None) :
-		workspace = default_workspace
-
-	print_operation_start(name, operation)
-
-	command = "xcodebuild " + operation
-	if (project != None) :
-		command += " -project " + project
-	else :
-		command += " -workspace " + workspace
+class BuildTarget:
+	def __init__(self, target):
+		self.name = target["name"]
+		self.project = target.get("project")
+		self.workspace = target.get("workspace")
+		if (self.workspace == None and self.project == None) :
+			self.workspace = default_workspace
+		self.scheme = target["scheme"]
+		self.dependencies = target.get("dependencies")
+		self.operations = target["operations"]
+		self.platform = target["platform"]
+		self.build_settings = None
+		self.min_codecov = target.get("min_codecov")
+		self.min_warn_codecov = target.get("min_warn_codecov")
+		self.coverage = None
+		self.failed = False
+		self.skipped = False
+	
+	def xcodebuild_command(self, operation, xcpretty) :
+		"""
+		Generate and return an xcodebuild command string based on the ivars and operation provided.
+		"""
+		command = "xcodebuild "
+		if (operation != None) :
+			command += operation + " "
 		
-	command += " -scheme \"" + scheme + "\" -configuration CodeCoverage " + ios_sim_flags + " " + ios_sim_dest
-	if (use_xcpretty) :
-		command += " | xcpretty"
+		if (self.project != None) :
+			command += " -project " + self.project
+		else :
+			command += " -workspace " + self.workspace
 		
-	print command
-	exit_code = subprocess.call("set -o pipefail;" + command, shell = True)
+		command += " -scheme \"" + self.scheme + "\" -configuration " + default_config
+		
+		if (operation == "test" and "codecov" in self.operations) :
+			command += " -enableCodeCoverage YES"
+		
+		if (self.platform == "iOS") :
+			command += " " + ios_sim_flags + " " + ios_sim_dest
+		
+		if (xcpretty) :
+			command += " | xcpretty"
+		
+		return command
+	
+	def get_build_settings(self) :
+		"""
+		Retrieve the build settings from xcodebuild and return thm in a dictionary
+		"""
+		if (self.build_settings != None) :
+			return self.build_settings
+		
+		command = self.xcodebuild_command(None, False)
+		command += " -showBuildSettings"
+        
+		settings_blob = subprocess.check_output(command, shell=True)
+		settings_blob = settings_blob.decode("utf-8")
+		settings_blob = settings_blob.split("\n")
+        
+		settings = {}
+		
+		for line in settings_blob :
+			split_line = line.split(" = ")
+			if (len(split_line) < 2) :
+				continue
+			key = split_line[0].strip()
+			value = split_line[1].strip()
+			
+			settings[key] = value
+		
+		self.build_settings = settings
+		
+		return settings
+		
+	def print_coverage(self, printName) :
+		"""
+		Print a summary of the code coverage results with the proper coloring and
+		return -1 if the coverage is below the minimum required.
+		"""
+		if (self.coverage == None) :
+			return 0;
+			
+		printed = False
+		
+		if (self.min_warn_codecov != None) :
+			if (self.coverage < self.min_warn_codecov) :
+				sys.stdout.write(tclr.WARN)
+				if (printName) :
+					sys.stdout.write(self.name + ": ")
+				sys.stdout.write(str(self.coverage) + "% coverage is below the recommended minimum requirement: " + str(self.min_warn_codecov) + "%" + tclr.END + "\n")
+				printed = True
+				
+		if (self.min_codecov != None) :
+			if (self.coverage < self.min_codecov) :
+				sys.stdout.write(tclr.FAIL)
+				if (printName) :
+					sys.stdout.write(self.name + ": ")
+				sys.stdout.write(str(self.coverage) + "% coverage is below the minimum requirement: " + str(self.min_codecov) + "%" + tclr.END + "\n")
+				return -1
+		
+		if (not printed) :
+			sys.stdout.write(tclr.OK)
+			if (printName) :
+				sys.stdout.write(self.name + ": ")
+			sys.stdout.write(str(self.coverage) + "%" + tclr.END + "\n")
+			
+		return 0
+		
+	
+	def do_codecov(self) :
+		"""
+		Print a code coverage report using llvm_cov, retrieve the coverage result and
+		print out an error if it is below the minimum requirement
+		"""
+		build_settings = self.get_build_settings();
+		codecov_dir = build_settings["OBJROOT"] + "/CodeCoverage"
+		executable_path = build_settings["EXECUTABLE_PATH"]
+		config = build_settings["CONFIGURATION"]
+		platform_name = build_settings.get("EFFECTIVE_PLATFORM_NAME")
+		if (platform_name == None) :
+			platform_name = ""
+		
+		command = "xcrun llvm-cov report -instr-profile Coverage.profdata -arch=\"x86_64\" -use-color Products/" + config + platform_name + "/" + executable_path
+		p = subprocess.Popen(command, cwd = codecov_dir, stdout = subprocess.PIPE, stderr = subprocess.PIPE, shell = True)
+		
+		output = p.communicate()
+		
+		last_line = None
+		for line in output[0].split("\n") :
+			if (len(line.strip()) > 0) :
+				last_line = line
+		
+		sys.stdout.write(output[0])
+		sys.stderr.write(output[1])
+		
+		last_line = last_line.split()
+		# Remove everything but 
+		cov_str = re.sub(r"[^0-9.]", "", last_line[3])
+		self.coverage = float(cov_str)
+		return self.print_coverage(False)
+		
+	
+	def do_operation(self, operation) :
+		exit_code = -1;
+		print_operation_start(self.name, operation)
+		
+		try :
+			if (operation == "codecov") :
+				exit_code = self.do_codecov()
+			else :
+				command = self.xcodebuild_command(operation, use_xcpretty)
+				print command
+				exit_code = subprocess.call("set -o pipefail;" + command, shell = True)
+			
+			if (exit_code != 0) :
+				self.failed = True
+		except Exception as inst:
+			self.failed = True
+			print "Failed due to exception in build script"
+			print type(inst)
+			print inst.args
+			print inst
 
-	print_operation_end(name, operation, exit_code)
-	return exit_code
-
-def do_mac_build(target, operation) :
-	arch = target.get("arch")
-	name = target["name"]
-	scheme = target["scheme"]
-
-	print_operation_start(name, operation)
-
-	command = "xcodebuild " + operation + " -workspace " + default_workspace + " -scheme \"" + scheme + "\""
-
-	if (arch != None) :
-		command += " -destination 'arch=" + arch + "'"
-
-	if (use_xcpretty) :
-		command += " | xcpretty"
-
-	print command
-	exit_code = subprocess.call("set -o pipefail;" + command, shell = True)
-
-	print_operation_end(name, operation, exit_code)
-
-	return exit_code
-
-build_status = dict()
-
-def check_dependencies(target) :
-	dependencies = target.get("dependencies")
-	if (dependencies == None) :
-		return True
-
-	for dependency in dependencies :
-		dependency_status = build_status.get(dependency)
-		if (dependency_status == None) :
-			print tclr.SKIP + "Skipping " + name + " dependency " + dependency + " not built yet." + tclr.END
-			build_status[name] = "Skipped"
-			return False
-
-		if (build_status[dependency] != "Succeeded") :
-			print tclr.SKIP + "Skipping " + name + " dependency " + dependency + " failed." + tclr.END
-			build_status[name] = "Skipped"
-			return False
-
-	return True
+		print_operation_end(self.name, operation, exit_code)
+		return exit_code
 
 clean = True
 
@@ -171,54 +270,60 @@ for arg in sys.argv :
 	if (arg == "--no-xcpretty") :
 		use_xcpretty = False
 
+targets = []
+
+for spec in target_specifiers :
+	targets.append(BuildTarget(spec))
+
 # start by cleaning up any derived data that might be lying around
 if (clean) :
-	subprocess.call("rm -rf ~/Library/Developer/Xcode/DerivedData/ADAL-*", shell=True)
-	subprocess.call("rm -rf ~/Library/Developer/Xcode/DerivedData/SampleSwiftApp-*", shell=True)
+	derived_folders = set()
+	for target in targets :
+		objroot = target.get_build_settings()["OBJROOT"]
+		trailing = "/Build/Intermediates"
+		derived_dir = objroot[:-len(trailing)]
+		derived_folders.add(derived_dir)
+		print derived_dir
+	
+	for dir in derived_folders :
+		print "Deleting " + dir
+		subprocess.call("rm -rf " + dir, shell=True)
 
-for target in build_targets:
+for target in targets:
 	exit_code = 0
-	name = target["name"]
-	platform = target["platform"]
 
-	# If we don't have the dependencies for this target built yet skip it.
-	if (not check_dependencies(target)) :
-		continue
-
-	for operation in target["operations"] :
+	for operation in target.operations :
 		if (exit_code != 0) :
 			break; # If one operation fails, then the others are almost certainly going to fail too
 
-		if (platform == "iOS") :
-			exit_code = do_ios_build(target, operation)
-		elif (platform == "Mac") :
-			exit_code = do_mac_build(target, operation)
-		else :
-			raise Exception('Unrecognized platform type ' + platform)
+		exit_code = target.do_operation(operation)
 
+	# Add success/failure state to the build status dictionary
 	if (exit_code == 0) :
-		print tclr.OK + name + " Succeeded" + tclr.END
-		build_status[name] = "Succeeded"
+		print tclr.OK + target.name + " Succeeded" + tclr.END
 	else :
-		print tclr.FAIL + name + " Failed" + tclr.END
-		build_status[name] = "Failed"
+		print tclr.FAIL + target.name + " Failed" + tclr.END
 
 final_status = 0
 
 print "\n"
 
-for target in build_targets :
-	project = target["name"]
-	status = build_status[project]
-	if (status == "Failed") :
-		print tclr.FAIL + project + " failed." + tclr.END
+code_coverage = False
+
+# Print out the final result of each operation.
+for target in targets :
+	if (target.failed) :
+		print tclr.FAIL + target.name + " failed." + tclr.END
 		final_status = 1
-	elif (status == "Skipped") :
-		print tclr.SKIP + '\033[93m' + project + " skipped." + tclr.END
-		final_status = 1
-	elif (status == "Succeeded") :
-		print tclr.OK + '\033[92m' + project + " succeeded." + tclr.END
 	else :
-		raise Exception('Unrecognized status: ' + status)
+		if ("codecov" in target.operations) :
+			code_coverage = True
+		print tclr.OK + '\033[92m' + target.name + " succeeded." + tclr.END
+
+if code_coverage :
+	print "\nCode Coverage Results:"
+	for target in targets :
+		if (target.coverage != None) :
+			target.print_coverage(True)
 
 sys.exit(final_status)


### PR DESCRIPTION
List of changes:
- Modified build.py to show code coverage (same as in MSAL)
- Removed "CodeCoverage" build configuration as it seems to be redundant.

I've noticed that build.py script is now much slower (when it runs with "clean" step) mainly due to the following command:

`xcodebuild -showBuildSettings`

Each invocation of this command takes ~30 sec on my machine.
For example:

`time xcodebuild -workspace ADAL.xcworkspace -scheme "ADAL" -configuration Debug -sdk iphonesimulator CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO -destination 'platform=iOS Simulator,name=iPhone 6,OS=latest' -showBuildSettings`
...
`xcodebuild -workspace ADAL.xcworkspace -scheme "ADAL" -configuration Debug     31.39s user 4.93s system 96% cpu 37.718 total`

We should decide whether we want to keep it (and have no hardcoded paths for cleaning step) or return hardcoded paths back but reduce invocation time.