### PR TITLE
Add clearAadCache to ADTestCase teardown

### DIFF
--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -28,6 +28,7 @@
 
 #import "ADTestCase.h"
 #import "ADClientMetrics.h"
+#import "ADAuthorityValidation+TestUtil.h"
 
 @implementation ADTestCase
 
@@ -39,8 +40,10 @@
 
 - (void)tearDown
 {
-    [super tearDown];
     [[ADClientMetrics getInstance] clearMetrics];
+    [ADAuthorityValidation clearAadCache];
+
+    [super tearDown];
 }
 
 

--- a/ADAL/tests/util/ADAadAuthorityCache+TestUtil.h
+++ b/ADAL/tests/util/ADAadAuthorityCache+TestUtil.h
@@ -33,4 +33,6 @@
 - (BOOL)tryWriteLock;
 - (BOOL)unlock;
 
+- (void)clear;
+
 @end

--- a/ADAL/tests/util/ADAadAuthorityCache+TestUtil.m
+++ b/ADAL/tests/util/ADAadAuthorityCache+TestUtil.m
@@ -57,4 +57,11 @@
     return 0 == pthread_rwlock_unlock(&_rwLock);
 }
 
+- (void)clear
+{
+    [self grabWriteLock];
+    [_recordMap removeAllObjects];
+    [self unlock];
+}
+
 @end

--- a/ADAL/tests/util/ADAuthorityValidation+TestUtil.h
+++ b/ADAL/tests/util/ADAuthorityValidation+TestUtil.h
@@ -25,4 +25,6 @@
 
 @interface ADAuthorityValidation (TestUtil)
 
++ (void)clearAadCache;
+
 @end

--- a/ADAL/tests/util/ADAuthorityValidation+TestUtil.m
+++ b/ADAL/tests/util/ADAuthorityValidation+TestUtil.m
@@ -22,7 +22,13 @@
 // THE SOFTWARE.
 
 #import "ADAuthorityValidation+TestUtil.h"
+#import "ADAadAuthorityCache+TestUtil.h"
 
 @implementation ADAuthorityValidation (TestUtil)
+
++ (void)clearAadCache
+{
+    [[ADAuthorityValidation sharedInstance]->_aadCache clear];
+}
 
 @end


### PR DESCRIPTION
- Add a clear cache path in ADAuthorityValidation+TestUtil and ADAadAuthorityCache+TestUtil.

In this case I’m clearing it out “correctly” respecting the current locking out of an abundance of caution.