### PR TITLE
Check for NSNull class in adIsStringNilOrBlank

### DIFF
--- a/ADAL/src/utils/NSString+ADHelperMethods.m
+++ b/ADAL/src/utils/NSString+ADHelperMethods.m
@@ -272,7 +272,7 @@ static inline void Encode3bytesTo4bytes(char* output, int b0, int b1, int b2)
 
 + (BOOL)adIsStringNilOrBlank:(NSString *)string
 {
-    if (!string || !string.length)
+    if (!string || [string isKindOfClass:[NSNull class]] || !string.length)
     {
         return YES;
     }

--- a/ADAL/tests/unit/ADTestNSStringHelperMethods.m
+++ b/ADAL/tests/unit/ADTestNSStringHelperMethods.m
@@ -45,6 +45,11 @@
     XCTAssertTrue([NSString adIsStringNilOrBlank:nil], "Should return true for nil.");
 }
 
+- (void)testIsStringNilOrBlank_whenNSNull_shouldReturnTrue
+{
+    XCTAssertTrue([NSString adIsStringNilOrBlank:(NSString *)[NSNull null]]);
+}
+
 - (void)testIsStringNilOrBlankSpace
 {
     XCTAssertTrue([NSString adIsStringNilOrBlank:@" "], "Should return true for nil.");


### PR DESCRIPTION
Fixes #1054 

Apple JSON parser will emit a `NSNull` in the case of a null in JSON, which while techincially correct creates a not-nil-nil situation that often trips up our code. Because usually one of the first things we do when validation JSON is pipe it into adIsStringNilOrBlank checking adIsStringNilOrBlank here will catch a number of cases that otherwise crash.