### PR TITLE
Remove AUTH_NON_PROTOCOL_ERROR

### DIFF
--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -112,8 +112,8 @@ NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is conf
                                 nil;
         return [ADAuthenticationError OAuthServerError:serverOAuth2Error description:errorDetails code:errorCode correlationId:correlationId];
     }
-    //In the case of more generic error, e.g. server unavailable, DNS error or no internet connection, the error object will be directly placed in the dictionary:
-    return [dictionary objectForKey:AUTH_NON_PROTOCOL_ERROR];
+    
+    return nil;
 }
 
 //Returns YES if we shouldn't attempt other means to get access token.

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -78,7 +78,6 @@ NSString *const ADAL_ID_DEVICE_MODEL      = @"x-client-DM";//E.g. iPhone
 //Internal constants:
 NSString *const AUTH_FAILED               = @"Authentication Failed";
 NSString *const AUTH_FAILED_ERROR_CODE    = @"Authentication Failed: %d";
-NSString *const AUTH_NON_PROTOCOL_ERROR   = @"non_protocol_error";
 
 NSString *const AUTH_FAILED_SERVER_ERROR   = @"The Authorization Server returned an unrecognized response";
 NSString *const AUTH_FAILED_NO_STATE       = @"The Authorization Server response has no encoded state";

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -126,8 +126,15 @@
                                   context:_requestParams];
     [webReq setRequestDictionary:request_data];
     AD_LOG_INFO_F(@"Attempting to acquire an access token from refresh token", nil, @"clientId: '%@'; resource: '%@';", [_requestParams clientId], [_requestParams resource]);
-    [webReq sendRequest:^(NSDictionary *response)
+    [webReq sendRequest:^(ADAuthenticationError *error, NSDictionary *response)
      {
+         if (error)
+         {
+             completionBlock([ADAuthenticationResult resultFromError:error]);
+             [webReq invalidate];
+             return;
+         }
+         
          ADTokenCacheItem* resultItem = (cacheItem) ? cacheItem : [ADTokenCacheItem new];
          
          //Always ensure that the cache item has all of these set, especially in the broad token case, where the passed item

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -49,8 +49,15 @@
     ADWebAuthRequest* req = [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:urlString]
                                                           context:_requestParams];
     [req setRequestDictionary:request_data];
-    [req sendRequest:^(NSDictionary *response)
+    [req sendRequest:^(ADAuthenticationError *error, NSDictionary *response)
      {
+         if (error)
+         {
+             completionBlock([ADAuthenticationResult resultFromError:error]);
+             [req invalidate];
+             return;
+         }
+         
          //Prefill the known elements in the item. These can be overridden by the response:
          ADTokenCacheItem* item = [ADTokenCacheItem new];
          item.resource = [_requestParams resource];
@@ -263,11 +270,16 @@
                                                               context:_requestParams];
         [req setIsGetRequest:YES];
         [req setRequestDictionary:requestData];
-        [req sendRequest:^(NSDictionary * parameters)
+        [req sendRequest:^(ADAuthenticationError *error, NSDictionary * parameters)
          {
+             if (error)
+             {
+                 requestCompletion(error, nil);
+                 [req invalidate];
+                 return;
+             }
              
              NSURL* endURL = nil;
-             ADAuthenticationError* error = nil;
              
              //OAuth2 error may be passed by the server
              endURL = [parameters objectForKey:@"url"];

--- a/ADAL/src/request/ADAuthorityValidationRequest.m
+++ b/ADAL/src/request/ADAuthorityValidationRequest.m
@@ -43,9 +43,8 @@ static NSString* const s_kAuthorizationEndPointKey = @"authorization_endpoint";
                                                                  context:context];
     
     [webRequest setIsGetRequest:YES];
-    [webRequest sendRequest:^(NSMutableDictionary *response)
+    [webRequest sendRequest:^(ADAuthenticationError *error, NSMutableDictionary *response)
     {
-        ADAuthenticationError *error = [response objectForKey:AUTH_NON_PROTOCOL_ERROR];
         if (error)
         {
             completionBlock(nil, error);

--- a/ADAL/src/request/ADWebAuthResponse.h
+++ b/ADAL/src/request/ADWebAuthResponse.h
@@ -22,11 +22,10 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "ADWebRequest.h"
 
 @class ADWebResponse;
 @class ADWebAuthRequest;
-
-typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
 
 @interface ADWebAuthResponse : NSObject
 {

--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -226,7 +226,7 @@
             NSString *rawResponse = [[NSString alloc] initWithData:webResponse.body encoding:NSUTF8StringEncoding];
             [_responseDictionary setObject:rawResponse forKey:@"raw_response"];
             
-            completionBlock(_responseDictionary);
+            completionBlock(nil, _responseDictionary);
             return;
         }
         else
@@ -342,7 +342,7 @@
                                             correlationId:_request.correlationId
                                              errorDetails:nil];
     
-    completionBlock(_responseDictionary);
+    completionBlock(nil, _responseDictionary);
 }
 
 #pragma mark -
@@ -408,15 +408,12 @@
 - (void)handleADError:(ADAuthenticationError*)adError
       completionBlock:(ADWebResponseCallback)completionBlock
 {
-    [_responseDictionary setObject:adError
-                            forKey:AUTH_NON_PROTOCOL_ERROR];
-    
     [[ADClientMetrics getInstance] endClientMetricsRecord:[[_request URL] absoluteString]
                                                 startTime:[_request startTime]
                                             correlationId:_request.correlationId
                                              errorDetails:[adError errorDetails]];
     
-    completionBlock(_responseDictionary);
+    completionBlock(adError, _responseDictionary);
 }
 
 @end

--- a/ADAL/src/request/ADWebRequest.h
+++ b/ADAL/src/request/ADWebRequest.h
@@ -26,7 +26,7 @@
 @class ADWebRequest;
 @class ADWebResponse;
 
-typedef void (^ADWebResponseCallback)(NSMutableDictionary *);
+typedef void (^ADWebResponseCallback)(ADAuthenticationError *, NSMutableDictionary *);
 
 @interface ADWebRequest : NSObject <NSURLSessionTaskDelegate, NSURLSessionDataDelegate, ADRequestContext>
 {

--- a/ADAL/src/validation/ADDrsDiscoveryRequest.m
+++ b/ADAL/src/validation/ADDrsDiscoveryRequest.m
@@ -39,10 +39,8 @@
     [webRequest setIsGetRequest:YES];
     [webRequest setAcceptOnlyOKResponse:YES];
     
-    [webRequest sendRequest:^(NSMutableDictionary *response)
+    [webRequest sendRequest:^(ADAuthenticationError *error, NSMutableDictionary *response)
     {
-        ADAuthenticationError *error = [response objectForKey:AUTH_NON_PROTOCOL_ERROR];
-
         if (error)
         {
             completionBlock(nil, error);

--- a/ADAL/src/validation/ADWebFingerRequest.m
+++ b/ADAL/src/validation/ADWebFingerRequest.m
@@ -39,10 +39,8 @@
     [webRequest setIsGetRequest:YES];
     [webRequest setAcceptOnlyOKResponse:YES];
     
-    [webRequest sendRequest:^(NSMutableDictionary *response)
+    [webRequest sendRequest:^(ADAuthenticationError *error, NSMutableDictionary *response)
     {
-        ADAuthenticationError *error = [response objectForKey:AUTH_NON_PROTOCOL_ERROR];
-        
         if (error)
         {
             completionBlock(nil, error);


### PR DESCRIPTION
This behavior of slipping the error in the dictionary instead of returning it directly violates ObjC best practices, and results in some truly byzantine code paths where the code should be exiting early instead. In most cases this change results in no differences in code execution, just simplifies the code. In a couple cases it means that we exit a little earlier, but has no effect on the overall flow.