### PR TITLE
Add ‘Url’ to the adBase64[Encode/Decode]Data function names

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -218,7 +218,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     //decrypt response first
     ADBrokerKeyHelper* brokerHelper = [[ADBrokerKeyHelper alloc] init];
     ADAuthenticationError* decryptionError = nil;
-    NSData *encryptedResponse = [NSString adBase64DecodeData:encryptedBase64Response ];
+    NSData *encryptedResponse = [NSString adBase64UrlDecodeData:encryptedBase64Response ];
     NSData* decrypted = [brokerHelper decryptBrokerResponse:encryptedResponse
                                                     version:protocolVersion
                                                       error:&decryptionError];
@@ -290,7 +290,7 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
     NSData* key = [brokerHelper getBrokerKey:error];
     AUTH_ERROR_RETURN_IF_NIL(key, AD_ERROR_UNEXPECTED, @"Unable to retrieve broker key.", _requestParams.correlationId);
     
-    NSString* base64Key = [NSString adBase64EncodeData:key];
+    NSString* base64Key = [NSString adBase64UrlEncodeData:key];
     AUTH_ERROR_RETURN_IF_NIL(base64Key, AD_ERROR_UNEXPECTED, @"Unable to base64 encode broker key.", _requestParams.correlationId);
     NSString* base64UrlKey = [base64Key adUrlFormEncode];
     AUTH_ERROR_RETURN_IF_NIL(base64UrlKey, AD_ERROR_UNEXPECTED, @"Unable to URL encode broker key.", _requestParams.correlationId);

--- a/ADAL/src/utils/ADHelpers.m
+++ b/ADAL/src/utils/ADHelpers.m
@@ -135,7 +135,7 @@
            [data length],
            cHMAC);
     NSData* signedData = [[NSData alloc] initWithBytes:cHMAC length:sizeof(cHMAC)];
-    NSString* signedEncodedDataString = [NSString adBase64EncodeData:signedData];
+    NSString* signedEncodedDataString = [NSString adBase64UrlEncodeData:signedData];
     return [NSString stringWithFormat:@"%@.%@",
             signingInput,
             signedEncodedDataString];

--- a/ADAL/src/utils/NSString+ADHelperMethods.h
+++ b/ADAL/src/utils/NSString+ADHelperMethods.h
@@ -43,10 +43,10 @@
 - (NSString *)adUrlFormEncode;
 
 /*! Converts base64 String to NSData */
-+ (NSData *)adBase64DecodeData:(NSString *)encodedString;
++ (NSData *)adBase64UrlDecodeData:(NSString *)encodedString;
 
 /*! Converts NSData to base64 String */
-+ (NSString *)adBase64EncodeData:(NSData *)data;
++ (NSString *)adBase64UrlEncodeData:(NSData *)data;
 
 - (NSString*)adComputeSHA256;
 

--- a/ADAL/src/utils/NSString+ADHelperMethods.m
+++ b/ADAL/src/utils/NSString+ADHelperMethods.m
@@ -68,7 +68,7 @@ BOOL validBase64Characters(const byte* data, const int size)
 /// See RFC 4648, Section 5 plus switch characters 62 and 63 and no padding.
 /// For a good overview of Base64 encoding, see http://en.wikipedia.org/wiki/Base64
 /// </remarks>
-+ (NSData *)adBase64DecodeData:(NSString *)encodedString
++ (NSData *)adBase64UrlDecodeData:(NSString *)encodedString
 {
     if ( nil == encodedString )
     {
@@ -165,7 +165,7 @@ BOOL validBase64Characters(const byte* data, const int size)
 
 - (NSString *)adBase64UrlDecode
 {
-    NSData *decodedData = [self.class adBase64DecodeData:self];
+    NSData *decodedData = [self.class adBase64UrlDecodeData:self];
     
     return [[NSString alloc] initWithData:decodedData encoding:NSUTF8StringEncoding];
 }
@@ -187,7 +187,7 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
 /// See RFC 4648, Section 5 plus switch characters 62 and 63 and no padding.
 /// For a good overview of Base64 encoding, see http://en.wikipedia.org/wiki/Base64
 /// </remarks>
-+ (NSString *)adBase64EncodeData:(NSData *)data
++ (NSString *)adBase64UrlEncodeData:(NSData *)data
 {
     if ( nil == data )
         return nil;
@@ -267,7 +267,7 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
 {
     NSData *decodedData = [self dataUsingEncoding:NSUTF8StringEncoding];
     
-    return [self.class adBase64EncodeData:decodedData];
+    return [self.class adBase64UrlEncodeData:decodedData];
 }
 
 + (BOOL)adIsStringNilOrBlank:(NSString *)string

--- a/ADAL/src/workplacejoin/ADJwtHelper.m
+++ b/ADAL/src/workplacejoin/ADJwtHelper.m
@@ -41,7 +41,7 @@
     NSString* signingInput = [NSString stringWithFormat:@"%@.%@", [headerJSON adBase64UrlEncode], [payloadJSON adBase64UrlEncode]];
     NSData* signedData = [ADJwtHelper sign:signingKey
                                       data:[signingInput dataUsingEncoding:NSUTF8StringEncoding]];
-    NSString* signedEncodedDataString = [NSString adBase64EncodeData: signedData];
+    NSString* signedEncodedDataString = [NSString adBase64UrlEncodeData: signedData];
     
     return [NSString stringWithFormat:@"%@.%@", signingInput, signedEncodedDataString];
 }

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -287,8 +287,8 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
                                       };
     
     NSString* idtoken = [NSString stringWithFormat:@"%@.%@",
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:part1_claims options:0 error:nil]],
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_claims options:0 error:nil]]];
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:part1_claims options:0 error:nil]],
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_claims options:0 error:nil]]];
     
     ADUserInformation* userInfo = [ADUserInformation userInformationWithIdToken:idtoken error:nil];
     

--- a/ADAL/tests/unit/ADTokenCacheTests.m
+++ b/ADAL/tests/unit/ADTokenCacheTests.m
@@ -168,8 +168,8 @@ static NSString* ReginaIdtoken()
                                       };
     
     NSString* idtoken = [NSString stringWithFormat:@"%@.%@",
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:part1_claims options:0 error:nil]],
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_claims options:0 error:nil]]];
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:part1_claims options:0 error:nil]],
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_claims options:0 error:nil]]];
     
     return idtoken;
 }
@@ -212,8 +212,8 @@ static NSString* CartmanIdtoken()
                                      @"given_name" : @"Cartman" };
     
     NSString* idtoken = [NSString stringWithFormat:@"%@.%@",
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_part1 options:0 error:nil]],
-                         [NSString adBase64EncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_part2 options:0 error:nil]]];
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_part1 options:0 error:nil]],
+                         [NSString adBase64UrlEncodeData:[NSJSONSerialization dataWithJSONObject:idtoken_part2 options:0 error:nil]]];
     
     return idtoken;
 }


### PR DESCRIPTION
These have been doing Base64 URL encoding/decoding all along, but the naming has left for some confusion.