### PR TITLE
Strict(er) Validation on ADAL Network Mock

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -323,6 +323,14 @@
 		D6669FB51F1D4F51002492C5 /* ADWebFingerRequest.h in Headers */ = {isa = PBXBuildFile; fileRef = D6669FAD1F1D4F51002492C5 /* ADWebFingerRequest.h */; };
 		D6669FB61F1D4F51002492C5 /* ADWebFingerRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6669FAE1F1D4F51002492C5 /* ADWebFingerRequest.m */; };
 		D6669FB71F1D4F51002492C5 /* ADWebFingerRequest.m in Sources */ = {isa = PBXBuildFile; fileRef = D6669FAE1F1D4F51002492C5 /* ADWebFingerRequest.m */; };
+		D67D3D351F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
+		D67D3D361F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
+		D67D3D371F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
+		D67D3D381F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
+		D67D3D3B1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
+		D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
+		D67D3D3D1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
+		D67D3D3E1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
 		D68040301D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */; };
 		D68040331D22F686007A61AC /* ADWebAuthResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D68040311D22F686007A61AC /* ADWebAuthResponse.h */; };
 		D68040351D22F686007A61AC /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
@@ -707,6 +715,12 @@
 		D6669FAC1F1D4F51002492C5 /* ADDrsDiscoveryRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADDrsDiscoveryRequest.m; sourceTree = "<group>"; };
 		D6669FAD1F1D4F51002492C5 /* ADWebFingerRequest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebFingerRequest.h; sourceTree = "<group>"; };
 		D6669FAE1F1D4F51002492C5 /* ADWebFingerRequest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebFingerRequest.m; sourceTree = "<group>"; };
+		D67D3D331F382F8B00660F32 /* NSDictionary+ADTestUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+ADTestUtil.h"; sourceTree = "<group>"; };
+		D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+ADTestUtil.m"; sourceTree = "<group>"; };
+		D67D3D391F38502900660F32 /* ADTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestCase.h; sourceTree = "<group>"; };
+		D67D3D3A1F38502900660F32 /* ADTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestCase.m; sourceTree = "<group>"; };
+		D67D3D3F1F38538100660F32 /* ADTest.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTest.pch; sourceTree = "<group>"; };
+		D67D3D401F38542700660F32 /* ADAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADAL.pch; sourceTree = "<group>"; };
 		D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoinUtil.m; sourceTree = "<group>"; };
 		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
 		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
@@ -928,6 +942,7 @@
 			children = (
 				9453C3A41C583AA8006B9E79 /* public */,
 				60C351B91DA0D588006C8435 /* ADAL.m */,
+				D67D3D401F38542700660F32 /* ADAL.pch */,
 				9453C3A31C583A9C006B9E79 /* ADAL_Internal.h */,
 				8BB8345B18074A58007F9F0D /* ADAuthenticationContext.m */,
 				D6E43A681B04026D000F5BE2 /* ADAuthenticationContext+Internal.h */,
@@ -983,6 +998,11 @@
 				96C75D231E303A8E0038D1EC /* ADTestURLSessionDataTask.m */,
 				D6D4D4961F2FCD8600CC1859 /* ADTestURLResponse.h */,
 				D6D4D4971F2FCD8600CC1859 /* ADTestURLResponse.m */,
+				D67D3D331F382F8B00660F32 /* NSDictionary+ADTestUtil.h */,
+				D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */,
+				D67D3D391F38502900660F32 /* ADTestCase.h */,
+				D67D3D3A1F38502900660F32 /* ADTestCase.m */,
+				D67D3D3F1F38538100660F32 /* ADTest.pch */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1914,6 +1934,7 @@
 				B20DC6031F0D998A00957806 /* ADTokenCacheTests.m in Sources */,
 				B20DC6051F0D998A00957806 /* ADUserInformationTests.m in Sources */,
 				96C75D241E303A8E0038D1EC /* ADTestURLSessionDataTask.m in Sources */,
+				D67D3D3B1F38502900660F32 /* ADTestCase.m in Sources */,
 				B20DC5FD1F0D998A00957806 /* ADTelemetryTests.m in Sources */,
 				8B92DB5F1819E6A4004AAB0E /* XCTestCase+TestHelperMethods.m in Sources */,
 				96C75D281E303DC40038D1EC /* ADTestURLSession.m in Sources */,
@@ -1932,6 +1953,7 @@
 				B20DC6011F0D998A00957806 /* ADTokenCacheKeyTests.m in Sources */,
 				B20DC5F71F0D998A00957806 /* ADClientMetricsTests.m in Sources */,
 				B20DC6211F0DA4BF00957806 /* ADWebAuthControllerTests.m in Sources */,
+				D67D3D351F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2038,6 +2060,8 @@
 				B20DC5F61F0D998A00957806 /* ADAuthenticationResultTests.m in Sources */,
 				B20DC5F21F0D998A00957806 /* ADAuthenticationErrorTests.m in Sources */,
 				96C75D251E303A8E0038D1EC /* ADTestURLSessionDataTask.m in Sources */,
+				D67D3D3D1F38502900660F32 /* ADTestCase.m in Sources */,
+				D67D3D371F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 				94DD18F51C5ACFF900F80C62 /* XCTestCase+TestHelperMethods.m in Sources */,
 				96C75D291E303DC40038D1EC /* ADTestURLSession.m in Sources */,
 				B20DC5F41F0D998A00957806 /* ADAuthenticationParametersTests.m in Sources */,
@@ -2051,6 +2075,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */,
 				B20DC60F1F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				B20DC5891F0D96A100957806 /* ADTelemetryTestDispatcher.m in Sources */,
@@ -2058,6 +2083,7 @@
 				B20DC5951F0D96A100957806 /* ADTestURLSessionDataTask.m in Sources */,
 				D6D4D4991F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC5961F0D96A100957806 /* XCTestCase+TestHelperMethods.m in Sources */,
+				D67D3D361F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 				B20DC5981F0D96A100957806 /* ADTestURLSession.m in Sources */,
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
 			);
@@ -2069,12 +2095,14 @@
 			files = (
 				B20DC5BE1F0D96A700957806 /* ADTelemetryTestDispatcher.m in Sources */,
 				B20DC5BF1F0D96A700957806 /* ADTestURLSessionDataTask.m in Sources */,
+				D67D3D3E1F38502900660F32 /* ADTestCase.m in Sources */,
 				B20DC5C61F0D96A700957806 /* XCTestCase+TestHelperMethods.m in Sources */,
 				B20DC6131F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5C71F0D96A700957806 /* ADTestURLSession.m in Sources */,
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC6101F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */,
+				D67D3D381F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2481,7 +2509,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -2514,7 +2542,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				INFOPLIST_FILE = "tests/unit/ios/ADAL_iOS_UTs-Info.plist";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2667,6 +2695,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "tests/unit/mac/ADAL_Mac_UTs-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -2689,6 +2718,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "tests/unit/mac/ADAL_Mac_UTs-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -2713,7 +2743,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -2746,7 +2776,7 @@
 				GCC_GENERATE_TEST_COVERAGE_FILES = NO;
 				GCC_INSTRUMENT_PROGRAM_FLOW_ARCS = NO;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
-				GCC_PREFIX_HEADER = src/ADAL.pch;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				INFOPLIST_FILE = "tests/integration/ios/ADAL_iOS_ITs-Info.plist";
 				OTHER_LDFLAGS = (
 					"$(inherited)",
@@ -2773,6 +2803,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "tests/integration/mac/ADAL_Mac_ITs-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
@@ -2795,6 +2826,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREFIX_HEADER = tests/ADTest.pch;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = "tests/integration/mac/ADAL_Mac_ITs-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";

--- a/ADAL/src/ADClientMetrics.m
+++ b/ADAL/src/ADClientMetrics.m
@@ -113,4 +113,17 @@ const NSString* HeaderLastEndpoint = @"x-client-last-endpoint";
     }
 }
 
+- (void)clearMetrics
+{
+    @synchronized (self)
+    {
+        _errorToReport = nil;
+        _endpoint = nil;
+        _correlationId = nil;
+        _responseTime = nil;
+        
+        _isPending = NO;
+    }
+}
+
 @end

--- a/ADAL/tests/ADTest.pch
+++ b/ADAL/tests/ADTest.pch
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,42 +17,19 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+#ifndef ADTest_pch
+#define ADTest_pch
 
 #import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
+#import "ADTestCase.h"
+#import "ADAL.pch"
 
-@interface ADClientMetrics : NSObject
-{
-@private
-    NSString* _endpoint;
-    NSString* _responseTime;
-    NSString* _correlationId;
-    NSString* _errorToReport;
-    NSDate* _startTime;
-    bool _isPending;
-}
-
-@property (readonly) NSString* endpoint;
-@property (readonly) NSString* responseTime;
-@property (readonly) NSString* correlationId;
-@property (readonly) NSString* errorToReport;
-@property (readonly) NSDate* startTime;
-@property bool isPending;
-
-+ (ADClientMetrics *)getInstance;
-
-- (void)addClientMetrics:(NSMutableDictionary *)requestHeaders
-                endpoint:(NSString *)endPoint;
-
-- (void)endClientMetricsRecord:(NSString *)endpoint
-                     startTime:(NSDate *)startTime
-                 correlationId:(NSUUID *)correlationId
-                  errorDetails:(NSString *)errorDetails;
-
-- (void)clearMetrics;
-
-@end
+#endif /* ADTest_pch */

--- a/ADAL/tests/ADTestCase.h
+++ b/ADAL/tests/ADTestCase.h
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,42 +17,16 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
 
-#import <Foundation/Foundation.h>
+#import <XCTest/XCTest.h>
 
-@interface ADClientMetrics : NSObject
-{
-@private
-    NSString* _endpoint;
-    NSString* _responseTime;
-    NSString* _correlationId;
-    NSString* _errorToReport;
-    NSDate* _startTime;
-    bool _isPending;
-}
-
-@property (readonly) NSString* endpoint;
-@property (readonly) NSString* responseTime;
-@property (readonly) NSString* correlationId;
-@property (readonly) NSString* errorToReport;
-@property (readonly) NSDate* startTime;
-@property bool isPending;
-
-+ (ADClientMetrics *)getInstance;
-
-- (void)addClientMetrics:(NSMutableDictionary *)requestHeaders
-                endpoint:(NSString *)endPoint;
-
-- (void)endClientMetricsRecord:(NSString *)endpoint
-                     startTime:(NSDate *)startTime
-                 correlationId:(NSUUID *)correlationId
-                  errorDetails:(NSString *)errorDetails;
-
-- (void)clearMetrics;
+@interface ADTestCase : XCTestCase
 
 @end

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,46 +17,32 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
 
-#import <XCTest/XCTest.h>
-#import "XCTestCase+TestHelperMethods.h"
-#import <libkern/OSAtomic.h>
 
-const int sMaxLoggerThreadsDuration = 5;//In seconds
-const int sMaxLoggerTestThreads = 100;
-volatile int32_t sLoggerTestThreadsCompleted = 0;
-dispatch_semaphore_t sLoggerTestCompletedSignal;
+#import "ADTestCase.h"
+#import "ADClientMetrics.h"
 
-@interface ADLoggerTests : ADTestCase
-
-@end
-
-@implementation ADLoggerTests
+@implementation ADTestCase
 
 - (void)setUp
 {
     [super setUp];
-    
-    [ADLogger setNSLogging:YES];//We disable it by default in the rest of the tests to limit the log files
-    XCTAssertTrue([ADLogger getNSLogging]);
 }
+
 
 - (void)tearDown
 {
     [super tearDown];
+    [[ADClientMetrics getInstance] clearMetrics];
 }
 
-- (void)testMessageNoThrowing
-{
-    //Neither of these calls should throw. See the method body for details:
-    [ADLogger log:ADAL_LOG_LEVEL_NO_LOG context:nil message:@"Message" errorCode:AD_ERROR_SUCCEEDED info:@"info" correlationId:nil userInfo:nil];
-    [ADLogger log:ADAL_LOG_LEVEL_ERROR context:nil message:nil errorCode:AD_ERROR_SUCCEEDED info:@"info" correlationId:nil userInfo:nil];
-    [ADLogger log:ADAL_LOG_LEVEL_ERROR context:nil message:@"message" errorCode:AD_ERROR_SUCCEEDED info:nil correlationId:nil userInfo:nil];
-}
+
 
 @end

--- a/ADAL/tests/ADTestURLResponse.h
+++ b/ADAL/tests/ADTestURLResponse.h
@@ -29,7 +29,7 @@
     NSURL *_requestURL;
     id _requestJSONBody;
     id _requestParamsBody;
-    NSDictionary *_requestHeaders;
+    NSMutableDictionary *_requestHeaders;
     NSData *_requestBody;
     NSDictionary *_QPs;
     NSDictionary *_expectedRequestHeaders;
@@ -37,6 +37,8 @@
     NSURLResponse *_response;
     NSError *_error;
 }
+
++ (NSDictionary *)defaultHeaders;
 
 + (ADTestURLResponse*)requestURLString:(NSString *)requestUrlString
                      responseURLString:(NSString *)responseUrlString
@@ -90,11 +92,10 @@
 + (ADTestURLResponse*)responseUnreachableWebFinger:(NSString *)passiveEndpoint
                                          authority:(NSString *)authority;
 
-
 - (void)setRequestURL:(NSURL *)requestURL;
 - (void)setRequestHeaders:(NSDictionary *)headers;
 - (void)setRequestBody:(NSData *)body;
-- (void)setRequestJSONBody:(NSDictionary *)jsonBody;
+- (void)setUrlFormEncodedBody:(NSDictionary *)formParameters;
 
 - (void)setResponseURL:(NSString *)urlString
                   code:(NSInteger)code

--- a/ADAL/tests/ADTestURLResponse.m
+++ b/ADAL/tests/ADTestURLResponse.m
@@ -24,8 +24,32 @@
 #import "ADTestURLResponse.h"
 #import "ADOAuth2Constants.h"
 #import "NSDictionary+ADExtensions.h"
+#import "NSURL+ADExtensions.h"
+#import "NSDictionary+ADTestUtil.h"
 
 @implementation ADTestURLResponse
+
++ (NSDictionary *)defaultHeaders
+{
+    static NSDictionary *s_defaultHeaders = nil;
+    static dispatch_once_t once;
+    
+    dispatch_once(&once, ^{
+        NSMutableDictionary* headers = [[ADLogger adalId] mutableCopy];
+        
+        headers[@"Accept"] = @"application/json";
+        headers[@"client-request-id"] = [ADTestRequireValueSentinel sentinel];
+        headers[@"return-client-request-id"] = @"true";
+        headers[@"x-ms-PkeyAuth"] = @"1.0";
+        
+        // TODO: This really shouldn't be a default header...
+        headers[@"Content-Type"] = @"application/x-www-form-urlencoded";
+        
+        s_defaultHeaders = [headers copy];
+    });
+    
+    return s_defaultHeaders;
+}
 
 + (ADTestURLResponse *)request:(NSURL *)request
                requestJSONBody:(NSDictionary *)requestBody
@@ -37,6 +61,7 @@
     response->_requestJSONBody = requestBody;
     response->_response = urlResponse;
     response->_responseData = data;
+    [response setRequestHeaders:nil];
     
     return response;
 }
@@ -50,6 +75,7 @@
     [response setRequestURL:request];
     response->_response = urlResponse;
     response->_responseData = data;
+    [response setRequestHeaders:nil];
     
     return response;
 }
@@ -61,6 +87,7 @@
     
     [response setRequestURL:request];
     response->_response = urlResponse;
+    [response setRequestHeaders:nil];
     
     return response;
 }
@@ -71,6 +98,7 @@
     ADTestURLResponse * response = [ADTestURLResponse new];
     
     [response setRequestURL:request];
+    [response setRequestHeaders:[ADLogger adalId]];
     response->_error = error;
     
     return response;
@@ -94,6 +122,7 @@
                                                          responseCode:200
                                                      httpHeaderFields:@{}
                                                      dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
     
     return response;
 }
@@ -107,6 +136,7 @@
                                                      httpHeaderFields:@{}
                                                      dictionaryAsJSON:@{OAUTH2_ERROR : @"I'm an OAUTH server error!",
                                                                         OAUTH2_ERROR_DESCRIPTION : @" I'm an OAUTH error description!"}];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
     
     return response;
 }
@@ -133,6 +163,8 @@
                                                                         @"IdentityProviderService" :
                                                                             @{@"PassiveAuthEndpoint" : passiveAuthEndpoint}
                                                                         }];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
     return response;
 }
 
@@ -148,6 +180,8 @@
                                                          responseCode:400
                                                      httpHeaderFields:@{}
                                                      dictionaryAsJSON:@{}];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
     return response;
 }
 
@@ -158,7 +192,10 @@
     NSString *drsURL = [NSString stringWithFormat:@"%@%@/enrollmentserver/contract?api-version=1.0&x-client-Ver=" ADAL_VERSION_STRING,
                         onPrems ? @"https://enterpriseregistration." : @"https://enterpriseregistration.windows.net/", domain];
     
-    return [self serverNotFoundResponseForURLString:drsURL];
+    ADTestURLResponse *response = [self serverNotFoundResponseForURLString:drsURL];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
+    return response;
 }
 
 
@@ -178,6 +215,8 @@
                                                                                          @"href" : authority
                                                                                          }]
                                                                         }];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
     return response;
 }
 
@@ -192,6 +231,8 @@
                                                          responseCode:400
                                                      httpHeaderFields:@{}
                                                      dictionaryAsJSON:@{}];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
     return response;
 }
 
@@ -211,6 +252,8 @@
                                                                                          @"href" : @"idontmatch.com"
                                                                                          }]
                                                                         }];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
     return response;
 }
 
@@ -222,9 +265,11 @@
     NSURL *endpointFullUrl = [NSURL URLWithString:passiveEndpoint.lowercaseString];
     NSString *url = [NSString stringWithFormat:@"https://%@/.well-known/webfinger?resource=%@&x-client-Ver=" ADAL_VERSION_STRING, endpointFullUrl.host, authority];
     
-    return [self serverNotFoundResponseForURLString:url];
+    ADTestURLResponse *response = [self serverNotFoundResponseForURLString:url];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+    
+    return response;
 }
-
 
 + (ADTestURLResponse *)requestURLString:(NSString*)requestUrlString
                       responseURLString:(NSString*)responseUrlString
@@ -235,6 +280,7 @@
     ADTestURLResponse *response = [ADTestURLResponse new];
     [response setRequestURL:[NSURL URLWithString:requestUrlString]];
     [response setResponseURL:responseUrlString code:responseCode headerFields:headerFields];
+    [response setRequestHeaders:[ADLogger adalId]];
     [response setJSONResponse:data];
     
     return response;
@@ -267,8 +313,8 @@
     ADTestURLResponse *response = [ADTestURLResponse new];
     [response setRequestURL:[NSURL URLWithString:requestUrlString]];
     [response setResponseURL:responseUrlString code:responseCode headerFields:headerFields];
-    response->_requestHeaders = requestHeaders;
-    response->_requestParamsBody = requestParams;
+    [response setRequestHeaders:requestHeaders];
+    [response setUrlFormEncodedBody:requestParams];
     [response setJSONResponse:data];
     
     return response;
@@ -321,7 +367,24 @@
 
 - (void)setRequestHeaders:(NSDictionary *)headers
 {
-    _requestHeaders = [headers copy];
+    if (headers)
+    {
+        _requestHeaders = [headers mutableCopy];
+    }
+    else
+    {
+        _requestHeaders = [NSMutableDictionary new];
+    }
+    
+    // These values come from ADClientMetrics and are dependent on a previous request, which breaks
+    // the isolation of the tests. For now the easiest path is to ignore them entirely.
+    if (!_requestHeaders[@"x-client-last-endpoint"])
+    {
+        _requestHeaders[@"x-client-last-error"] = [ADTestIgnoreSentinel sentinel];
+        _requestHeaders[@"x-client-last-endpoint"] = [ADTestIgnoreSentinel sentinel];
+        _requestHeaders[@"x-client-last-request"] = [ADTestIgnoreSentinel sentinel];
+        _requestHeaders[@"x-client-last-response-time"] = [ADTestIgnoreSentinel sentinel];
+    }
 }
 
 - (void)setRequestBody:(NSData *)body
@@ -329,9 +392,23 @@
     _requestBody = body;
 }
 
-- (void)setRequestJSONBody:(NSDictionary *)jsonBody
+- (void)setUrlFormEncodedBody:(NSDictionary *)formParameters
 {
-    _requestParamsBody = jsonBody;
+    _requestParamsBody = nil;
+    if (!formParameters)
+    {
+        return;
+    }
+    
+    _requestParamsBody = formParameters;
+    if (!_requestHeaders)
+    {
+        _requestHeaders = [NSMutableDictionary new];
+    }
+    
+    _requestHeaders[@"Content-Type"] = @"application/x-www-form-urlencoded";
+    NSString *urlEncoded = [formParameters adURLFormEncode];
+    _requestHeaders[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)[urlEncoded lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
 }
 
 - (BOOL)matchesURL:(NSURL *)url
@@ -342,7 +419,7 @@
         return NO;
     }
     
-    if ([url.host caseInsensitiveCompare:_requestURL.host] != NSOrderedSame)
+    if ([[url adHostWithPortIfNecessary] caseInsensitiveCompare:[_requestURL adHostWithPortIfNecessary]] != NSOrderedSame)
     {
         return NO;
     }
@@ -359,7 +436,9 @@
     if (![NSString adIsStringNilOrBlank:query])
     {
         NSDictionary *QPs = [NSDictionary adURLFormDecode:query];
-        if (![QPs isEqualToDictionary:_QPs])
+        if (![_QPs compareToActual:QPs
+                             label:@"URL QPs"
+                           myLabel:@"Expected URL QPs"])
         {
             return NO;
         }
@@ -383,9 +462,11 @@
     
     if (_requestParamsBody)
     {
-        NSString* string = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
-        id obj = [NSDictionary adURLFormDecode:string];
-        return [obj isEqual:_requestParamsBody];
+        NSString * string = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
+        NSDictionary *obj = [NSDictionary adURLFormDecode:string];
+        return [_requestParamsBody compareToActual:obj
+                                             label:@"URL Encoded Body Parameter"
+                                           myLabel:@"Expected URL Encoded Body Parameter"];
     }
     
     if (_requestBody)
@@ -400,28 +481,21 @@
 {
     if (!_requestHeaders)
     {
-        return YES;
+        if (!headers || headers.count == 0)
+        {
+            return YES;
+        }
+        // This wiil spit out to console the extra stuff that we weren't expecting
+        [@{} compareToActual:headers label:@"Request Headers" myLabel:@"Expected Request Headers"];
+        return NO;
     }
     
-    BOOL matches = YES;
-    
-    for (id key in _requestHeaders)
-    {
-        id header = [_requestHeaders objectForKey:key];
-        id matchHeader = [headers objectForKey:key];
-        if (!matchHeader)
-        {
-            AD_LOG_ERROR_F(@"Request is missing header", AD_FAILED, nil, @"%@", key);
-            matches = NO;
-        }
-        else if (![header isEqual:matchHeader])
-        {
-            AD_LOG_ERROR_F(@"Request headers do not match", AD_FAILED, nil, @"expected: \"%@\" actual: \"%@\"", header, matchHeader);
-            matches = NO;
-        }
-    }
-    
-    return matches;
+    return [_requestHeaders compareToActual:headers label:@"Request Headers" myLabel:@"Expected Request Headers"];
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: %@>", NSStringFromClass(self.class), _requestURL];
 }
 
 @end

--- a/ADAL/tests/ADTestURLResponse.m
+++ b/ADAL/tests/ADTestURLResponse.m
@@ -439,9 +439,7 @@
     if (![NSString adIsStringNilOrBlank:query])
     {
         NSDictionary *QPs = [NSDictionary adURLFormDecode:query];
-        if (![_QPs compareToActual:QPs
-                             label:@"URL QPs"
-                           myLabel:@"Expected URL QPs"])
+        if (![_QPs compareAndPrintDiff:QPs dictionaryDescription:@"URL QPs"])
         {
             return NO;
         }
@@ -467,9 +465,7 @@
     {
         NSString * string = [[NSString alloc] initWithData:body encoding:NSUTF8StringEncoding];
         NSDictionary *obj = [NSDictionary adURLFormDecode:string];
-        return [_requestParamsBody compareToActual:obj
-                                             label:@"URL Encoded Body Parameter"
-                                           myLabel:@"Expected URL Encoded Body Parameter"];
+        return [_requestParamsBody compareAndPrintDiff:obj dictionaryDescription:@"URL Encoded Body Parameters"];
     }
     
     if (_requestBody)
@@ -489,11 +485,11 @@
             return YES;
         }
         // This wiil spit out to console the extra stuff that we weren't expecting
-        [@{} compareToActual:headers label:@"Request Headers" myLabel:@"Expected Request Headers"];
+        [@{} compareAndPrintDiff:headers dictionaryDescription:@"Request Headers"];
         return NO;
     }
     
-    return [_requestHeaders compareToActual:headers label:@"Request Headers" myLabel:@"Expected Request Headers"];
+    return [_requestHeaders compareAndPrintDiff:headers dictionaryDescription:@"Request Headers"];
 }
 
 - (NSString *)description

--- a/ADAL/tests/ADTestURLResponse.m
+++ b/ADAL/tests/ADTestURLResponse.m
@@ -40,7 +40,10 @@
         headers[@"Accept"] = @"application/json";
         headers[@"client-request-id"] = [ADTestRequireValueSentinel sentinel];
         headers[@"return-client-request-id"] = @"true";
+        
+#if TARGET_OS_IPHONE
         headers[@"x-ms-PkeyAuth"] = @"1.0";
+#endif
         
         // TODO: This really shouldn't be a default header...
         headers[@"Content-Type"] = @"application/x-www-form-urlencoded";

--- a/ADAL/tests/ADTestURLSession.m
+++ b/ADAL/tests/ADTestURLSession.m
@@ -28,6 +28,46 @@
 #import "NSDictionary+ADExtensions.h"
 #import "ADOAuth2Constants.h"
 
+#include <assert.h>
+#include <stdbool.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/sysctl.h>
+
+// From https://developer.apple.com/library/content/qa/qa1361/_index.html
+static bool AmIBeingDebugged(void)
+// Returns true if the current process is being debugged (either
+// running under the debugger or has a debugger attached post facto).
+{
+    int                 junk;
+    int                 mib[4];
+    struct kinfo_proc   info;
+    size_t              size;
+    
+    // Initialize the flags so that, if sysctl fails for some bizarre
+    // reason, we get a predictable result.
+    
+    info.kp_proc.p_flag = 0;
+    
+    // Initialize mib, which tells sysctl the info we want, in this case
+    // we're looking for information about a specific process ID.
+    
+    mib[0] = CTL_KERN;
+    mib[1] = KERN_PROC;
+    mib[2] = KERN_PROC_PID;
+    mib[3] = getpid();
+    
+    // Call sysctl.
+    
+    size = sizeof(info);
+    junk = sysctl(mib, sizeof(mib) / sizeof(*mib), &info, &size, NULL, 0);
+    assert(junk == 0);
+    
+    // We're being debugged if the P_TRACED flag is set.
+    
+    return ( (info.kp_proc.p_flag & P_TRACED) != 0 );
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
 @implementation NSURLSession (TestSessionOverride)
@@ -107,8 +147,6 @@ static NSMutableArray* s_responses = nil;
     [s_responses removeAllObjects];
 }
 
-
-
 - (NSURLSessionDataTask *)dataTaskWithURL:(NSURL *)url
 {
     NSURLRequest *request = [NSURLRequest requestWithURL:url];
@@ -141,9 +179,15 @@ static NSMutableArray* s_responses = nil;
         
         if ([obj isKindOfClass:[ADTestURLResponse class]])
         {
-            response = (ADTestURLResponse*)obj;
+            response = (ADTestURLResponse *)obj;
             
-            if ([response matchesURL:requestURL] && [response matchesHeaders:headers] && [response matchesBody:body])
+            // We don't want the compiler to short circuit this case as finding out in one go all
+            // of the data that doesn't match can speed up debugging & fixing tests
+            bool match = [response matchesURL:requestURL];
+            match &= [response matchesBody:body];
+            match &= [response matchesHeaders:headers];
+            
+            if (match)
             {
                 [s_responses removeObjectAtIndex:i];
                 return response;
@@ -155,16 +199,50 @@ static NSMutableArray* s_responses = nil;
             NSMutableArray *subResponses = [s_responses objectAtIndex:i];
             response = [subResponses objectAtIndex:0];
             
-            if ([response matchesURL:requestURL] && [response matchesHeaders:headers] && [response matchesBody:body])
+            bool match = [response matchesURL:requestURL];
+            match &= [response matchesBody:body];
+            match &= [response matchesHeaders:headers];
+            
+            if (match)
             {
                 [subResponses removeObjectAtIndex:0];
                 if ([subResponses count] == 0)
-                {                    [s_responses removeObjectAtIndex:i];
+                {
+                    [s_responses removeObjectAtIndex:i];
                 }
                 return response;
             }
         }
     }
+    
+    // This class is used in the test target only. If you're seeing this outside the test target that means you linked in the file wrong
+    // take it out!
+    //
+    // No unit tests are allowed to hit network. This is done to ensure reliability of the test code. Tests should run quickly and
+    // deterministically. If you're hitting this assert that means you need to add an expected request and response to ADTestURLConnection
+    // using the ADTestRequestReponse class and add it using -[ADTestURLConnection addExpectedRequestResponse:] if you have a single
+    // request/response or -[ADTestURLConnection addExpectedRequestsAndResponses:] if you have a series of network requests that you need
+    // to ensure happen in the proper order.
+    //
+    // Example:
+    //
+    // MSALTestRequestResponse *response = [MSALTestRequestResponse requestURLString:@"https://requestURL"
+    //                                                             responseURLString:@"https://idontknowwhatthisshouldbe.com"
+    //                                                                  responseCode:400
+    //                                                              httpHeaderFields:@{}
+    //                                                              dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
+    //
+    //  [MSALTestURLSession addResponse:response];
+    
+    if (AmIBeingDebugged())
+    {
+        NSLog(@"Failed to find repsonse for %@\ncurrent responses: %@", requestURL, s_responses);
+        // This will cause the tests to immediately stop execution right here if we're in the debugger,
+        // hopefully making it a little easier to see why a test is failing. :)
+        __builtin_trap();
+    }
+    
+    NSAssert(nil, @"did not find a matching response for %@", requestURL.absoluteString);
     
     return nil;
 }

--- a/ADAL/tests/ADTestURLSessionDataTask.m
+++ b/ADAL/tests/ADTestURLSessionDataTask.m
@@ -57,33 +57,6 @@
     
     if (!response)
     {
-        // This class is used in the test target only. If you're seeing this outside the test target that means you linked in the file wrong
-        // take it out!
-        //
-        // No unit tests are allowed to hit network. This is done to ensure reliability of the test code. Tests should run quickly and
-        // deterministically. If you're hitting this assert that means you need to add an expected request and response to ADTestURLConnection
-        // using the ADTestRequestReponse class and add it using -[ADTestURLConnection addExpectedRequestResponse:] if you have a single
-        // request/response or -[ADTestURLConnection addExpectedRequestsAndResponses:] if you have a series of network requests that you need
-        // to ensure happen in the proper order.
-        //
-        // Example:
-        //
-        // ADTestRequestResponse* response = [ADTestRequestResponse requestURLString:@"https://login.windows.net/common/discovery/instance?api-version=1.0&authorization_endpoint=https://login.windows.net/omercantest.onmicrosoft.com/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING
-        //                                                         responseURLString:@"https://idontknowwhatthisshouldbe.com"
-        //                                                              responseCode:400
-        //                                                          httpHeaderFields:@{}
-        //                                                          dictionaryAsJSON:@{@"tenant_discovery_endpoint" : @"totally valid!"}];
-        //
-        //  [ADTestURLSession addExpectedRequestResponse:response];
-        //
-        //
-        //  Consult the ADTestRequestResponse class for a list of helper methods for formulating requests and responses.
-
-        NSString *requestURLString = self.request.URL.absoluteString;
-        NSAssert(response, @"did not find a matching response for %@", requestURLString);
-        
-        AD_LOG_ERROR_F(@"No matching response found.", NSURLErrorNotConnectedToInternet, nil, @"request url = %@", self.request.URL);
-        
         [self.session dispatchIfNeed:^{
             NSError* error = [NSError errorWithDomain:NSURLErrorDomain
                                                  code:NSURLErrorNotConnectedToInternet

--- a/ADAL/tests/NSDictionary+ADTestUtil.h
+++ b/ADAL/tests/NSDictionary+ADTestUtil.h
@@ -29,10 +29,9 @@
 
 @interface NSDictionary (ADTestUtil)
 
-- (BOOL)compareToActual:(NSDictionary *)dictionary;
-- (BOOL)compareToActual:(NSDictionary *)dictionary
-                  label:(NSString *)label
-                myLabel:(NSString *)myLabel;
+- (BOOL)compareAndPrintDiff:(NSDictionary *)dictionary;
+- (BOOL)compareAndPrintDiff:(NSDictionary *)dictionary
+      dictionaryDescription:(NSString *)description;
 
 @end
 

--- a/ADAL/tests/NSDictionary+ADTestUtil.h
+++ b/ADAL/tests/NSDictionary+ADTestUtil.h
@@ -1,3 +1,5 @@
+//------------------------------------------------------------------------------
+//
 // Copyright (c) Microsoft Corporation.
 // All rights reserved.
 //
@@ -15,42 +17,41 @@
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
 
 #import <Foundation/Foundation.h>
 
-@interface ADClientMetrics : NSObject
-{
-@private
-    NSString* _endpoint;
-    NSString* _responseTime;
-    NSString* _correlationId;
-    NSString* _errorToReport;
-    NSDate* _startTime;
-    bool _isPending;
-}
+@interface NSDictionary (ADTestUtil)
 
-@property (readonly) NSString* endpoint;
-@property (readonly) NSString* responseTime;
-@property (readonly) NSString* correlationId;
-@property (readonly) NSString* errorToReport;
-@property (readonly) NSDate* startTime;
-@property bool isPending;
+- (BOOL)compareToActual:(NSDictionary *)dictionary;
+- (BOOL)compareToActual:(NSDictionary *)dictionary
+                  label:(NSString *)label
+                myLabel:(NSString *)myLabel;
 
-+ (ADClientMetrics *)getInstance;
+@end
 
-- (void)addClientMetrics:(NSMutableDictionary *)requestHeaders
-                endpoint:(NSString *)endPoint;
+/*!
+ Sentinel class to use for values you want to make sure are present in a dictionary but don't
+ care about the actual value.
+ */
+@interface ADTestRequireValueSentinel : NSObject
 
-- (void)endClientMetricsRecord:(NSString *)endpoint
-                     startTime:(NSDate *)startTime
-                 correlationId:(NSUUID *)correlationId
-                  errorDetails:(NSString *)errorDetails;
++ (instancetype)sentinel;
 
-- (void)clearMetrics;
+@end
+
+
+/*!
+ Sentinel class to use for values you don't care if it is present or not
+ */
+@interface ADTestIgnoreSentinel : NSObject
+
++ (instancetype)sentinel;
 
 @end

--- a/ADAL/tests/NSDictionary+ADTestUtil.m
+++ b/ADAL/tests/NSDictionary+ADTestUtil.m
@@ -29,14 +29,13 @@
 
 @implementation NSDictionary (ADTestUtil)
 
-- (BOOL)compareToActual:(NSDictionary *)dictionary
+- (BOOL)compareAndPrintDiff:(NSDictionary *)dictionary
 {
-    return [self compareToActual:dictionary label:@"actual" myLabel:@"expected"];
+    return [self compareAndPrintDiff:dictionary dictionaryDescription:@"dictionary"];
 }
 
-- (BOOL)compareToActual:(NSDictionary *)dictionary
-                  label:(NSString *)label
-                myLabel:(NSString *)myLabel
+- (BOOL)compareAndPrintDiff:(NSDictionary *)dictionary
+      dictionaryDescription:(NSString *)description
 {
     BOOL fSame = YES;
     
@@ -51,12 +50,12 @@
         
         if (!otherVal)
         {
-            NSLog(@"\"%@\" missing from %@.", key, label);
+            NSLog(@"\"%@\" : \"%@\" missing from %@.", key, myVal, description);
             fSame = NO;
         }
         else if (![myVal isKindOfClass:[ADTestRequireValueSentinel class]] && ![myVal isEqual:otherVal])
         {
-            NSLog(@"\"%@\" does not match. %@: \"%@\" %@: \"%@\"", key, myLabel, self[key], label, otherVal);
+            NSLog(@"\"%@\" in %@ does not match. actual: \"%@\" expected: \"%@\"", key, description, otherVal, myVal);
             fSame = NO;
         }
     }
@@ -70,7 +69,7 @@
         
         if (!self[key])
         {
-            NSLog(@"@\"%@\" : @\"%@\" in %@, not found in %@", key, dictionary[key], label, myLabel);
+            NSLog(@"@\"%@\" : @\"%@\" in %@, not found in expected", key, dictionary[key], description);
             fSame = NO;
         }
     }

--- a/ADAL/tests/NSDictionary+ADTestUtil.m
+++ b/ADAL/tests/NSDictionary+ADTestUtil.m
@@ -1,0 +1,113 @@
+//------------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+//
+//------------------------------------------------------------------------------
+
+#import "NSDictionary+ADTestUtil.h"
+
+@implementation NSDictionary (ADTestUtil)
+
+- (BOOL)compareToActual:(NSDictionary *)dictionary
+{
+    return [self compareToActual:dictionary label:@"actual" myLabel:@"expected"];
+}
+
+- (BOOL)compareToActual:(NSDictionary *)dictionary
+                  label:(NSString *)label
+                myLabel:(NSString *)myLabel
+{
+    BOOL fSame = YES;
+    
+    for (NSString *key in self)
+    {
+        id myVal = self[key];
+        id otherVal = dictionary[key];
+        if ([myVal isKindOfClass:[ADTestIgnoreSentinel class]] || [otherVal isKindOfClass:[ADTestIgnoreSentinel class]])
+        {
+            continue;
+        }
+        
+        if (!otherVal)
+        {
+            NSLog(@"\"%@\" missing from %@.", key, label);
+            fSame = NO;
+        }
+        else if (![myVal isKindOfClass:[ADTestRequireValueSentinel class]] && ![myVal isEqual:otherVal])
+        {
+            NSLog(@"\"%@\" does not match. %@: \"%@\" %@: \"%@\"", key, myLabel, self[key], label, otherVal);
+            fSame = NO;
+        }
+    }
+    
+    for (NSString *key in dictionary)
+    {
+        if ([dictionary[key] isKindOfClass:[ADTestIgnoreSentinel class]])
+        {
+            continue;
+        }
+        
+        if (!self[key])
+        {
+            NSLog(@"@\"%@\" : @\"%@\" in %@, not found in %@", key, dictionary[key], label, myLabel);
+            fSame = NO;
+        }
+    }
+    
+    return fSame;
+}
+
+@end
+
+@implementation ADTestRequireValueSentinel
+
+static ADTestRequireValueSentinel *s_requiredSentinel = nil;
+
++ (void)initialize
+{
+    s_requiredSentinel = [ADTestRequireValueSentinel new];
+}
+
++ (instancetype)sentinel
+{
+    return s_requiredSentinel;
+}
+
+@end
+
+@implementation ADTestIgnoreSentinel
+
+static ADTestIgnoreSentinel *s_ignoreSentinel = nil;
+
++ (void)initialize
+{
+    s_ignoreSentinel = [ADTestIgnoreSentinel new];
+}
+
++ (instancetype)sentinel
+{
+    return s_ignoreSentinel;
+}
+
+@end

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -29,7 +29,8 @@
 #define ADTAssertContains(_str, _contains) XCTAssertTrue([_str containsString:_contains], "%@ does not contain \"%@\"", _str, _contains)
 
 #define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
-#define TEST_REDIRECT_URL [NSURL URLWithString:@"urn:ietf:wg:oauth:2.0:oob"]
+#define TEST_REDIRECT_URL_STRING @"urn:ietf:wg:oauth:2.0:oob"
+#define TEST_REDIRECT_URL [NSURL URLWithString:TEST_REDIRECT_URL_STRING]
 #define TEST_RESOURCE @"resource"
 #define TEST_USER_ID @"eric_cartman@contoso.com"
 #define TEST_CLIENT_ID @"c3c7f5e5-7153-44d4-90e6-329686d48d76"

--- a/ADAL/tests/integration/ADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/ADAuthorityValidationIntegrationTests.m
@@ -37,7 +37,7 @@
 
 static NSString* const s_kTrustedAuthority = @"https://login.windows.net";
 
-@interface ADAuthortyValidationTests : XCTestCase
+@interface ADAuthortyValidationTests : ADTestCase
 {
     dispatch_semaphore_t _dsem;
 }
@@ -190,9 +190,12 @@ static NSString* const s_kTrustedAuthority = @"https://login.windows.net";
     requestURL = [NSURL URLWithString:requestURLString];
 
     NSError* responseError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:nil];
+    
+    ADTestURLResponse *response = [ADTestURLResponse request:requestURL
+                                            respondWithError:responseError];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
 
-    [ADTestURLSession addResponse:[ADTestURLResponse request:requestURL
-                                               respondWithError:responseError]];
+    [ADTestURLSession addResponse:response];
     
     [authorityValidation validateAuthority:requestParams
                            completionBlock:^(BOOL validated, ADAuthenticationError *error)

--- a/ADAL/tests/integration/ios/ADAcquireTokenPkeyAuthTests.m
+++ b/ADAL/tests/integration/ios/ADAcquireTokenPkeyAuthTests.m
@@ -27,8 +27,9 @@
 #import "ADAuthenticationContext+Internal.h"
 #import "ADTestURLSession.h"
 #import "ADTokenCacheItem+Internal.h"
+#import "NSDictionary+ADTestUtil.h"
 
-@interface ADAcquireTokenPkeyAuthTests : XCTestCase
+@interface ADAcquireTokenPkeyAuthTests : ADTestCase
 {
     dispatch_semaphore_t _dsem;
 }
@@ -81,12 +82,12 @@
 
 - (ADTestURLResponse *)defaultPkeyAuthNoWPJResponse
 {
-    NSString* expectedAuthHeader = @"PKeyAuth  Context=\"pkeyauth_context\", Version=\"1.0\"";
+    NSDictionary *headers = @{ @"Authorization" : @"PKeyAuth  Context=\"pkeyauth_context\", Version=\"1.0\"" };
     return [self adResponseRefreshToken:TEST_REFRESH_TOKEN
                               authority:TEST_AUTHORITY
                                resource:TEST_RESOURCE
                                clientId:TEST_CLIENT_ID
-                         requestHeaders:@{ @"Authorization" : expectedAuthHeader }
+                         requestHeaders:headers
                           correlationId:TEST_CORRELATION_ID
                         newRefreshToken:@"new refresh token"
                          newAccessToken:@"new access token"

--- a/ADAL/tests/unit/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ADAuthenticationContextTests.m
@@ -32,7 +32,7 @@
 
 #define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
 
-@interface ADAuthenticationContextTests : XCTestCase
+@interface ADAuthenticationContextTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADAuthenticationErrorTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorTests.m
@@ -24,7 +24,7 @@
 #import <XCTest/XCTest.h>
 #import "XCTestCase+TestHelperMethods.h"
 
-@interface ADAuthenticationErrorTests : XCTestCase
+@interface ADAuthenticationErrorTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADAuthenticationParametersTests.m
+++ b/ADAL/tests/unit/ADAuthenticationParametersTests.m
@@ -29,7 +29,7 @@
 #import "ADTestURLSession.h"
 #import "ADTestURLResponse.h"
 
-@interface ADAuthenticationParametersTests : XCTestCase
+@interface ADAuthenticationParametersTests : ADTestCase
 {
     @private
     ADAuthenticationParameters* mParameters;
@@ -150,7 +150,7 @@
 }
 
 
-- (void) testParametersFromResourceURLParametersPositiveCase
+- (void)testParametersFromResourceURLParametersPositiveCase
 {
     //HTTP
     NSURL* resourceUrl = [[NSURL alloc] initWithString:@"http://testapi007.azurewebsites.net/api/WorkItem"];

--- a/ADAL/tests/unit/ADAuthenticationResultTests.m
+++ b/ADAL/tests/unit/ADAuthenticationResultTests.m
@@ -28,7 +28,7 @@
 #import "XCTestCase+TestHelperMethods.h"
 #import "ADUserInformation.h"
 
-@interface ADAuthenticationResultTests : XCTestCase
+@interface ADAuthenticationResultTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADAuthorityValidationTests.m
+++ b/ADAL/tests/unit/ADAuthorityValidationTests.m
@@ -37,7 +37,7 @@
 
 static NSString* const s_kTrustedAuthority = @"https://login.windows.net";
 
-@interface ADAuthortyValidationTests : XCTestCase
+@interface ADAuthortyValidationTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADClientMetricsTests.m
+++ b/ADAL/tests/unit/ADClientMetricsTests.m
@@ -24,7 +24,7 @@
 #import <XCTest/XCTest.h>
 #import "ADClientMetrics.h"
 
-@interface ADClientMetricsTests : XCTestCase
+@interface ADClientMetricsTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADHelpersTests.m
+++ b/ADAL/tests/unit/ADHelpersTests.m
@@ -25,7 +25,7 @@
 #import "ADHelpers.h"
 #import "XCTestCase+TestHelperMethods.h"
 
-@interface ADHelpersTests : XCTestCase
+@interface ADHelpersTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADTelemetryTests.m
+++ b/ADAL/tests/unit/ADTelemetryTests.m
@@ -38,7 +38,7 @@
 #import "ADTelemetryTestDispatcher.h"
 #import "ADTelemetryEventStrings.h"
 
-@interface ADTelemetryTests : XCTestCase
+@interface ADTelemetryTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADTestNSStringHelperMethods.m
+++ b/ADAL/tests/unit/ADTestNSStringHelperMethods.m
@@ -24,7 +24,7 @@
 #import <XCTest/XCTest.h>
 #import "XCTestCase+TestHelperMethods.h"
 
-@interface ADTestNSStringHelperMethods : XCTestCase
+@interface ADTestNSStringHelperMethods : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADTokenCacheItemTests.m
+++ b/ADAL/tests/unit/ADTokenCacheItemTests.m
@@ -27,7 +27,7 @@
 #import "ADTokenCacheItem+Internal.h"
 #import "ADUserInformation.h"
 
-@interface ADTokenCacheItemTests : XCTestCase
+@interface ADTokenCacheItemTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADTokenCacheKeyTests.m
+++ b/ADAL/tests/unit/ADTokenCacheKeyTests.m
@@ -25,7 +25,7 @@
 #import "ADTokenCacheKey.h"
 #import "XCTestCase+TestHelperMethods.h"
 
-@interface ADTokenCacheKeyTests : XCTestCase
+@interface ADTokenCacheKeyTests : ADTestCase
 {
     NSString* mAuthority;
     NSString* mResource;

--- a/ADAL/tests/unit/ADTokenCacheTests.m
+++ b/ADAL/tests/unit/ADTokenCacheTests.m
@@ -253,7 +253,7 @@ static ADTokenCacheItem* CartmanItem(NSString* resource)
 @end
 
 
-@interface ADTokenCacheTests : XCTestCase
+@interface ADTokenCacheTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADUserInformationTests.m
+++ b/ADAL/tests/unit/ADUserInformationTests.m
@@ -25,7 +25,7 @@
 #import "XCTestCase+TestHelperMethods.h"
 #import "ADUserInformation.h"
 
-@interface ADUserInformationTests : XCTestCase
+@interface ADUserInformationTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ADWebAuthControllerTests.m
+++ b/ADAL/tests/unit/ADWebAuthControllerTests.m
@@ -25,7 +25,7 @@
 #import "ADTokenCache+Internal.h"
 #import "ADWebAuthController+Internal.h"
 
-@interface ADWebAuthControllerTests : XCTestCase
+@interface ADWebAuthControllerTests : ADTestCase
 {
 @private
     dispatch_semaphore_t _dsem;

--- a/ADAL/tests/unit/ADWebAuthResponseTests.m
+++ b/ADAL/tests/unit/ADWebAuthResponseTests.m
@@ -25,7 +25,7 @@
 #import <XCTest/XCTest.h>
 #import "ADWebAuthResponse.h"
 
-@interface ADWebAuthResponseTests : XCTestCase
+@interface ADWebAuthResponseTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/NSURLExtensionsTests.m
+++ b/ADAL/tests/unit/NSURLExtensionsTests.m
@@ -24,7 +24,7 @@
 #import "NSURL+ADExtensions.h"
 #import "XCTestCase+TestHelperMethods.h"
 
-@interface NSURLExtensionsTests : XCTestCase
+@interface NSURLExtensionsTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ios/ADBrokerKeyHelperTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerKeyHelperTests.m
@@ -36,7 +36,7 @@ enum {
     CSSM_ALGID_AES
 };
 
-@interface ADBrokerKeyHelperTests : XCTestCase
+@interface ADBrokerKeyHelperTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ios/ADBrokerMessageTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerMessageTests.m
@@ -36,7 +36,7 @@
 
 static NSString* s_kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
 
-@interface ADBrokerMessageTests : XCTestCase
+@interface ADBrokerMessageTests : ADTestCase
 
 @end
 

--- a/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
@@ -50,7 +50,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
 
 @end
 
-@interface ADKeychainTokenCacheTests : XCTestCase
+@interface ADKeychainTokenCacheTests : ADTestCase
 {
     ADKeychainTokenCache* mStore;
 }


### PR DESCRIPTION
- Copied over auto-break-in-debugger from MSAL networtk mock
- Copied over dictionary validation and diffing code from MSAL, this makes it easier to see what is missing from the expected request when the debugger breaks
- Fixed a lot of test request headers to comply with the stricter matching
- Added a “Ignore” sentinel for dictionary values that we don’t care if they exist or not (hack to get around ADClientMetrics)