### PR TITLE
Switched from cloud_instance_name to cloud_instance_host_name

### DIFF
--- a/ADAL/src/ADOAuth2Constants.h
+++ b/ADAL/src/ADOAuth2Constants.h
@@ -91,7 +91,7 @@ extern NSString *const AUTH_FAILED_BUSY;
 extern NSString *const AAD_SECURECONVERSATION_LABEL;
 
 extern NSString *const AUTH_USERNAME_KEY;
-extern NSString *const AUTH_CLOUD_INSTANCE_NAME;
+extern NSString *const AUTH_CLOUD_INSTANCE_HOST_NAME;
 
 extern NSString* const ADAL_BROKER_SCHEME;
 extern NSString* const ADAL_BROKER_APP_REDIRECT_URI;

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -91,8 +91,8 @@ NSString *const AUTH_FAILED_BUSY           = @"Authorization call is already in 
 
 NSString *const AAD_SECURECONVERSATION_LABEL = @"AzureAD-SecureConversation";
 
-NSString *const AUTH_USERNAME_KEY           = @"username";
-NSString *const AUTH_CLOUD_INSTANCE_NAME    = @"cloud_instance_name";
+NSString *const AUTH_USERNAME_KEY                = @"username";
+NSString *const AUTH_CLOUD_INSTANCE_HOST_NAME    = @"cloud_instance_host_name";
 
 //application constants
 NSString* const ADAL_BROKER_SCHEME = @"msauth";

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -187,7 +187,7 @@
                  {
                      NSDictionary* queryParams = [end adQueryParameters];
                      code = [queryParams objectForKey:OAUTH2_CODE];
-                     [self setCloudAuthority:[queryParams objectForKey:AUTH_CLOUD_INSTANCE_NAME]];
+                     [self setCloudInstanceHostname:[queryParams objectForKey:AUTH_CLOUD_INSTANCE_HOST_NAME]];
                  }
                  else
                  {
@@ -233,7 +233,7 @@
                                                                        correlationId:[_requestParams correlationId]];
                      }
                      
-                     [self setCloudAuthority:[parameters objectForKey:AUTH_CLOUD_INSTANCE_NAME]];
+                     [self setCloudInstanceHostname:[parameters objectForKey:AUTH_CLOUD_INSTANCE_HOST_NAME]];
                      
                  }
              }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -117,7 +117,7 @@
 - (void)setAssertionType:(ADAssertionType)assertionType;
 
 // This can be set anyTime
-- (void)setCloudAuthority:(NSString *)cloudInstanceName;
+- (void)setCloudInstanceHostname:(NSString *)cloudInstanceHostName;
 
 /*!
     Takes the UI interaction lock for the current request, will send an error

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -199,11 +199,11 @@ static dispatch_semaphore_t s_interactionLock = nil;
     [_requestParams setCorrelationId:correlationId];
 }
 
-- (void)setCloudAuthority:(NSString *)cloudInstanceName
+- (void)setCloudInstanceHostname:(NSString *)cloudInstanceHostName
 {
-    if (cloudInstanceName)
+    if (cloudInstanceHostName)
     {
-        _cloudAuthority = [_context.authority adAuthorityWithCloudInstanceName:cloudInstanceName];
+        _cloudAuthority = [_context.authority adAuthorityWithCloudInstanceHostname:cloudInstanceHostName];
     }
     else
     {

--- a/ADAL/src/utils/NSString+ADURLExtensions.h
+++ b/ADAL/src/utils/NSString+ADURLExtensions.h
@@ -25,6 +25,6 @@
 
 @interface NSString (ADURLExtensions)
 
-- (NSString *)adAuthorityWithCloudInstanceName:(NSString *)cloudInstanceName;
+- (NSString *)adAuthorityWithCloudInstanceHostname:(NSString *)cloudInstanceHostName;
 
 @end

--- a/ADAL/src/utils/NSString+ADURLExtensions.m
+++ b/ADAL/src/utils/NSString+ADURLExtensions.m
@@ -25,19 +25,24 @@
 
 @implementation NSString (ADURLExtensions)
 
-- (NSString *)adAuthorityWithCloudInstanceName:(NSString *)cloudInstanceName
+- (NSString *)adAuthorityWithCloudInstanceHostname:(NSString *)cloudInstanceHostName
 {
-    if (!cloudInstanceName)
+    if ([NSString adIsStringNilOrBlank:cloudInstanceHostName])
     {
         return self;
     }
     
     NSURLComponents *urlComponents = [NSURLComponents componentsWithString:self];
     
-    // TODO: remove the hardcoded login prefix, once server starts sending a new parameter that includes full host name
-    NSString *loginHost = [NSString stringWithFormat:@"login.%@", cloudInstanceName];
+    // Invalid URL
+    if ([NSString adIsStringNilOrBlank:urlComponents.host])
+    {
+        return self;
+    }
     
-    return [self stringByReplacingOccurrencesOfString:[urlComponents host] withString:loginHost];
+    urlComponents.host = cloudInstanceHostName;
+    
+    return [urlComponents string];
     
 }
 

--- a/ADAL/tests/unit/ADURLExtensionsTest.m
+++ b/ADAL/tests/unit/ADURLExtensionsTest.m
@@ -33,36 +33,50 @@
 - (void)testAdAuthorityWithCloudInstanceName_whenNil_shouldReturnSame
 {
     NSString *authority = @"https://login.microsoftonline.com/common";
-    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceName:nil];
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:nil];
+    XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.com/common");
+}
+
+- (void)testAdAuthorityWithCloudInstanceName_whenEmpty_shouldReturnSame
+{
+    NSString *authority = @"https://login.microsoftonline.com/common";
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"  "];
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.com/common");
 }
 
 - (void)testAdAuthorityWithCloudInstanceName_whenCommon_shouldSwap
 {
     NSString *authority = @"https://login.microsoftonline.com/common";
-    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceName:@"microsoftonline.de"];
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"login.microsoftonline.de"];
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.de/common");
 }
 
 - (void)testAdAuthorityWithCloudInstanceName_whenWithTenant_shouldSwap
 {
     NSString *authority = @"https://login.microsoftonline.com/b960c013-d381-403c-8d4d-939edac0d9ea";
-    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceName:@"microsoftonline.de"];
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"login.microsoftonline.de"];
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.de/b960c013-d381-403c-8d4d-939edac0d9ea");
 }
 
 - (void)testAdAuthorityWithCloudInstanceName_whenLoginWindowsNet_shouldSwap
 {
     NSString *authority = @"https://login.windows.net/common";
-    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceName:@"microsoftonline.de"];
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"login.microsoftonline.de"];
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.de/common");
 }
 
 - (void)testAdAuthorityWithCloudInstanceName_whenLoginSts_shouldSwap
 {
     NSString *authority = @"https://sts.microsoft.com/common";
-    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceName:@"microsoftonline.de"];
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"login.microsoftonline.de"];
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.de/common");
+}
+
+- (void)testAdAuthorityWithCloudInstanceName_whenNoHost_shouldReturnSame
+{
+    NSString *authority = @"https://";
+    NSString *authorityWithCloudName = [authority adAuthorityWithCloudInstanceHostname:@"login.microsoftonline.de"];
+    XCTAssertEqualObjects(authorityWithCloudName, @"https://");
 }
 
 @end


### PR DESCRIPTION
NB: Preparing the pull request for the review, but it **shouldn't be merged until** cloud_instance_host_name is available in sovereign clouds.