### PR TITLE
Split Authority Validation Integration Tests into two files

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -238,8 +238,8 @@
 		B20DC60A1F0D998A00957806 /* NSURLExtensionsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC5EE1F0D998A00957806 /* NSURLExtensionsTests.m */; };
 		B20DC60F1F0D99A300957806 /* ADAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */; };
 		B20DC6101F0D99A300957806 /* ADAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */; };
-		B20DC6121F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6111F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m */; };
-		B20DC6131F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6111F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m */; };
+		B20DC6121F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */; };
+		B20DC6131F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */; };
 		B20DC6151F0D9A7600957806 /* ADAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6141F0D9A7600957806 /* ADAuthorityValidationTests.m */; };
 		B20DC6161F0D9A7600957806 /* ADAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6141F0D9A7600957806 /* ADAuthorityValidationTests.m */; };
 		B20DC6181F0DA2E800957806 /* ADTestNSStringHelperMethods.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC6171F0DA2E800957806 /* ADTestNSStringHelperMethods.m */; };
@@ -331,6 +331,8 @@
 		D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
 		D67D3D3D1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
 		D67D3D3E1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
+		D67D3D461F422C3000660F32 /* ADFSAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */; };
+		D67D3D471F422C3200660F32 /* ADFSAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */; };
 		D68040301D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */; };
 		D68040331D22F686007A61AC /* ADWebAuthResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D68040311D22F686007A61AC /* ADWebAuthResponse.h */; };
 		D68040351D22F686007A61AC /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
@@ -684,7 +686,7 @@
 		B20DC5ED1F0D998A00957806 /* ADWebAuthResponseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponseTests.m; sourceTree = "<group>"; };
 		B20DC5EE1F0D998A00957806 /* NSURLExtensionsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSURLExtensionsTests.m; sourceTree = "<group>"; };
 		B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenTests.m; sourceTree = "<group>"; };
-		B20DC6111F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthorityValidationIntegrationTests.m; sourceTree = "<group>"; };
+		B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AADAuthorityValidationIntegrationTests.m; sourceTree = "<group>"; };
 		B20DC6141F0D9A7600957806 /* ADAuthorityValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthorityValidationTests.m; sourceTree = "<group>"; };
 		B20DC6171F0DA2E800957806 /* ADTestNSStringHelperMethods.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestNSStringHelperMethods.m; sourceTree = "<group>"; };
 		B20DC61A1F0DA34B00957806 /* ADBrokerMessageTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADBrokerMessageTests.m; sourceTree = "<group>"; };
@@ -721,6 +723,7 @@
 		D67D3D3A1F38502900660F32 /* ADTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestCase.m; sourceTree = "<group>"; };
 		D67D3D3F1F38538100660F32 /* ADTest.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTest.pch; sourceTree = "<group>"; };
 		D67D3D401F38542700660F32 /* ADAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADAL.pch; sourceTree = "<group>"; };
+		D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADFSAuthorityValidationTests.m; sourceTree = "<group>"; };
 		D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoinUtil.m; sourceTree = "<group>"; };
 		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
 		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
@@ -1346,7 +1349,8 @@
 			isa = PBXGroup;
 			children = (
 				B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */,
-				B20DC6111F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m */,
+				B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */,
+				D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */,
 				B20DC5DE1F0D97E400957806 /* mac */,
 				B20DC5DB1F0D97DD00957806 /* ios */,
 			);
@@ -2079,12 +2083,13 @@
 				B20DC60F1F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				B20DC5891F0D96A100957806 /* ADTelemetryTestDispatcher.m in Sources */,
-				B20DC6121F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m in Sources */,
+				B20DC6121F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5951F0D96A100957806 /* ADTestURLSessionDataTask.m in Sources */,
 				D6D4D4991F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC5961F0D96A100957806 /* XCTestCase+TestHelperMethods.m in Sources */,
 				D67D3D361F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 				B20DC5981F0D96A100957806 /* ADTestURLSession.m in Sources */,
+				D67D3D471F422C3200660F32 /* ADFSAuthorityValidationTests.m in Sources */,
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2097,8 +2102,9 @@
 				B20DC5BF1F0D96A700957806 /* ADTestURLSessionDataTask.m in Sources */,
 				D67D3D3E1F38502900660F32 /* ADTestCase.m in Sources */,
 				B20DC5C61F0D96A700957806 /* XCTestCase+TestHelperMethods.m in Sources */,
-				B20DC6131F0D9A5500957806 /* ADAuthorityValidationIntegrationTests.m in Sources */,
+				B20DC6131F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5C71F0D96A700957806 /* ADTestURLSession.m in Sources */,
+				D67D3D461F422C3000660F32 /* ADFSAuthorityValidationTests.m in Sources */,
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC6101F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */,

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -331,8 +331,8 @@
 		D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
 		D67D3D3D1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
 		D67D3D3E1F38502900660F32 /* ADTestCase.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D3A1F38502900660F32 /* ADTestCase.m */; };
-		D67D3D461F422C3000660F32 /* ADFSAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */; };
-		D67D3D471F422C3200660F32 /* ADFSAuthorityValidationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */; };
+		D67D3D461F422C3000660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationIntegrationTests.m */; };
+		D67D3D471F422C3200660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D431F3E975200660F32 /* ADFSAuthorityValidationIntegrationTests.m */; };
 		D68040301D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */; };
 		D68040331D22F686007A61AC /* ADWebAuthResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = D68040311D22F686007A61AC /* ADWebAuthResponse.h */; };
 		D68040351D22F686007A61AC /* ADWebAuthResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D68040321D22F686007A61AC /* ADWebAuthResponse.m */; };
@@ -723,7 +723,7 @@
 		D67D3D3A1F38502900660F32 /* ADTestCase.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestCase.m; sourceTree = "<group>"; };
 		D67D3D3F1F38538100660F32 /* ADTest.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTest.pch; sourceTree = "<group>"; };
 		D67D3D401F38542700660F32 /* ADAL.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADAL.pch; sourceTree = "<group>"; };
-		D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADFSAuthorityValidationTests.m; sourceTree = "<group>"; };
+		D67D3D431F3E975200660F32 /* ADFSAuthorityValidationIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADFSAuthorityValidationIntegrationTests.m; sourceTree = "<group>"; };
 		D680402F1D21C4EB007A61AC /* ADWorkPlaceJoinUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWorkPlaceJoinUtil.m; sourceTree = "<group>"; };
 		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
 		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
@@ -1350,7 +1350,7 @@
 			children = (
 				B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */,
 				B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */,
-				D67D3D431F3E975200660F32 /* ADFSAuthorityValidationTests.m */,
+				D67D3D431F3E975200660F32 /* ADFSAuthorityValidationIntegrationTests.m */,
 				B20DC5DE1F0D97E400957806 /* mac */,
 				B20DC5DB1F0D97DD00957806 /* ios */,
 			);
@@ -2089,7 +2089,7 @@
 				B20DC5961F0D96A100957806 /* XCTestCase+TestHelperMethods.m in Sources */,
 				D67D3D361F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 				B20DC5981F0D96A100957806 /* ADTestURLSession.m in Sources */,
-				D67D3D471F422C3200660F32 /* ADFSAuthorityValidationTests.m in Sources */,
+				D67D3D471F422C3200660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2104,7 +2104,7 @@
 				B20DC5C61F0D96A700957806 /* XCTestCase+TestHelperMethods.m in Sources */,
 				B20DC6131F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5C71F0D96A700957806 /* ADTestURLSession.m in Sources */,
-				D67D3D461F422C3000660F32 /* ADFSAuthorityValidationTests.m in Sources */,
+				D67D3D461F422C3000660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */,
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC6101F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */,

--- a/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
@@ -1,0 +1,211 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import "ADAuthenticationContext.h"
+#import "ADAuthenticationResult.h"
+#import "ADAuthorityValidation.h"
+#import "ADAuthorityValidationRequest.h"
+#import "ADDrsDiscoveryRequest.h"
+#import "ADTestURLSession.h"
+#import "ADTestURLResponse.h"
+
+#import "ADUserIdentifier.h"
+#import "ADWebFingerRequest.h"
+#import "XCTestCase+TestHelperMethods.h"
+#import <XCTest/XCTest.h>
+
+static NSString* const s_kTrustedAuthority = @"https://login.windows.net";
+
+@interface AADAuthorityValidationTests : ADTestCase
+
+@end
+
+@implementation AADAuthorityValidationTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+//Does not call the server, just passes invalid authority
+- (void)testValidateAuthorityError
+{
+    NSArray* cases = @[@"http://invalidscheme.com",
+                       @"https://Invalid URL 2305 8 -0238460-820-386"];
+    ADRequestParameters* requestParams = [ADRequestParameters new];
+    requestParams.correlationId = [NSUUID UUID];
+    
+    ADAuthorityValidation* authorityValidation = [[ADAuthorityValidation alloc] init];
+    
+    for (NSString* testCase in cases)
+    {
+        [requestParams setAuthority:testCase];
+        
+        XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
+        [authorityValidation validateAuthority:requestParams
+                               completionBlock:^(BOOL validated, ADAuthenticationError *error)
+        {
+            XCTAssertFalse(validated, @"\"%@\" should come back invalid.", testCase);
+            XCTAssertNotNil(error);
+            
+            [expectation fulfill];
+        }];
+        
+        [self waitForExpectationsWithTimeout:1 handler:nil];
+    }
+}
+
+// Tests a normal authority
+- (void)testAadNormalFlow
+{
+    NSString* authority = @"https://login.windows-ppe.net/common";
+    
+    ADAuthorityValidation* authorityValidation = [[ADAuthorityValidation alloc] init];
+    ADRequestParameters* requestParams = [ADRequestParameters new];
+    requestParams.authority = authority;
+    requestParams.correlationId = [NSUUID UUID];
+    
+    [ADTestURLSession addResponse:[ADTestURLResponse responseValidAuthority:authority]];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Validate valid authority."];
+    [authorityValidation validateAuthority:requestParams
+                           completionBlock:^(BOOL validated, ADAuthenticationError * error)
+     {
+         XCTAssertTrue(validated);
+         XCTAssertNil(error);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertTrue([authorityValidation isAuthorityValidated:[NSURL URLWithString:@"https://login.windows-ppe.net"]]);
+}
+
+//Ensures that an invalid authority is not approved
+- (void)testAadNonValidatedAuthority
+{
+    NSString* authority = @"https://myfakeauthority.microsoft.com/contoso.com";
+    
+    ADAuthorityValidation* authorityValidation = [[ADAuthorityValidation alloc] init];
+    ADRequestParameters* requestParams = [ADRequestParameters new];
+    requestParams.authority = authority;
+    requestParams.correlationId = [NSUUID UUID];
+    
+    [ADTestURLSession addResponse:[ADTestURLResponse responseInvalidAuthority:authority]];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
+    [authorityValidation validateAuthority:requestParams
+                           completionBlock:^(BOOL validated, ADAuthenticationError * error)
+     {
+         XCTAssertFalse(validated);
+         XCTAssertNotNil(error);
+         XCTAssertEqual(error.code, AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertFalse([authorityValidation isAuthorityValidated:[NSURL URLWithString:authority]]);
+}
+
+- (void)testBadAadAuthorityWithValidation
+{
+    ADAuthenticationError* error = nil;
+    
+    NSString* authority = @"https://myfakeauthority.microsoft.com/contoso.com";
+    
+    ADAuthenticationContext* context = [[ADAuthenticationContext alloc] initWithAuthority:authority
+                                                                        validateAuthority:YES
+                                                                                    error:&error];
+    
+    XCTAssertNotNil(context);
+    XCTAssertNil(error);
+    
+    [ADTestURLSession addInvalidAuthorityResponse:authority];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"acquireTokenWithResource: with invalid authority."];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:TEST_REDIRECT_URL
+                               userId:TEST_USER_ID
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+- (void)testUnreachableAadServer
+{
+    NSString* authority = @"https://login.windows.cn/MSOpenTechBV.onmicrosoft.com";
+
+    
+    ADAuthorityValidation* authorityValidation = [[ADAuthorityValidation alloc] init];
+    ADRequestParameters* requestParams = [ADRequestParameters new];
+    requestParams.authority = authority;
+    requestParams.correlationId = [NSUUID UUID];
+    
+    NSURL* requestURL = [ADAuthorityValidationRequest urlForAuthorityValidation:authority trustedAuthority:s_kTrustedAuthority];
+    NSString* requestURLString = [NSString stringWithFormat:@"%@&x-client-Ver=" ADAL_VERSION_STRING, requestURL.absoluteString];
+    
+    requestURL = [NSURL URLWithString:requestURLString];
+
+    NSError* responseError = [NSError errorWithDomain:NSURLErrorDomain code:NSURLErrorCannotFindHost userInfo:nil];
+    
+    ADTestURLResponse *response = [ADTestURLResponse request:requestURL
+                                            respondWithError:responseError];
+    [response setRequestHeaders:[ADTestURLResponse defaultHeaders]];
+
+    [ADTestURLSession addResponse:response];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority when server is unreachable."];
+    
+    [authorityValidation validateAuthority:requestParams
+                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    {
+        XCTAssertFalse(validated);
+        XCTAssertNotNil(error);
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectationsWithTimeout:1 handler:nil];
+    
+    XCTAssertFalse([authorityValidation isAuthorityValidated:[NSURL URLWithString:authority]]);
+}
+
+@end

--- a/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
@@ -47,11 +47,6 @@
     [super tearDown];
 }
 
-- (void)testExample {
-    // This is an example of a functional test case.
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-}
-
 - (void)testAdfsNormalOnPrems
 {
     NSString* authority = @"https://login.windows.com/adfs";


### PR DESCRIPTION
No code changes here, just splitting these tests into two files so that subsequent PRs are less confusing. :)