### PR TITLE
Add a wait semaphore to the url session mock 

### DIFF
--- a/ADAL/tests/ADTestURLResponse.h
+++ b/ADAL/tests/ADTestURLResponse.h
@@ -36,6 +36,7 @@
     NSData *_responseData;
     NSURLResponse *_response;
     NSError *_error;
+    dispatch_semaphore_t _waitSemaphore;
 }
 
 + (NSDictionary *)defaultHeaders;
@@ -83,6 +84,8 @@
           headerFields:(NSDictionary *)headerFields;
 - (void)setResponseJSON:(id)jsonResponse;
 - (void)setResponseData:(NSData *)response;
+
+- (void)setWaitSemaphore:(dispatch_semaphore_t)sem;
 
 - (BOOL)matchesURL:(NSURL *)url;
 - (BOOL)matchesBody:(NSData *)body;

--- a/ADAL/tests/ADTestURLResponse.h
+++ b/ADAL/tests/ADTestURLResponse.h
@@ -85,6 +85,10 @@
 - (void)setResponseJSON:(id)jsonResponse;
 - (void)setResponseData:(NSData *)response;
 
+/*!
+    Set a semaphore that ADTestURLSession will wait on until it is signalled in the test. The test
+    must signal this semaphore or else the test will deadlock.
+ */
 - (void)setWaitSemaphore:(dispatch_semaphore_t)sem;
 
 - (BOOL)matchesURL:(NSURL *)url;

--- a/ADAL/tests/ADTestURLResponse.m
+++ b/ADAL/tests/ADTestURLResponse.m
@@ -257,6 +257,11 @@
     _requestHeaders[@"Content-Length"] = [NSString stringWithFormat:@"%lu", (unsigned long)[urlEncoded lengthOfBytesUsingEncoding:NSUTF8StringEncoding]];
 }
 
+- (void)setWaitSemaphore:(dispatch_semaphore_t)sem
+{
+    _waitSemaphore = sem;
+}
+
 - (BOOL)matchesURL:(NSURL *)url
 {
     // Start with making sure the base URLs match up

--- a/ADAL/tests/ADTestURLSessionDataTask.m
+++ b/ADAL/tests/ADTestURLSessionDataTask.m
@@ -69,6 +69,11 @@
         return;
     }
     
+    if (response->_waitSemaphore)
+    {
+        dispatch_semaphore_wait(response->_waitSemaphore, DISPATCH_TIME_FOREVER);
+    }
+    
     if (response->_error)
     {
         [self.session dispatchIfNeed:^{


### PR DESCRIPTION
So tests can ensure things happen in the proper order they are trying to test