### PR TITLE
Server telemetry should ignore zeroes

### DIFF
--- a/ADAL/src/utils/NSString+ADTelemetryExtensions.m
+++ b/ADAL/src/utils/NSString+ADTelemetryExtensions.m
@@ -32,6 +32,12 @@
         [_DICT setObject:_OBJECT forKey:_KEY]; \
     } \
 
+#define CHECK_AND_SET_OBJ_IF_NOT_ZERO(_DICT, _OBJECT, _KEY) \
+    if (![NSString adIsStringNilOrBlank:_OBJECT] && ![_OBJECT isEqualToString:@"0"]) \
+    { \
+        [_DICT setObject:_OBJECT forKey:_KEY]; \
+    } \
+
 @implementation NSString (ADTelemetryExtensions)
 
 - (NSDictionary *)parsedClientTelemetry
@@ -49,8 +55,8 @@
             if ([telemetryComponents[0] isEqualToString:AD_CLIENT_TELEMETRY_VERSION_NUMBER])
             {
                 // Fill in the data
-                CHECK_AND_SET_OBJ(telemetryDict, telemetryComponents[1], AD_TELEMETRY_KEY_SERVER_ERROR_CODE);
-                CHECK_AND_SET_OBJ(telemetryDict, telemetryComponents[2], AD_TELEMETRY_KEY_SERVER_SUBERROR_CODE);
+                CHECK_AND_SET_OBJ_IF_NOT_ZERO(telemetryDict, telemetryComponents[1], AD_TELEMETRY_KEY_SERVER_ERROR_CODE);
+                CHECK_AND_SET_OBJ_IF_NOT_ZERO(telemetryDict, telemetryComponents[2], AD_TELEMETRY_KEY_SERVER_SUBERROR_CODE);
                 CHECK_AND_SET_OBJ(telemetryDict, telemetryComponents[3], AD_TELEMETRY_KEY_RT_AGE);
                 CHECK_AND_SET_OBJ(telemetryDict, telemetryComponents[4], AD_TELEMETRY_KEY_SPE_INFO);
             }

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -1277,8 +1277,8 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.api_error_code"] isEqualToString:@"AD_ERROR_SUCCEEDED"]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.oauth_error_code"] isEqualToString:@""]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.is_successfull"] isEqualToString:@"yes"]);
-    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_error_code"], @"");
-    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_sub_error_code"], @"");
+    XCTAssertNil([event objectForKey:@"Microsoft.ADAL.server_error_code"]);
+    XCTAssertNil([event objectForKey:@"Microsoft.ADAL.server_sub_error_code"]);
     XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.rt_age"], @"2550.0643");
     XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.spe_info"], @"I");
     

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -1277,8 +1277,8 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.api_error_code"] isEqualToString:@"AD_ERROR_SUCCEEDED"]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.oauth_error_code"] isEqualToString:@""]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.is_successfull"] isEqualToString:@"yes"]);
-    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_error_code"], @"0");
-    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_sub_error_code"], @"0");
+    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_error_code"], @"");
+    XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.server_sub_error_code"], @"");
     XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.rt_age"], @"2550.0643");
     XCTAssertEqualObjects([event objectForKey:@"Microsoft.ADAL.spe_info"], @"I");
     

--- a/ADAL/tests/unit/NSStringTelemetryExtensionsTests.m
+++ b/ADAL/tests/unit/NSStringTelemetryExtensionsTests.m
@@ -109,4 +109,30 @@
     XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.ADAL.spe_info"], @"I");
 }
 
+- (void)testParsedClientTelemetry_whenErrorSubErrorHaveZeroesRtAgeEmpty_shouldReturnOnlySpeInfo
+{
+    NSString *clientTelemetry = @"1,0,0,,I";
+    
+    NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
+    
+    XCTAssertNotNil(parsedTelemetry);
+    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.ADAL.server_error_code"]);
+    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.ADAL.server_sub_error_code"]);
+    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.ADAL.rt_age"]);
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.ADAL.spe_info"], @"I");
+}
+
+- (void)testParsedClientTelemetry_whenErrorHasZeroes_shouldReturnAllPropertiesButErrorCode
+{
+    NSString *clientTelemetry = @"1,0,5,200.5,I";
+    
+    NSDictionary *parsedTelemetry = [clientTelemetry parsedClientTelemetry];
+    
+    XCTAssertNotNil(parsedTelemetry);
+    XCTAssertNil([parsedTelemetry objectForKey:@"Microsoft.ADAL.server_error_code"]);
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.ADAL.server_sub_error_code"], @"5");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.ADAL.rt_age"], @"200.5");
+    XCTAssertEqualObjects([parsedTelemetry objectForKey:@"Microsoft.ADAL.spe_info"], @"I");
+}
+
 @end


### PR DESCRIPTION
Ignore server error and sub error code values, if they are equal to "0" to optimize payload size