### PR TITLE
Cloud graph resource url

### DIFF
--- a/ADAL/src/ADAuthenticationResult+Internal.h
+++ b/ADAL/src/ADAuthenticationResult+Internal.h
@@ -52,5 +52,6 @@
 /*! Internal method to set the extendedLifetimeToken flag. */
 - (void)setExtendedLifeTimeToken:(BOOL)extendedLifeTimeToken;
 - (void)setCloudAuthority:(NSString *)cloudAuthority;
+- (void)setGraphResourceUrl:(NSString *)graphResourceUrl;
 
 @end

--- a/ADAL/src/ADAuthenticationResult+Internal.m
+++ b/ADAL/src/ADAuthenticationResult+Internal.m
@@ -234,4 +234,9 @@ multiResourceRefreshToken: (BOOL) multiResourceRefreshToken
     _authority = cloudAuthority;
 }
 
+- (void)setGraphResourceUrl:(NSString *)graphResourceUrl
+{
+    _graphResourceUrl = graphResourceUrl;
+}
+
 @end

--- a/ADAL/src/ADAuthenticationResult.m
+++ b/ADAL/src/ADAuthenticationResult.m
@@ -36,6 +36,7 @@
 @synthesize correlationId = _correlationId;
 @synthesize extendedLifeTimeToken = _extendedLifeTimeToken;
 @synthesize authority = _authority;
+@synthesize graphResourceUrl = _graphResourceUrl;
 
 - (id)init
 {

--- a/ADAL/src/ADOAuth2Constants.h
+++ b/ADAL/src/ADOAuth2Constants.h
@@ -92,6 +92,7 @@ extern NSString *const AAD_SECURECONVERSATION_LABEL;
 
 extern NSString *const AUTH_USERNAME_KEY;
 extern NSString *const AUTH_CLOUD_INSTANCE_NAME;
+extern NSString *const AUTH_CLOUD_GRAPH_HOST_KEY;
 
 extern NSString* const ADAL_BROKER_SCHEME;
 extern NSString* const ADAL_BROKER_APP_REDIRECT_URI;

--- a/ADAL/src/ADOAuth2Constants.m
+++ b/ADAL/src/ADOAuth2Constants.m
@@ -93,6 +93,7 @@ NSString *const AAD_SECURECONVERSATION_LABEL = @"AzureAD-SecureConversation";
 
 NSString *const AUTH_USERNAME_KEY           = @"username";
 NSString *const AUTH_CLOUD_INSTANCE_NAME    = @"cloud_instance_name";
+NSString *const AUTH_CLOUD_GRAPH_HOST_KEY   = @"cloud_graph_host_name";
 
 //application constants
 NSString* const ADAL_BROKER_SCHEME = @"msauth";

--- a/ADAL/src/public/ADAuthenticationResult.h
+++ b/ADAL/src/public/ADAuthenticationResult.h
@@ -53,6 +53,7 @@ typedef enum
     BOOL                            _multiResourceRefreshToken;
     BOOL                            _extendedLifeTimeToken;
     NSString*                       _authority;
+    NSString*                       _graphResourceUrl;
 }
 
 /*! See the ADAuthenticationResultStatus details */
@@ -85,6 +86,13 @@ typedef enum
  It will be different from the authority provided by developer for sovereign cloud scenarios.
  */
 @property (readonly) NSString* authority;
+
+/*!
+  Represents graph resource URL for the user.
+  If implementing app uses graph in sovereign cloud scenarios, it should use this URL instead of hardcoding it.
+  Available only in interactive and instance_aware login.
+*/
+@property (readonly) NSString* graphResourceUrl;
 
 @end
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -420,6 +420,7 @@
                  {
                      ADAuthenticationResult *result = [ADAuthenticationResult resultFromError:error correlationId:_requestParams.correlationId];
                      [result setCloudAuthority:_cloudAuthority];
+                     [result setGraphResourceUrl:_graphResourceUrl];
                      completionBlock(result);
                      return;
                  }
@@ -452,6 +453,7 @@
                                                                    context:_requestParams];
                           result = [ADAuthenticationContext updateResult:result toUser:[_requestParams identifier]];
                           [result setCloudAuthority:_cloudAuthority];
+                          [result setGraphResourceUrl:_graphResourceUrl];
                       }
                       completionBlock(result);
                   }];

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -188,6 +188,7 @@
                      NSDictionary* queryParams = [end adQueryParameters];
                      code = [queryParams objectForKey:OAUTH2_CODE];
                      [self setCloudAuthority:[queryParams objectForKey:AUTH_CLOUD_INSTANCE_NAME]];
+                     [self setGraphResourceHost:[queryParams objectForKey:AUTH_CLOUD_GRAPH_HOST_KEY]];
                  }
                  else
                  {
@@ -234,6 +235,7 @@
                      }
                      
                      [self setCloudAuthority:[parameters objectForKey:AUTH_CLOUD_INSTANCE_NAME]];
+                     [self setGraphResourceHost:[parameters objectForKey:AUTH_CLOUD_GRAPH_HOST_KEY]];
                      
                  }
              }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -76,6 +76,7 @@
     ADAuthenticationError* _underlyingError;
     
     NSString *_cloudAuthority;
+    NSString *_graphResourceUrl;
 }
 
 @property (retain) NSString* logComponent;
@@ -118,6 +119,7 @@
 
 // This can be set anyTime
 - (void)setCloudAuthority:(NSString *)cloudInstanceName;
+- (void)setGraphResourceHost:(NSString *)graphResourceHost;
 
 /*!
     Takes the UI interaction lock for the current request, will send an error

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -211,6 +211,11 @@ static dispatch_semaphore_t s_interactionLock = nil;
     }
 }
 
+- (void)setGraphResourceHost:(NSString *)graphResourceHost
+{
+    _graphResourceUrl = [NSString adGraphResourceUrlWithHost:graphResourceHost];
+}
+
 #if AD_BROKER
 
 - (NSString*)redirectUri

--- a/ADAL/src/utils/NSString+ADURLExtensions.h
+++ b/ADAL/src/utils/NSString+ADURLExtensions.h
@@ -26,5 +26,6 @@
 @interface NSString (ADURLExtensions)
 
 - (NSString *)adAuthorityWithCloudInstanceName:(NSString *)cloudInstanceName;
++ (NSString *)adGraphResourceUrlWithHost:(NSString *)graphResourceHost;
 
 @end

--- a/ADAL/src/utils/NSString+ADURLExtensions.m
+++ b/ADAL/src/utils/NSString+ADURLExtensions.m
@@ -41,4 +41,20 @@
     
 }
 
++ (NSString *)adGraphResourceUrlWithHost:(NSString *)graphResourceHost
+{
+    if (![NSString adIsStringNilOrBlank:graphResourceHost])
+    {
+        NSURLComponents *components = [[NSURLComponents alloc] init];
+        components.host = graphResourceHost;
+        components.scheme = @"https";
+        
+        return [components string];
+    }
+    else
+    {
+        return nil;
+    }
+}
+
 @end

--- a/ADAL/tests/unit/ADURLExtensionsTest.m
+++ b/ADAL/tests/unit/ADURLExtensionsTest.m
@@ -65,4 +65,23 @@
     XCTAssertEqualObjects(authorityWithCloudName, @"https://login.microsoftonline.de/common");
 }
 
+- (void)testAdGraphResourceUrlWithHost_whenNil_shouldReturnNil
+{
+    NSString *resourceUrl = [NSString adGraphResourceUrlWithHost:nil];
+    XCTAssertNil(resourceUrl);
+}
+
+- (void)testAdGraphResourceUrlWithHost_whenEmpty_shouldReturnNil
+{
+    NSString *resourceUrl = [NSString adGraphResourceUrlWithHost:@"   "];
+    XCTAssertNil(resourceUrl);
+}
+
+- (void)testAdGraphResourceUrlWithHost_whenHasHost_shouldReturnUrl
+{
+    NSString *host = @"graph.windows.net";
+    NSString *resourceUrl = [NSString adGraphResourceUrlWithHost:host];
+    XCTAssertEqualObjects(resourceUrl, @"https://graph.windows.net");
+}
+
 @end


### PR DESCRIPTION
Now also taking graph host from the response and passing it in ADAuthenticationResult for sovereign aware scenarios (partner ask). Probably and hopefully we won't need this, if a better solution to unblock partners can be found.