### PR TITLE
Make sure SPE info is not-nil before trying to set it

### DIFF
--- a/ADAL/src/request/ADWebAuthResponse.m
+++ b/ADAL/src/request/ADWebAuthResponse.m
@@ -308,7 +308,11 @@
     if (![NSString adIsStringNilOrBlank:clientTelemetry])
     {
         NSString *speInfo = [clientTelemetry parsedClientTelemetry][AD_TELEMETRY_KEY_SPE_INFO];
-        [_responseDictionary setObject:speInfo forKey:AD_TELEMETRY_KEY_SPE_INFO];
+        
+        if (![NSString adIsStringNilOrBlank:speInfo])
+        {
+            [_responseDictionary setObject:speInfo forKey:AD_TELEMETRY_KEY_SPE_INFO];
+        }
     }
     
     [self handleSuccess:completionBlock];


### PR DESCRIPTION
Just realized that SPE info is not always set and it needs double checking for nil