### PR TITLE
Split tests. Part 1.

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -28,6 +28,9 @@
 		04AB6D4F1D9D619B007E9A83 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04AB6D4D1D9D619B007E9A83 /* Main.storyboard */; };
 		04AB6D511D9D619B007E9A83 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 04AB6D501D9D619B007E9A83 /* Assets.xcassets */; };
 		04AB6D541D9D619B007E9A83 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 04AB6D521D9D619B007E9A83 /* LaunchScreen.storyboard */; };
+		234F3CE71F35161C00DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CE51F35159500DE4AA4 /* ADAuthenticationContextTests.m */; };
+		234F3CED1F35182500DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */; };
+		234F3CEE1F35182600DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */; };
 		290750AC1E380F32000F0C29 /* ADTelemetryCollectionRules.h in Headers */ = {isa = PBXBuildFile; fileRef = 290750AA1E380F32000F0C29 /* ADTelemetryCollectionRules.h */; };
 		2949ABC01E395FC400F56C57 /* ADTelemetryCollectionRules.m in Sources */ = {isa = PBXBuildFile; fileRef = 290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */; };
 		2949ABC11E39605F00F56C57 /* ADTelemetryCollectionRules.m in Sources */ = {isa = PBXBuildFile; fileRef = 290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */; };
@@ -208,8 +211,6 @@
 		B20DC5C71F0D96A700957806 /* ADTestURLSession.m in Sources */ = {isa = PBXBuildFile; fileRef = 96C75D271E303DC40038D1EC /* ADTestURLSession.m */; };
 		B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */; };
 		B20DC5CB1F0D96A700957806 /* ADAL.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9453C3FD1C586425006B9E79 /* ADAL.framework */; };
-		B20DC5EF1F0D998A00957806 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5E11F0D998A00957806 /* ADAuthenticationContextTests.m */; };
-		B20DC5F01F0D998A00957806 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5E11F0D998A00957806 /* ADAuthenticationContextTests.m */; };
 		B20DC5F11F0D998A00957806 /* ADAuthenticationErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5E21F0D998A00957806 /* ADAuthenticationErrorTests.m */; };
 		B20DC5F21F0D998A00957806 /* ADAuthenticationErrorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5E21F0D998A00957806 /* ADAuthenticationErrorTests.m */; };
 		B20DC5F31F0D998A00957806 /* ADAuthenticationParametersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5E31F0D998A00957806 /* ADAuthenticationParametersTests.m */; };
@@ -480,6 +481,9 @@
 		04AB6D531D9D619B007E9A83 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		04AB6D551D9D619B007E9A83 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		04AB6D5A1D9D61CA007E9A83 /* UnitTestHostApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = UnitTestHostApp.entitlements; sourceTree = "<group>"; };
+		234F3CE51F35159500DE4AA4 /* ADAuthenticationContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationContextTests.m; sourceTree = "<group>"; };
+		234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationContextTests.m; sourceTree = "<group>"; };
+		234F3CEF1F3519A300DE4AA4 /* ADAuthenticationContextTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationContextTests.h; sourceTree = "<group>"; };
 		290750AA1E380F32000F0C29 /* ADTelemetryCollectionRules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTelemetryCollectionRules.h; sourceTree = "<group>"; };
 		290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTelemetryCollectionRules.m; sourceTree = "<group>"; };
 		29DBF6D31E36CD1E00D5B690 /* NSMutableDictionary+ADExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSMutableDictionary+ADExtensions.h"; sourceTree = "<group>"; };
@@ -669,7 +673,6 @@
 		B20DC5D91F0D97CD00957806 /* ADAL_Mac_UTs-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ADAL_Mac_UTs-Info.plist"; sourceTree = "<group>"; };
 		B20DC5DC1F0D97DD00957806 /* ADAL_iOS_ITs-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ADAL_iOS_ITs-Info.plist"; sourceTree = "<group>"; };
 		B20DC5DF1F0D97E400957806 /* ADAL_Mac_ITs-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "ADAL_Mac_ITs-Info.plist"; sourceTree = "<group>"; };
-		B20DC5E11F0D998A00957806 /* ADAuthenticationContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationContextTests.m; sourceTree = "<group>"; };
 		B20DC5E21F0D998A00957806 /* ADAuthenticationErrorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationErrorTests.m; sourceTree = "<group>"; };
 		B20DC5E31F0D998A00957806 /* ADAuthenticationParametersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationParametersTests.m; sourceTree = "<group>"; };
 		B20DC5E41F0D998A00957806 /* ADAuthenticationResultTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationResultTests.m; sourceTree = "<group>"; };
@@ -1319,7 +1322,8 @@
 		B20DC5D31F0D975A00957806 /* unit */ = {
 			isa = PBXGroup;
 			children = (
-				B20DC5E11F0D998A00957806 /* ADAuthenticationContextTests.m */,
+				234F3CEF1F3519A300DE4AA4 /* ADAuthenticationContextTests.h */,
+				234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */,
 				B20DC5E21F0D998A00957806 /* ADAuthenticationErrorTests.m */,
 				B20DC5E31F0D998A00957806 /* ADAuthenticationParametersTests.m */,
 				B20DC5E41F0D998A00957806 /* ADAuthenticationResultTests.m */,
@@ -1356,6 +1360,7 @@
 		B20DC5D51F0D97C600957806 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				234F3CE51F35159500DE4AA4 /* ADAuthenticationContextTests.m */,
 				B20DC5D61F0D97C600957806 /* ADAL_iOS_UTs-Info.plist */,
 				B20DC61A1F0DA34B00957806 /* ADBrokerMessageTests.m */,
 				B20DC61C1F0DA39C00957806 /* ADBrokerKeyHelperTests.m */,
@@ -1927,6 +1932,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B20DC5F31F0D998A00957806 /* ADAuthenticationParametersTests.m in Sources */,
+				234F3CED1F35182500DE4AA4 /* ADAuthenticationContextTests.m in Sources */,
 				603841A01DF9248F00D30F3D /* ADTelemetryTestDispatcher.m in Sources */,
 				B20DC5FF1F0D998A00957806 /* ADTokenCacheItemTests.m in Sources */,
 				B20DC5FB1F0D998A00957806 /* ADLoggerTests.m in Sources */,
@@ -1939,6 +1945,7 @@
 				8B92DB5F1819E6A4004AAB0E /* XCTestCase+TestHelperMethods.m in Sources */,
 				96C75D281E303DC40038D1EC /* ADTestURLSession.m in Sources */,
 				D6D4D4981F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
+				234F3CE71F35161C00DE4AA4 /* ADAuthenticationContextTests.m in Sources */,
 				601BEE311C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */,
 				B20DC6151F0D9A7600957806 /* ADAuthorityValidationTests.m in Sources */,
 				B20DC5F91F0D998A00957806 /* ADHelpersTests.m in Sources */,
@@ -1946,7 +1953,6 @@
 				B20DC6181F0DA2E800957806 /* ADTestNSStringHelperMethods.m in Sources */,
 				B20DC5F51F0D998A00957806 /* ADAuthenticationResultTests.m in Sources */,
 				B20DC61D1F0DA39C00957806 /* ADBrokerKeyHelperTests.m in Sources */,
-				B20DC5EF1F0D998A00957806 /* ADAuthenticationContextTests.m in Sources */,
 				B20DC61F1F0DA3C500957806 /* ADKeychainTokenCacheTests.m in Sources */,
 				B20DC6091F0D998A00957806 /* NSURLExtensionsTests.m in Sources */,
 				B20DC61B1F0DA34B00957806 /* ADBrokerMessageTests.m in Sources */,
@@ -2052,7 +2058,6 @@
 				B20DC6221F0DA4BF00957806 /* ADWebAuthControllerTests.m in Sources */,
 				B20DC5FC1F0D998A00957806 /* ADLoggerTests.m in Sources */,
 				B20DC6001F0D998A00957806 /* ADTokenCacheItemTests.m in Sources */,
-				B20DC5F01F0D998A00957806 /* ADAuthenticationContextTests.m in Sources */,
 				603841A11DF9248F00D30F3D /* ADTelemetryTestDispatcher.m in Sources */,
 				B20DC6081F0D998A00957806 /* ADWebAuthResponseTests.m in Sources */,
 				B20DC6161F0D9A7600957806 /* ADAuthorityValidationTests.m in Sources */,
@@ -2067,6 +2072,7 @@
 				B20DC5F41F0D998A00957806 /* ADAuthenticationParametersTests.m in Sources */,
 				B20DC6191F0DA2E800957806 /* ADTestNSStringHelperMethods.m in Sources */,
 				601BEE321C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */,
+				234F3CEE1F35182600DE4AA4 /* ADAuthenticationContextTests.m in Sources */,
 				B20DC6041F0D998A00957806 /* ADTokenCacheTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -136,11 +136,6 @@ typedef enum
                                    responseHeaders:(NSDictionary *)responseHeaders
                                       responseJson:(NSDictionary *)responseJson;
 
-/*! Verifies that the correct error is returned when any method was passed invalid arguments.
- */
-- (void)adValidateForInvalidArgument:(NSString *)argument
-                               error:(ADAuthenticationError *)error;
-
 //Creates a new item with all of the properties having correct values
 - (ADTokenCacheItem *)adCreateCacheItem;
 - (ADTokenCacheItem *)adCreateCacheItem:(NSString*)userId;

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -39,14 +39,6 @@
 #define TEST_REFRESH_TOKEN @"refresh token"
 #define TEST_CORRELATION_ID ({NSUUID *testID = [[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"]; testID;})
 
-typedef enum
-{
-    TEST_LOG_LEVEL,
-    TEST_LOG_MESSAGE,
-    TEST_LOG_INFO,
-    TEST_LOG_CODE,
-} ADLogPart;
-
 @class ADTokenCacheItem;
 @class ADUserInformation;
 @class ADTokenCacheKey;
@@ -59,14 +51,6 @@ typedef enum
                     expected:(NSString *)expected
                         file:(const char *)file
                         line:(int)line;
-
-/*! Used with the class factory methods that create class objects. Verifies
- the expectations when the passed argument is invalid:
- - The creator should return nil.
- - The error should be set accordingly, containing the argument in the description.*/
-- (void)adValidateFactoryForInvalidArgument:(NSString *)argument
-                             returnedObject:(id)returnedObject
-                                      error:(ADAuthenticationError *)error;
 
 - (ADTestURLResponse *)adResponseBadRefreshToken:(NSString *)refreshToken
                                        authority:(NSString *)authority
@@ -153,45 +137,6 @@ typedef enum
 
 //Creates a sample user information object
 - (ADUserInformation *)adCreateUserInformation:(NSString*)userId;
-
-- (NSString *)adLogLevelLogs;
-- (NSString *)adMessagesLogs;
-- (NSString *)adInformationLogs;
-- (NSString *)adErrorCodesLogs;
-
-//Counts how many times the "contained" is sequentially occurring in "string".
-//Example: "bar bar" is contained once in "bar bar bar" and twice in "bar bar bar bar".
-- (int)adCountOccurencesOf:(NSString *)contained
-                  inString:(NSString *)string;
-
-//The methods help with verifying of the logs:
-- (int)adCountOfLogOccurrencesIn:(ADLogPart)logPart
-                        ofString:(NSString *)contained;
-
-//Checks if the test coverage is enabled and stores the test coverage, if yes.
-- (void)adFlushCodeCoverage;
-
-/* A special helper, which invokes the 'block' parameter in the UI thread and waits for its internal
- callback block to complete.
- IMPORTANT: The internal callback block should end with ASYNCH_COMPLETE macro to signal its completion. Example:
- static volatile int comletion  = 0;
- [self adCallAndWaitWithFile:@"" __FILE__ line:__LINE__ completionSignal: &completion block:^
- {
-    [mAuthenticationContext acquireTokenWithResource:mResource
-                                     completionBlock:^(ADAuthenticationResult* result)
-    {
-        //Inner block:
-        mResult = result;
-        ASYNC_BLOCK_COMPLETE(completion);//Signals the completion
-    }];
- }];
- The method executes the block in the UI thread, but runs an internal run loop and thus allows methods which enqueue their
- completion callbacks on the UI thread.
- */
-- (void)adCallAndWaitWithFile:(NSString*)file
-                         line:(int)line
-                    semaphore:(dispatch_semaphore_t)signal
-                        block:(void (^)(void)) block;
 
 @end
 

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -65,50 +65,12 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     XCTAssertTrue(found, "The parameter is not specified in the error details. Error details:%@", error.errorDetails);
 }
 
-
-/* See header for details.*/
-- (void)adValidateFactoryForInvalidArgument:(NSString *)argument
-                             returnedObject:(id)returnedObject
-                                      error:(ADAuthenticationError *)error
-{
-    XCTAssertNil(returnedObject, "Creator should have returned nil. Object: %@", returnedObject);
-    
-    [self adValidateForInvalidArgument:argument error:error];
-}
-
 //Parses backwards the log to find the test begin prefix. Returns the beginning
 //of the log string if not found:
 - (long)indexOfTestBegin:(NSString *)log
 {
     NSUInteger index = [log rangeOfString:sTestBegin options:NSBackwardsSearch].location;
     return (index == NSNotFound) ? 0 : index;
-}
-
-//Helper method to count how many times a string occurs in another string:
-- (int)adCountOccurencesOf:(NSString *)contained
-                  inString:(NSString *)string
-{
-    XCTAssertNotNil(contained);
-    XCTAssertNotNil(string);
-    
-    NSRange range = {.location = 0, .length = string.length};
-    int occurences = 0;
-    long end = string.length - contained.length;
-    while (range.location < end)
-    {
-        NSRange result = [string rangeOfString:contained options:NSLiteralSearch range:range];
-        if (result.location != NSNotFound)
-        {
-            ++occurences;
-            range.location = result.location + result.length;
-            range.length = string.length - range.location;
-        }
-        else
-        {
-            break;
-        }
-    }
-    return occurences;
 }
 
 //String clearing helper method:
@@ -275,24 +237,6 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     // If you're hitting this you might as well fix it before trying to run other tests.
     NSAssert(userInfo, @"Failed to create a userinfo object from a static idtoken. Something must have horribly broke,");
     return userInfo;
-}
-
-- (void)adCallAndWaitWithFile:(NSString *)file
-                         line:(int)line
-                    semaphore:(dispatch_semaphore_t)sem
-                        block:(void (^)(void))block
-{
-    THROW_ON_NIL_ARGUMENT(sem);
-    THROW_ON_NIL_EMPTY_ARGUMENT(file);
-    THROW_ON_NIL_ARGUMENT(block);
-    
-    (void)line;
-    
-    block();//Run the intended asynchronous method
-    while (dispatch_semaphore_wait(sem, DISPATCH_TIME_NOW))
-    {
-        [[NSRunLoop mainRunLoop] runMode:NSDefaultRunLoopMode beforeDate:[NSDate dateWithTimeIntervalSinceNow:0.1]];
-    }
 }
 
 - (ADTestURLResponse *)adResponseBadRefreshToken:(NSString *)refreshToken

--- a/ADAL/tests/unit/ADAuthenticationContextTests.h
+++ b/ADAL/tests/unit/ADAuthenticationContextTests.h
@@ -21,10 +21,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <XCTest/XCTest.h>
-
 #define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
 
-@interface ADAuthenticationContextTests : XCTestCase
+@interface ADAuthenticationContextTests : ADTestCase
 
 @end

--- a/ADAL/tests/unit/ADAuthenticationContextTests.h
+++ b/ADAL/tests/unit/ADAuthenticationContextTests.h
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+
+#define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
+
+@interface ADAuthenticationContextTests : XCTestCase
+
+@end

--- a/ADAL/tests/unit/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ADAuthenticationContextTests.m
@@ -42,7 +42,7 @@
     [super tearDown];
 }
 
-#pragma mark - Tests
+#pragma mark - Initialization
 
 - (void)testNew_shouldThrow
 {
@@ -53,6 +53,8 @@
 {
     XCTAssertThrows([[ADAuthenticationContext alloc] init], @"The new selector should not work due to requirement to use the parameterless init. At: '%s'", __PRETTY_FUNCTION__);
 }
+
+#pragma mark - authenticationContextWithAuthority
 
 - (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnError
 {

--- a/ADAL/tests/unit/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ADAuthenticationContextTests.m
@@ -56,133 +56,79 @@
 
 #pragma mark - authenticationContextWithAuthority
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:nil error:&error];
     
+    XCTAssertNil(context);
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidatedAuthorityNo_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil error:&error];
-    
-    XCTAssertNil(context);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidatedAuthorityNo_shouldReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidatedAuthorityNo_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO error:&error];
-    
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlank_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlank_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " error:&error];
-    
-    XCTAssertNil(context);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlank_shouldReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNo_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO error:&error];
-    
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNo_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNo_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
+    XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValid_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValid_shouldReturnContextAndNilError
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY error:&error];
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValid_shouldNotReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNo_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNo_shouldReturnContextAndNilError
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO error:&error];
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNo_shouldNotReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO error:&error];
-    
     XCTAssertNil(error);
 }
 

--- a/ADAL/tests/unit/ADAuthenticationErrorTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorTests.m
@@ -40,7 +40,7 @@
     [super tearDown];
 }
 
-#pragma mark - Tests
+#pragma mark - Initialization
 
 - (void)testNew_shouldThrow
 {
@@ -56,6 +56,8 @@
 {
     XCTAssertThrows([[ADAuthenticationError alloc] initWithDomain:@"domain" code:123 userInfo:nil], @"Parameterless init should throw. At: '%s'", __PRETTY_FUNCTION__);
 }
+
+#pragma mark - errorFromArgument
 
 - (void)testErrorFromArgument_whenArgumentIsValidArgumentNameNilCorrelationIdNil_shouldThrow
 {
@@ -99,6 +101,8 @@
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The argument 'parameter123456 %@' is invalid. Value:value1245 %s@");
 }
+
+#pragma mark - errorFromAuthenticationError
 
 - (void)testErrorFromAuthenticationError_whenErrorOAuthHprotocolCodeValiderrorDetailsValidCorrelationIdNil_shouldReturnError
 {

--- a/ADAL/tests/unit/ADAuthenticationErrorTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorTests.m
@@ -40,70 +40,84 @@
     [super tearDown];
 }
 
-- (void)testNew
+#pragma mark - Tests
+
+- (void)testNew_shouldThrow
 {
     XCTAssertThrows([ADAuthenticationError new], @"The new selector should not work due to requirement to use the parameterless init. At: '%s'", __PRETTY_FUNCTION__);
 }
 
-- (void)testParameterlessInit
+- (void)testParameterlessInit_shouldThrow
 {
-    XCTAssertThrows([ADAuthenticationError init], @"Parameterless init should throw. At: '%s'", __PRETTY_FUNCTION__);
+    XCTAssertThrows([[ADAuthenticationError alloc] init], @"Parameterless init should throw. At: '%s'", __PRETTY_FUNCTION__);
 }
 
-- (void)testParentInitWithDomain
+- (void)testParentInitWithDomain_shouldThrow
 {
     XCTAssertThrows([[ADAuthenticationError alloc] initWithDomain:@"domain" code:123 userInfo:nil], @"Parameterless init should throw. At: '%s'", __PRETTY_FUNCTION__);
 }
 
-- (void)testErrorFromArgumentNameNil
+- (void)testErrorFromArgument_whenArgumentIsValidArgumentNameNilCorrelationIdNil_shouldThrow
 {
     XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:@"val" argumentName:nil correlationId:nil],
                                  NSException, NSInvalidArgumentException, "Nil argument name should throw.");
+}
+
+- (void)testErrorFromArgument_whenArgumentIsEmptyStringArgumentNameNilCorrelationIdNil_shouldThrow
+{
     XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:@"" argumentName:nil correlationId:nil],
                                  NSException, NSInvalidArgumentException, "Nil argument name should throw.");
+}
+
+- (void)testErrorFromArgument_whenArgumentNilArgumentNameNilCorrelationIdNil_shouldThrow
+{
     XCTAssertThrowsSpecificNamed([ADAuthenticationError errorFromArgument:nil argumentName:nil correlationId:nil],
                                  NSException, NSInvalidArgumentException, "Nil argument name should throw.");
 }
 
-- (void)testErrorFromArgumentNil
+- (void)testErrorFromArgument_whenArgumentNilArgumentNameIsValidCorrelationIdNil_shouldReturnError
 {
-    NSString* parameter = @"parameter123456 %@";
-    //nil value:
-    ADAuthenticationError* error = [ADAuthenticationError errorFromArgument:nil argumentName:parameter correlationId:nil];
-    XCTAssertNotNil(error, "No error for nil prameter");
-    [self adValidateForInvalidArgument:parameter error:error];
-    XCTAssertTrue([error.errorDetails containsString:@"(null)"], "'null' should be part of the text");
-}
-
-- (void)testErrorFromArgumentNormal
-{
-    NSString* parameter = @"parameter123456 %@";
-    NSString* parameterValue = @"value1245 %s@";
-    ADAuthenticationError* error = [ADAuthenticationError errorFromArgument:parameterValue argumentName:parameter correlationId:nil];
-    XCTAssertNotNil(error, "No error for valid prameter");
+    NSString *parameter = @"parameter123456 %@";
     
-    [self adValidateForInvalidArgument:parameter error:error];
-    XCTAssertTrue([error.errorDetails containsString:parameterValue], "Value should be part of the text");
+    ADAuthenticationError *error = [ADAuthenticationError errorFromArgument:nil argumentName:parameter correlationId:nil];
+    
+    XCTAssertNotNil(error);
+    ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
+    XCTAssertNil(error.protocolCode);
+    ADAssertStringEquals(error.errorDetails, @"The argument 'parameter123456 %@' is invalid. Value:(null)");
 }
 
-- (void)testErrorFromOAuthError
+- (void)testErrorFromArgument_whenArgumentIsValidArgumentNameIsValidCorrelationIdNil_shouldReturnError
 {
-    NSString* details = @"Some details";
-    NSString* protocolCode = @"procol code";
-    ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_OAUTH protocolCode:protocolCode errorDetails:details correlationId:nil];
+    NSString *parameter = @"parameter123456 %@";
+    NSString *parameterValue = @"value1245 %s@";
+    
+    ADAuthenticationError *error = [ADAuthenticationError errorFromArgument:parameterValue argumentName:parameter correlationId:nil];
+    
+    XCTAssertNotNil(error);
+    ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
+    XCTAssertNil(error.protocolCode);
+    ADAssertStringEquals(error.errorDetails, @"The argument 'parameter123456 %@' is invalid. Value:value1245 %s@");
+}
+
+- (void)testErrorFromAuthenticationError_whenErrorOAuthHprotocolCodeValiderrorDetailsValidCorrelationIdNil_shouldReturnError
+{
+    NSString *details = @"Some details";
+    NSString *protocolCode = @"procol code";
+    
+    ADAuthenticationError *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_OAUTH protocolCode:protocolCode errorDetails:details correlationId:nil];
+    
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     ADAssertLongEquals(error.code, AD_ERROR_SERVER_OAUTH);
     ADAssertStringEquals(error.protocolCode, protocolCode);
     ADAssertStringEquals(error.errorDetails, details);
 }
 
-- (void)testDescription
+- (void)testErrorFromAuthenticationError_whenErrorValidprotocolCodeValiderrorDetailsValidCorrelationIdNil_shouldReturnErrorWithDescription
 {
-    NSString* details = @"Some details";
-    NSString* protocolCode = @"some-protocol-code";
-    ADAuthenticationError* error = [ADAuthenticationError errorFromAuthenticationError:42 protocolCode:protocolCode errorDetails:details correlationId:nil];
-    XCTAssertTrue([error.description containsString:details]);
-    XCTAssertTrue([error.description containsString:protocolCode]);
+    ADAuthenticationError *error = [ADAuthenticationError errorFromAuthenticationError:42 protocolCode:@"some-protocol-code" errorDetails:@"Some details" correlationId:nil];
+    
+    ADAssertStringEquals(error.description, @"Error with code: 42 Domain: ADAuthenticationErrorDomain ProtocolCode:some-protocol-code Details:Some details. Inner error details: Error Domain=ADAuthenticationErrorDomain Code=42 \"(null)\"");
 }
 
 @end

--- a/ADAL/tests/unit/ADAuthenticationErrorTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorTests.m
@@ -104,7 +104,7 @@
 
 #pragma mark - errorFromAuthenticationError
 
-- (void)testErrorFromAuthenticationError_whenErrorOAuthHprotocolCodeValiderrorDetailsValidCorrelationIdNil_shouldReturnError
+- (void)testErrorFromAuthenticationError_whenCodeValidErrorProtocolValidDetailsValidCorrelationIdNil_shouldReturnError
 {
     NSString *details = @"Some details";
     NSString *protocolCode = @"procol code";
@@ -117,7 +117,7 @@
     ADAssertStringEquals(error.errorDetails, details);
 }
 
-- (void)testErrorFromAuthenticationError_whenErrorValidprotocolCodeValiderrorDetailsValidCorrelationIdNil_shouldReturnErrorWithDescription
+- (void)testErrorFromAuthenticationError_whenErrorValidCodeValidErrorDetailsValidCorrelationIdNil_shouldReturnErrorWithDescription
 {
     ADAuthenticationError *error = [ADAuthenticationError errorFromAuthenticationError:42 protocolCode:@"some-protocol-code" errorDetails:@"Some details" correlationId:nil];
     

--- a/ADAL/tests/unit/ADAuthenticationParametersTests.m
+++ b/ADAL/tests/unit/ADAuthenticationParametersTests.m
@@ -59,30 +59,17 @@
 
 #pragma mark - parametersFromResourceUrl
 
-- (void)testParametersFromResourceUrl_whenResourceUrlIsNil_shouldReturnNilParameters
+- (void)testParametersFromResourceUrl_whenResourceUrlIsNil_shouldReturnErrorAndNilParameters
 {
     XCTestExpectation *expectation = [self expectationWithDescription:@"parametersFromResourceUrl: with nil resource should return error."];
     
-    [ADAuthenticationParameters parametersFromResourceUrl:nil completionBlock:^(ADAuthenticationParameters *parameters, ADAuthenticationError __unused *error)
-     {
-         XCTAssertNil(parameters);
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
-}
-
-- (void)testParametersFromResourceUrl_whenResourceUrlIsNil_shouldReturnError
-{
-    XCTestExpectation *expectation = [self expectationWithDescription:@"parametersFromResourceUrl: with nil resource should return error."];
-    
-    [ADAuthenticationParameters parametersFromResourceUrl:nil completionBlock:^(ADAuthenticationParameters __unused *parameters, ADAuthenticationError *error)
+    [ADAuthenticationParameters parametersFromResourceUrl:nil completionBlock:^(ADAuthenticationParameters *parameters, ADAuthenticationError *error)
      {
          XCTAssertNotNil(error);
          ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
          XCTAssertNil(error.protocolCode);
          ADAssertStringEquals(error.errorDetails, @"The argument 'resourceUrl' is invalid. Value:(null)");
+         XCTAssertNil(parameters);
          
          [expectation fulfill];
      }];
@@ -97,7 +84,7 @@
     XCTAssertThrowsSpecificNamed([ADAuthenticationParameters parametersFromResourceUrl:resource completionBlock:nil], NSException, NSInvalidArgumentException);
 }
 
-- (void)testParametersFromResourceUrl_whenResourceUrlIsNotExist_shouldReturnNilParameters
+- (void)testParametersFromResourceUrl_whenResourceUrlIsNotExist_shouldReturnErrorAndNilParameters
 {
     NSURL *resource = [[NSURL alloc] initWithString:@"https://noneistingurl12345676789.com"];
     [ADTestURLSession addNotFoundResponseForURLString:@"https://noneistingurl12345676789.com?x-client-Ver=" ADAL_VERSION_STRING];
@@ -105,6 +92,8 @@
     XCTestExpectation *expectation = [self expectationWithDescription:@"parametersFromResourceUrl: with non existing resource should return error."];
     [ADAuthenticationParameters parametersFromResourceUrl:resource completionBlock:^(ADAuthenticationParameters *parameters, ADAuthenticationError __unused *error)
      {
+         XCTAssertNotNil(error);
+         XCTAssertFalse([NSString adIsStringNilOrBlank:error.errorDetails], @"Error should have details.");
          XCTAssertNil(parameters);
          
          [expectation fulfill];
@@ -113,24 +102,7 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testParametersFromResourceUrl_whenResourceUrlIsNotExist_shouldReturnError
-{
-    NSURL *resource = [[NSURL alloc] initWithString:@"https://noneistingurl12345676789.com"];
-    [ADTestURLSession addNotFoundResponseForURLString:@"https://noneistingurl12345676789.com?x-client-Ver=" ADAL_VERSION_STRING];
-    
-    XCTestExpectation *expectation = [self expectationWithDescription:@"parametersFromResourceUrl: with non existing resource should return error."];
-    [ADAuthenticationParameters parametersFromResourceUrl:resource completionBlock:^(ADAuthenticationParameters __unused *parameters, ADAuthenticationError *error)
-     {
-         XCTAssertNotNil(error);
-         XCTAssertFalse([NSString adIsStringNilOrBlank:error.errorDetails], @"Error should have details.");
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
-}
-
-- (void)testParametersFromResourceUrl_whenHttpResourceUrlExists_shouldReturnAuthenticationParameters
+- (void)testParametersFromResourceUrl_whenHttpResourceUrlExists_shouldReturnAuthenticationParametersAndNilError
 {
     NSURL *resourceUrl = [[NSURL alloc] initWithString:@"http://testapi007.azurewebsites.net/api/WorkItem"];
     ADTestURLResponse *response = [ADTestURLResponse requestURLString:@"http://testapi007.azurewebsites.net/api/WorkItem?x-client-Ver=" ADAL_VERSION_STRING
@@ -146,26 +118,6 @@
          XCTAssertNotNil(parameters);
          XCTAssertNotNil(parameters.authority);
          XCTAssertEqualObjects(parameters.authority, @"https://login.windows.net/omercantest.onmicrosoft.com");
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
-}
-
-- (void)testParametersFromResourceUrl_whenHttpResourceUrlExists_shouldReturnNilError
-{
-    NSURL *resourceUrl = [[NSURL alloc] initWithString:@"http://testapi007.azurewebsites.net/api/WorkItem"];
-    ADTestURLResponse *response = [ADTestURLResponse requestURLString:@"http://testapi007.azurewebsites.net/api/WorkItem?x-client-Ver=" ADAL_VERSION_STRING
-                                                    responseURLString:@"http://contoso.com"
-                                                         responseCode:HTTP_UNAUTHORIZED
-                                                     httpHeaderFields:@{@"WWW-Authenticate" : @"Bearer authorization_uri=\"https://login.windows.net/omercantest.onmicrosoft.com\"" }
-                                                     dictionaryAsJSON:@{}];
-    [ADTestURLSession addResponse:response];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Get parameters for valid resourceUrl."];
-    
-    [ADAuthenticationParameters parametersFromResourceUrl:resourceUrl completionBlock:^(ADAuthenticationParameters __unused *parameters, ADAuthenticationError *error)
-     {
          XCTAssertNil(error);
          
          [expectation fulfill];
@@ -174,7 +126,7 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testParametersFromResourceUrl_whenHttpsResourceUrlExists_shouldReturnAuthenticationParameters
+- (void)testParametersFromResourceUrl_whenHttpsResourceUrlExists_shouldReturnAuthenticationParametersAndNilError
 {
     NSURL *resourceUrl = [[NSURL alloc] initWithString:@"https://testapi007.azurewebsites.net/api/WorkItem"];
     ADTestURLResponse *response = [ADTestURLResponse requestURLString:@"https://testapi007.azurewebsites.net/api/WorkItem?x-client-Ver=" ADAL_VERSION_STRING
@@ -190,26 +142,6 @@
          XCTAssertNotNil(parameters);
          XCTAssertNotNil(parameters.authority);
          XCTAssertEqualObjects(parameters.authority, @"https://login.windows.net/omercantest.onmicrosoft.com");
-         
-         [expectation fulfill];
-     }];
-    
-    [self waitForExpectationsWithTimeout:1 handler:nil];
-}
-
-- (void)testParametersFromResourceUrl_whenHttpsResourceUrlExists_shouldReturnNilError
-{
-    NSURL *resourceUrl = [[NSURL alloc] initWithString:@"https://testapi007.azurewebsites.net/api/WorkItem"];
-    ADTestURLResponse *response = [ADTestURLResponse requestURLString:@"https://testapi007.azurewebsites.net/api/WorkItem?x-client-Ver=" ADAL_VERSION_STRING
-                                                    responseURLString:@"https://contoso.com"
-                                                         responseCode:HTTP_UNAUTHORIZED
-                                                     httpHeaderFields:@{@"WWW-Authenticate" : @"Bearer authorization_uri=\"https://login.windows.net/omercantest.onmicrosoft.com\"" }
-                                                     dictionaryAsJSON:@{}];
-    [ADTestURLSession addResponse:response];
-    XCTestExpectation *expectation = [self expectationWithDescription:@"Get parameters for valid resourceUrl."];
-    
-    [ADAuthenticationParameters parametersFromResourceUrl:resourceUrl completionBlock:^(ADAuthenticationParameters __unused *parameters, ADAuthenticationError *error)
-     {
          XCTAssertNil(error);
          
          [expectation fulfill];
@@ -220,24 +152,16 @@
 
 #pragma mark - parametersFromResponse
 
-- (void)testParametersFromResponse_whenResponseNilErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters parametersFromResponse:nil error:&error];
-
-    XCTAssertNotNil(error);
-    ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
-    XCTAssertNil(error.protocolCode);
-    ADAssertStringEquals(error.errorDetails, @"The argument 'response' is invalid. Value:(null)");
-}
-
-- (void)testParametersFromResponse_whenResponseNilErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testParametersFromResponse_whenResponseNilErrorPointerIsProvided_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     ADAuthenticationParameters *parameters = [ADAuthenticationParameters parametersFromResponse:nil error:&error];
 
+    XCTAssertNotNil(error);
+    ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
+    XCTAssertNil(error.protocolCode);
+    ADAssertStringEquals(error.errorDetails, @"The argument 'response' is invalid. Value:(null)");
     XCTAssertNil(parameters);
 }
 
@@ -248,27 +172,18 @@
     XCTAssertNil(parameters);
 }
 
-- (void)testParametersFromResponse_whenResponseWithoutAuthenticateHeaderErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testParametersFromResponse_whenResponseWithoutAuthenticateHeaderErrorPointerIsProvided_shouldReturnErrorAndNilParameters
 {
     NSHTTPURLResponse *response = [NSHTTPURLResponse new];
     ADAuthenticationError *error;
     
     ADAuthenticationParameters *parameters = [ADAuthenticationParameters parametersFromResponse:response error:&error];
     
-    XCTAssertNil(parameters);
-}
-
-- (void)testParametersFromResponse_whenResponseWithoutAuthenticateHeaderErrorPointerIsProvided_shouldReturnError
-{
-    NSHTTPURLResponse *response = [NSHTTPURLResponse new];
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters parametersFromResponse:response error:&error];
-    
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' is missing in the Unauthorized (401) response. Make sure that the resouce server supports OAuth2 protocol.");
+    XCTAssertNil(parameters);
 }
 
 - (void)testParametersFromResponse_whenResponseWithoutAuthenticateHeaderErrorPointerNil_shouldReturnNilParameters
@@ -280,23 +195,7 @@
     XCTAssertNil(parameters);
 }
 
-- (void)testParametersFromResponse_whenResponseWithUppercaseAuthenticateHeaderErrorPointerIsProvided_shouldReturnNilError
-{
-    NSURL *url = [NSURL URLWithString:@"http://www.example.com"];
-    NSDictionary *headerFields = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
-                                                             forKey:@"WWW-AUTHENTICATE"];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
-                                                              statusCode:401
-                                                             HTTPVersion:@"1.1"
-                                                            headerFields:headerFields];
-    ADAuthenticationError *error = nil;
-    
-    [ADAuthenticationParameters parametersFromResponse:response error:&error];
-    
-    XCTAssertNil(error);
-}
-
-- (void)testParametersFromResponse_whenResponseWithUppercaseAuthenticateHeaderErrorPointerIsProvided_shouldReturnParametersWithAuthority
+- (void)testParametersFromResponse_whenResponseWithUppercaseAuthenticateHeader_shouldReturnParametersAndNilError
 {
     NSURL *url = [NSURL URLWithString:@"http://www.example.com"];
     NSDictionary *headerFields = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
@@ -312,25 +211,11 @@
     XCTAssertNotNil(parameters);
     XCTAssertNotNil(parameters.authority);
     ADAssertStringEquals(parameters.authority, @"https://www.example.com");
-}
-
-- (void)testParametersFromResponse_whenResponseWithPartiallyUppercaseAuthenticateHeaderErrorPointerIsProvided_shouldReturnNilError
-{
-    NSURL *url = [NSURL URLWithString:@"http://www.example.com"];
-    NSDictionary *headerFields = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
-                                                             forKey:@"www-AUTHEnticate"];
-    NSHTTPURLResponse *response = [[NSHTTPURLResponse alloc] initWithURL:url
-                                                              statusCode:401
-                                                             HTTPVersion:@"1.1"
-                                                            headerFields:headerFields];
-    ADAuthenticationError *error = nil;
-    
-    [ADAuthenticationParameters parametersFromResponse:response error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testParametersFromResponse_whenResponseWithPartiallyUppercaseAuthenticateHeaderErrorPointerIsProvided_shouldReturnParametersWithAuthority
+- (void)testParametersFromResponse_whenResponseWithPartiallyUppercaseAuthenticateHeader_shouldReturnParametersAndNilError
+
 {
     NSURL *url = [NSURL URLWithString:@"http://www.example.com"];
     NSDictionary *headerFields = [NSDictionary dictionaryWithObject:@"Bearer authorization_uri=\"https://www.example.com\""
@@ -346,45 +231,22 @@
     XCTAssertNotNil(parameters);
     XCTAssertNotNil(parameters.authority);
     ADAssertStringEquals(parameters.authority, @"https://www.example.com");
+    XCTAssertNil(error);
 }
 
 #pragma mark - parametersFromResponseAuthenticateHeader
 
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderNilErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:nil error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderNilErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testParametersFromResponseAuthenticateHeader_whenHeaderNil_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     ADAuthenticationParameters *parameters = [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:nil error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderNilErrorPointerNil_shouldReturnNilParameters
-{
-    ADAuthenticationParameters *parameters = [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:nil error:nil];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsValid_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:@"Bearer authorization_uri=\"https://login.windows.net/common\", resource_uri=\"something.com\", anotherParam=\"Indeed, another param=5\" " error:&error];
-    
-    XCTAssertNil(error);
-}
-
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsValid_shouldReturnParameters
+- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsValid_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -396,220 +258,132 @@
     NSDictionary *extractedParameters = [parameters extractedParameters];
     XCTAssertNotNil(extractedParameters);
     ADAssertStringEquals([extractedParameters objectForKey:@"anotherParam"], @"Indeed, another param=5");
+    XCTAssertNil(error);
 }
 
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsInvalid_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:@"Bearer authorization_uri=\".\\..\\windows\\system32\\drivers\\etc\\host\"" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsValid_shouldReturnNilParameters
+- (void)testParametersFromResponseAuthenticateHeader_whenHeaderIsInvalid_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     ADAuthenticationParameters *parameters = [ADAuthenticationParameters parametersFromResponseAuthenticateHeader:@"Bearer authorization_uri=\".\\..\\windows\\system32\\drivers\\etc\\host\"" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
 #pragma mark - extractChallengeParameters
 
-- (void)testExtractChallengeParameters_whenHeaderContentsNilErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:nil error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsNilErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsNil_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:nil error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsEmptyErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsEmpty_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"" error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsEmptyErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"" error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value: ");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsBlankErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsBlank_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"   " error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsBlankErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"   " error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value:    ");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerButIsInvalidErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerButIsInvalid_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"BearerBlahblah" error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerButIsInvalidErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"BearerBlahblah" error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value: BearerBlahblah");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerCommaButIsInvalidErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerCommaButIsInvalid_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer,, " error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerCommaButIsInvalidErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer,, " error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value: Bearer,, ");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceButIsInvalidErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceButIsInvalid_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer test string" error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceButIsInvalidErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer test string" error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value: Bearer test string");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerauthorizationErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearerauthorization_uri=\"abc\", resource_id=\"something\"" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerauthorizationErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerauthorization_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearerauthorization_uri=\"abc\", resource_id=\"something\"" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomething_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer something" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualBarErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=bar" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualBarErrorPointerIsProvided_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualBar_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=bar" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuoteErrorPointerIsProvided_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=\"bar\"" error:&error];
-    
-    XCTAssertNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuoteErrorPointerIsProvided_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuote_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -617,55 +391,31 @@
     
     XCTAssertNotNil(parameters);
     ADAssertStringEquals(parameters[@"something"], @"bar");
+    XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarErrorPointerIsProvided_shouldReturnError
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBar_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     // Missing second quote.
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=\"bar" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarErrorPointerIsProvided_shouldReturnNilParameters
-{
-    ADAuthenticationError *error;
-    
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=\"bar" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
--(void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuoteCommaErrorPointerIsProvided_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=\"bar\"," error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuoteCommaErrorPointerIsProvided_shouldReturnNilParameters
+-(void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceSomethingEqualQuoteBarQuoteComma_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=\"bar\"," error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerMultipleSpacesAuthorizationUriErrorPointerIsProvided_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer   authorization_uri=\"https://login.windows.net/common\"" error:&error];
-    
-    XCTAssertNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerMultipleSpacesAuthorizationUriErrorPointerIsProvided_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerMultipleSpacesAuthorizationUri_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -673,18 +423,10 @@
     
     XCTAssertNotNil(parameters);
     ADAssertStringEquals(parameters[@"authorization_uri"], @"https://login.windows.net/common");
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUriErrorPointerIsProvided_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer authorization_uri=\"https://login.windows.net/common\"" error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUriErrorPointerIsProvided_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUri_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -692,18 +434,10 @@
     
     XCTAssertNotNil(parameters);
     ADAssertStringEquals(parameters[@"authorization_uri"], @"https://login.windows.net/common");
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUriCommaResourceIdErrorPointerIsProvided_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer authorization_uri=\"https://login.windows.net/common\",resource_id=\"something\"" error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUriCommaResourceIdErrorPointerIsProvided_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsStartsWithBearerSpaceAuthorizationUriCommaResourceId_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -712,18 +446,10 @@
     XCTAssertNotNil(parameters);
     ADAssertStringEquals(parameters[@"authorization_uri"], @"https://login.windows.net/common");
     ADAssertStringEquals(parameters[@"resource_id"], @"something");
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsHasEmptyAuthorizationUriAndValidResourceIdErrorPointerIsProvided_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer authorization_uri=\"\",resource_id=\"something\"" error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsHasEmptyAuthorizationUriAndValidResourceIdErrorPointerIsProvided_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsHasEmptyAuthorizationUriAndValidResourceId_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -732,18 +458,10 @@
     XCTAssertNotNil(parameters);
     XCTAssertNil(parameters[@"authorization_uri"]);
     ADAssertStringEquals(parameters[@"resource_id"], @"something");
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsHasCommasInAttribute_shouldReturnNilError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer  error_descritpion=\"Make sure, that you handle commas, inside the text\",authorization_uri=\"https://login.windows.net/common\",resource_id=\"something\"" error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsHasCommasInAttribute_shouldReturnParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsHasCommasInAttribute_shouldReturnParametersAndNilError
 {
     ADAuthenticationError *error;
     
@@ -753,63 +471,40 @@
     ADAssertStringEquals(parameters[@"error_descritpion"], @"Make sure, that you handle commas, inside the text");
     ADAssertStringEquals(parameters[@"authorization_uri"], @"https://login.windows.net/common");
     ADAssertStringEquals(parameters[@"resource_id"], @"something");
+    XCTAssertNil(error);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsHasAttributeValueWithoutQuotes_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsHasAttributeValueWithoutQuotes_shouldReturnErrorANdNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=bar" error:&error];
-    
-    XCTAssertNil(parameters);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsHasAttributeValueWithoutQuotes_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer something=bar" error:&error];
     
     XCTAssertNotNil(error);
     ADAssertStringEquals(error.domain, ADAuthenticationErrorDomain);
     XCTAssertNil(error.protocolCode);
     ADAssertStringEquals(error.errorDetails, @"The authentication header 'WWW-Authenticate' for the Unauthorized (401) response cannot be parsed. Header value: Bearer something=bar");
     XCTAssertEqual(error.code, AD_ERROR_SERVER_AUTHENTICATE_HEADER_BAD_FORMAT);
+    XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidAndContainsEqualsCommasSpaces_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer = , = , " error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidAndContainsEqualsCommasSpaces_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidAndContainsEqualsCommasSpaces_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer = , = , " error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 
-- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidAndContainsEqualsCommas_shouldReturnError
-{
-    ADAuthenticationError *error;
-    
-    [ADAuthenticationParameters extractChallengeParameters:@"Bearer =,=,=" error:&error];
-    
-    XCTAssertNotNil(error);
-}
-
-- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidandContainsEqualsCommasSpaces_shouldReturnNilParameters
+- (void)testExtractChallengeParameters_whenHeaderContentsIsInvalidAndContainsEqualsCommas_shouldReturnErrorAndNilParameters
 {
     ADAuthenticationError *error;
     
     NSDictionary *parameters = [ADAuthenticationParameters extractChallengeParameters:@"Bearer =,=,=" error:&error];
     
+    XCTAssertNotNil(error);
     XCTAssertNil(parameters);
 }
 

--- a/ADAL/tests/unit/ADClientMetricsTests.m
+++ b/ADAL/tests/unit/ADClientMetricsTests.m
@@ -23,6 +23,7 @@
 
 #import <XCTest/XCTest.h>
 #import "ADClientMetrics.h"
+#import "XCTestCase+TestHelperMethods.h"
 
 @interface ADClientMetricsTests : ADTestCase
 
@@ -30,61 +31,114 @@
 
 @implementation ADClientMetricsTests
 
-- (void)setUp {
+- (void)setUp
+{
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
 }
 
-- (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
+- (void)tearDown
+{
     [super tearDown];
 }
 
-- (void)testMetrics
+#pragma mark - addClientMetrics
+
+- (void)testAddClientMetrics_whenNoMetrics_shouldNotModifyHeader
 {
-    ADClientMetrics* metrics = [ADClientMetrics new];
-    NSMutableDictionary* header = [NSMutableDictionary new];
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSMutableDictionary *header = [NSMutableDictionary new];
     
-    NSDate* startTime = [NSDate new];
-    [metrics addClientMetrics:header
-                     endpoint:@"https://login.windows.net/common/oauth2/token"];
-    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
-                          startTime:startTime
-                      correlationId:[NSUUID UUID]
-                       errorDetails:@"error"];
+    [metrics addClientMetrics:header endpoint:@"https://login.windows.net/common/oauth2/token"];
+    
     XCTAssertEqual([header count], 0);
-    
-    [metrics addClientMetrics:header
-                     endpoint:@"https://login.windows.net/common/oauth2/token"];
-    XCTAssertEqual([header count], 4);
 }
 
-- (void)testMetricsWithADFSEndpointFollowedByNonADFS
+- (void)testAddClientMetrics_whenMetricsAreStored_shouldAddMetricsToHeader
 {
-    ADClientMetrics* metrics = [ADClientMetrics new];
-    NSMutableDictionary* header = [NSMutableDictionary new];
-    
-    NSDate* startTime = [NSDate new];
-    [metrics addClientMetrics:header
-                     endpoint:@"https://sts.contoso.com/adfs/oauth2/token"];
-    XCTAssertEqual([header count], 0);
-    [metrics endClientMetricsRecord:@"https://sts.contoso.com/adfs/oauth2/token"
-                          startTime:startTime
-                      correlationId:[NSUUID UUID]
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSMutableDictionary *header = [NSMutableDictionary new];
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"3FBD4165-1CA5-436D-A2C7-15EF855F6893"];
+    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
+                          startTime:[NSDate new]
+                      correlationId:correlationId
                        errorDetails:@"error"];
     
-    [metrics addClientMetrics:header
-                     endpoint:@"https://login.windows.net/common/oauth2/token"];
+    [metrics addClientMetrics:header endpoint:@"https://login.windows.net/common/oauth2/token"];
+    
+    XCTAssertEqual([header count], 4);
+    ADAssertStringEquals(header[@"x-client-last-endpoint"], @"token");
+    ADAssertStringEquals(header[@"x-client-last-error"], @"error");
+    ADAssertStringEquals(header[@"x-client-last-request"], @"3FBD4165-1CA5-436D-A2C7-15EF855F6893");
+    XCTAssertNotNil(header[@"x-client-last-response-time"]);
+}
+
+- (void)testAddClientMetrics_whenMetricsAreStored_shouldClearStoredMetrics
+{
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSMutableDictionary *header = [NSMutableDictionary new];
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"3FBD4165-1CA5-436D-A2C7-15EF855F6893"];
+    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
+                          startTime:[NSDate new]
+                      correlationId:correlationId
+                       errorDetails:@"error"];
+    
+    [metrics addClientMetrics:header endpoint:@"https://login.windows.net/common/oauth2/token"];
+    
+    XCTAssertNil(metrics.endpoint);
+    XCTAssertNil(metrics.correlationId);
+    XCTAssertNil(metrics.errorToReport);
+    XCTAssertNil(metrics.responseTime);
+}
+
+- (void)testAddClientMetrics_whenMetricsAreStoredWithADFSEndpoint_shouldNotAddMetricsToHeader
+{
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSMutableDictionary *header = [NSMutableDictionary new];
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"3FBD4165-1CA5-436D-A2C7-15EF855F6893"];
+    [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
+                          startTime:[NSDate new]
+                      correlationId:correlationId
+                       errorDetails:@"error"];
+    
+    [metrics addClientMetrics:header endpoint:@"https://sts.contoso.com/adfs/oauth2/token"];
+    
     XCTAssertEqual([header count], 0);
+}
+
+#pragma mark - endClientMetricsRecord
+
+- (void)testEndClientMetricsRecord_whenMetricsAreProvided_shouldStoreThem
+{
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSDate *startTime = [NSDate new];
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"3FBD4165-1CA5-436D-A2C7-15EF855F6893"];
     
     [metrics endClientMetricsRecord:@"https://login.windows.net/common/oauth2/token"
                           startTime:startTime
-                      correlationId:[NSUUID UUID]
+                      correlationId:correlationId
                        errorDetails:@"error"];
     
-    [metrics addClientMetrics:header
-                     endpoint:@"https://login.windows.net/common/oauth2/token"];
-    XCTAssertEqual([header count], 4);
+    ADAssertStringEquals(metrics.endpoint, @"https://login.windows.net/common/oauth2/token");
+    ADAssertStringEquals(metrics.correlationId, @"3FBD4165-1CA5-436D-A2C7-15EF855F6893");
+    ADAssertStringEquals(metrics.errorToReport, @"error");
+    XCTAssertNotNil(metrics.responseTime);
+}
+
+- (void)testEndClientMetricsRecord_whenMetricsAreProvidedWithADFSEndpoint_shouldNotStoreThem
+{
+    ADClientMetrics *metrics = [ADClientMetrics new];
+    NSDate *startTime = [NSDate new];
+    NSUUID *correlationId = [[NSUUID alloc] initWithUUIDString:@"3FBD4165-1CA5-436D-A2C7-15EF855F6893"];
+    
+    [metrics endClientMetricsRecord:@"https://sts.contoso.com/adfs/oauth2/token"
+                          startTime:startTime
+                      correlationId:correlationId
+                       errorDetails:@"error"];
+    
+    XCTAssertNil(metrics.endpoint);
+    XCTAssertNil(metrics.correlationId);
+    XCTAssertNil(metrics.errorToReport);
+    XCTAssertNil(metrics.responseTime);
 }
 
 @end

--- a/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
@@ -30,156 +30,136 @@
 #import "ADUserIdentifier.h"
 #import "ADAuthenticationRequest.h"
 
-@implementation ADAuthenticationContextTests
+@interface ADAuthenticationContextTests (iOS)
 
-- (void)setUp
-{
-    [super setUp];
-}
+@end
 
-- (void)tearDown
-{
-    [super tearDown];
-}
+@implementation ADAuthenticationContextTests (iOS)
 
-#pragma mark - Tests
-
-- (void)testNew_shouldThrow
-{
-    XCTAssertThrows([ADAuthenticationContext new], @"The new selector should not work due to requirement to use the parameterless init. At: '%s'", __PRETTY_FUNCTION__);
-}
-
-- (void)testParameterlessInit_shouldThrow
-{
-    XCTAssertThrows([[ADAuthenticationContext alloc] init], @"The new selector should not work due to requirement to use the parameterless init. At: '%s'", __PRETTY_FUNCTION__);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:nil sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNil_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnNilContext
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:nil sharedGroup:nil error:&error];
     
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidatedAuthorityNo_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidateAuthorityNoSharedGroupNil_shouldReturnNilContext
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO sharedGroup:nil error:&error];
+    
+    XCTAssertNil(context);
+}
+
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidateAuthorityNoSharedGroupNil_shouldReturnError
+{
+    ADAuthenticationContext* context = nil;
+    ADAuthenticationError* error = nil;
+    
+    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidatedAuthorityNo_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankSharedGroupNil_shouldReturnError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO error:&error];
-    
-    XCTAssertNil(context);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlank_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " error:&error];
-    
-    XCTAssertNil(context);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlank_shouldReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNo_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankSharedGroupNil_shouldReturnNilContext
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " sharedGroup:nil error:&error];
     
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNo_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNoSharedGroupNil_shouldReturnError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO error:&error];
-    
+    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO sharedGroup:nil error:&error];
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValid_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNoSharedGroupNil_shouldReturnNilContext
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO sharedGroup:nil error:&error];
+    XCTAssertNil(context);
+}
+
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidSharedGroupNil_shouldReturnContext
+{
+    ADAuthenticationContext* context = nil;
+    ADAuthenticationError* error = nil;
+    
+    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY sharedGroup:nil error:&error];
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValid_shouldNotReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidSharedGroupNil_shouldNotReturnError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY sharedGroup:nil error:&error];
     
     XCTAssertNil(error);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNo_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNoShareGroupNil_shouldReturnContext
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO sharedGroup:nil error:&error];
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNo_shouldNotReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNoShareGroupNil_shouldNotReturnError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
     
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO error:&error];
+    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO sharedGroup:nil error:&error];
     
     XCTAssertNil(error);
 }

--- a/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
@@ -38,114 +38,71 @@
 
 #pragma mark - authenticationContextWithAuthority
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:nil sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil sharedGroup:nil error:&error];
-    
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidateAuthorityNoSharedGroupNil_shouldReturnNilContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidateAuthorityNoSharedGroupNil_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO sharedGroup:nil error:&error];
-    
-    XCTAssertNil(context);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityNilValidateAuthorityNoSharedGroupNil_shouldReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:nil validateAuthority:NO sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
+    XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankSharedGroupNil_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankSharedGroupNil_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " sharedGroup:nil error:&error];
     
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankSharedGroupNil_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " sharedGroup:nil error:&error];
-    
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNoSharedGroupNil_shouldReturnError
+- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNoSharedGroupNil_shouldReturnErrorAndNilContext
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO sharedGroup:nil error:&error];
+    
     XCTAssertNotNil(error);
     XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_INVALID_ARGUMENT);
     ADTAssertContains(error.errorDetails, @"authority");
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityBlankValidateAuthorityNoSharedGroupNil_shouldReturnNilContext
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:@"   " validateAuthority:NO sharedGroup:nil error:&error];
     XCTAssertNil(context);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidSharedGroupNil_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidSharedGroupNil_shouldReturnContextAndNilError
 {
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
+    ADAuthenticationContext *context = nil;
+    ADAuthenticationError *error = nil;
     
     context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY sharedGroup:nil error:&error];
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidSharedGroupNil_shouldNotReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY sharedGroup:nil error:&error];
-    
     XCTAssertNil(error);
 }
 
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNoShareGroupNil_shouldReturnContext
+- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNoShareGroupNil_shouldReturnContextAndNilError
 {
     ADAuthenticationContext* context = nil;
     ADAuthenticationError* error = nil;
@@ -154,15 +111,6 @@
     
     XCTAssertNotNil(context);
     XCTAssertEqualObjects(context.authority, TEST_AUTHORITY);
-}
-
-- (void)testAuthenticationContextWithAuthority_whenAuthorityIsValidValidateAuthorityNoShareGroupNil_shouldNotReturnError
-{
-    ADAuthenticationContext* context = nil;
-    ADAuthenticationError* error = nil;
-    
-    context = [ADAuthenticationContext authenticationContextWithAuthority:TEST_AUTHORITY validateAuthority:NO sharedGroup:nil error:&error];
-    
     XCTAssertNil(error);
 }
 

--- a/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
+++ b/ADAL/tests/unit/ios/ADAuthenticationContextTests.m
@@ -36,6 +36,8 @@
 
 @implementation ADAuthenticationContextTests (iOS)
 
+#pragma mark - authenticationContextWithAuthority
+
 - (void)testAuthenticationContextWithAuthority_whenAuthorityNilSharedGroupNil_shouldReturnError
 {
     ADAuthenticationContext* context = nil;


### PR DESCRIPTION
Changed tests accordingly to the following rules:
1. Only one logical assertion per test.
2. Test only one code unit at a time.
3. Follow [Arrange-Act-Assert](http://wiki.c2.com/?ArrangeActAssert) pattern.
4. Follow our test naming convention: `test[Method]_when[Condition]_should[Result]`
5. Keep test **simple**.