### PR TITLE
-[ADAadAuthorityCache cacheAliasesForAuthority:]

### DIFF
--- a/ADAL/src/validation/ADAadAuthorityCache.h
+++ b/ADAL/src/validation/ADAadAuthorityCache.h
@@ -51,6 +51,14 @@
 - (NSURL *)networkUrlForAuthority:(NSURL *)authority;
 - (NSURL *)cacheUrlForAuthority:(NSURL *)authority;
 
+/*!
+    Returns an array of authority URLs for the provided URL, in the order that cache lookups
+    should be attempted.
+ 
+    @param  authority   The authority URL the developer provided for the authority context
+ */
+- (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority;
+
 - (ADAadAuthorityCacheRecord *)tryCheckCache:(NSURL *)authority;
 - (ADAadAuthorityCacheRecord *)checkCache:(NSURL *)authority;
 

--- a/ADAL/src/validation/ADAadAuthorityCache.m
+++ b/ADAL/src/validation/ADAadAuthorityCache.m
@@ -330,7 +330,7 @@ static NSURL *urlForPreferredHost(NSURL *url, NSString *preferredHost)
     
     NSArray<NSString *> *aliases = record.aliases;
     NSString *cacheHost = record.cacheHost;
-    NSString *host = authority.host;
+    NSString *host = authority.adHostWithPortIfNecessary;
     if (cacheHost)
     {
         // The cache lookup order for authorities is defined as the preferred host first

--- a/ADAL/src/validation/ADAadAuthorityCache.m
+++ b/ADAL/src/validation/ADAadAuthorityCache.m
@@ -317,4 +317,48 @@ static NSURL *urlForPreferredHost(NSURL *url, NSString *preferredHost)
     return urlForPreferredHost(authority, record.cacheHost);
 }
 
+- (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority
+{
+    NSMutableArray<NSURL *> *authorities = [NSMutableArray new];
+    
+    __auto_type record = [self checkCache:authority];
+    if (!record)
+    {
+        [authorities addObject:authority];
+        return authorities;
+    }
+    
+    NSArray<NSString *> *aliases = record.aliases;
+    NSString *cacheHost = record.cacheHost;
+    NSString *host = authority.host;
+    if (cacheHost)
+    {
+        // The cache lookup order for authorities is defined as the preferred host first
+        [authorities addObject:urlForPreferredHost(authority, cacheHost)];
+        if (![cacheHost isEqualToString:host])
+        {
+            // Followed by the authority provided by the developer, provided here by the authority
+            // URL passed into this method
+            [authorities addObject:authority];
+        }
+    }
+    else
+    {
+        [authorities addObject:authority];
+    }
+    
+    // And then we add any remaining aliases listed in the metadata
+    for (NSString *alias in aliases)
+    {
+        if ([alias isEqualToString:host] || (cacheHost && [alias isEqualToString:cacheHost]))
+        {
+            continue;
+        }
+        
+        [authorities addObject:urlForPreferredHost(authority, alias)];
+    }
+    
+    return authorities;
+}
+
 @end

--- a/ADAL/src/validation/ADAuthorityValidation.h
+++ b/ADAL/src/validation/ADAuthorityValidation.h
@@ -63,6 +63,8 @@ typedef void(^ADAuthorityValidationCallback)(BOOL validated, ADAuthenticationErr
 
 - (NSURL *)networkUrlForAuthority:(NSURL *)authority
                           context:(id<ADRequestContext>)context;
+- (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority;
+
 @end
 
 

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -326,6 +326,16 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     return url;
 }
 
+- (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority
+{
+    if ([ADHelpers isADFSInstanceURL:authority])
+    {
+        return @[ authority ];
+    }
+    
+    return [_aadCache cacheAliasesForAuthority:authority];
+}
+
 
 #pragma mark - ADFS authority validation
 - (void)validateADFSAuthority:(NSURL *)authority

--- a/ADAL/tests/unit/ADAadAuthorityCacheTests.m
+++ b/ADAL/tests/unit/ADAadAuthorityCacheTests.m
@@ -419,6 +419,29 @@
     XCTAssertEqualObjects(aliases, expected);
 }
 
+- (void)testCacheAliasesForAuthority_withPortDifferentPreferredCache_shouldReturnArrayInProperOrder
+{
+    ADAadAuthorityCache *cache = [[ADAadAuthorityCache alloc] init];
+    NSURL *authority = [NSURL URLWithString:@"https://login.contoso.com:8888/endpoint"];
+    __auto_type record = [ADAadAuthorityCacheRecord new];
+    record.validated = YES;
+    record.networkHost = @"login.contoso.com:8888";
+    record.cacheHost = @"login.contoso.net:9000";
+    record.aliases = @[ @"sts.contoso.com", @"login.contoso.net:9000", @"sts.contoso.net", @"login.contoso.com:8888" ];
+    cache.recordMap = @{ @"login.contoso.com:8888" : record };
+    // cacheAliasesForAuthority should be returning the preferred host first
+    NSArray *expected = @[[NSURL URLWithString:@"https://login.contoso.net:9000/endpoint"],
+                          // The host the API was called with second
+                          authority,
+                          // And then any remaining hosts in the alias list
+                          [NSURL URLWithString:@"https://sts.contoso.com/endpoint"],
+                          [NSURL URLWithString:@"https://sts.contoso.net/endpoint"]];
+    
+    NSArray *aliases = [cache cacheAliasesForAuthority:authority];
+    
+    XCTAssertEqualObjects(aliases, expected);
+}
+
 #pragma mark -
 #pragma mark Process Metadata tests
 

--- a/ADAL/tests/unit/ADAadAuthorityCacheTests.m
+++ b/ADAL/tests/unit/ADAadAuthorityCacheTests.m
@@ -355,6 +355,71 @@
 }
 
 #pragma mark -
+#pragma mark Cache Aliases tests
+
+- (void)testCacheAliasesForAuthority_whenNilCache_shouldReturnArrayWithAuthority
+{
+    ADAadAuthorityCache *cache = [[ADAadAuthorityCache alloc] init];
+    NSURL *authority = [NSURL URLWithString:@"https://login.contoso.com/endpoint"];
+    
+    NSArray *aliases = [cache cacheAliasesForAuthority:authority];
+    
+    XCTAssertEqualObjects(aliases, @[authority]);
+}
+
+- (void)testCacheAliasesForAuthority_withNoMetadata_shouldReturnArrayWithAuthority
+{
+    ADAadAuthorityCache *cache = [[ADAadAuthorityCache alloc] init];
+    NSURL *authority = [NSURL URLWithString:@"https://login.contoso.com/endpoint"];
+    __auto_type record = [ADAadAuthorityCacheRecord new];
+    record.validated = YES;
+    cache.recordMap = @{ @"login.contoso.com" : record };
+    
+    NSArray *aliases = [cache cacheAliasesForAuthority:authority];
+    
+    XCTAssertEqualObjects(aliases, @[authority]);
+}
+
+- (void)testCacheAliasesForAuthority_withSimpleMetadata_shouldReturnArrayWithAuthority
+{
+    ADAadAuthorityCache *cache = [[ADAadAuthorityCache alloc] init];
+    NSURL *authority = [NSURL URLWithString:@"https://login.contoso.com/endpoint"];
+    __auto_type record = [ADAadAuthorityCacheRecord new];
+    record.validated = YES;
+    record.networkHost = @"login.contoso.com";
+    record.cacheHost = @"login.contoso.com";
+    record.aliases = @[ @"login.contoso.com" ];
+    cache.recordMap = @{ @"login.contoso.com" : record };
+    
+    NSArray *aliases = [cache cacheAliasesForAuthority:authority];
+    
+    XCTAssertEqualObjects(aliases, @[authority]);
+}
+
+- (void)testCacheAliasesForAuthority_withDifferentPreferredCache_shouldReturnArrayInProperOrder
+{
+    ADAadAuthorityCache *cache = [[ADAadAuthorityCache alloc] init];
+    NSURL *authority = [NSURL URLWithString:@"https://login.contoso.com/endpoint"];
+    __auto_type record = [ADAadAuthorityCacheRecord new];
+    record.validated = YES;
+    record.networkHost = @"login.contoso.com";
+    record.cacheHost = @"login.contoso.net";
+    record.aliases = @[ @"sts.contoso.com", @"login.contoso.net", @"sts.contoso.net", @"login.contoso.com" ];
+    cache.recordMap = @{ @"login.contoso.com" : record };
+                          // cacheAliasesForAuthority should be returning the preferred host first
+    NSArray *expected = @[[NSURL URLWithString:@"https://login.contoso.net/endpoint"],
+                          // The host the API was called with second
+                          authority,
+                          // And then any remaining hosts in the alias list
+                          [NSURL URLWithString:@"https://sts.contoso.com/endpoint"],
+                          [NSURL URLWithString:@"https://sts.contoso.net/endpoint"]];
+    
+    NSArray *aliases = [cache cacheAliasesForAuthority:authority];
+    
+    XCTAssertEqualObjects(aliases, expected);
+}
+
+#pragma mark -
 #pragma mark Process Metadata tests
 
 - (void)testProcessMetadata_whenNilMetadata_shouldCreateDefaultEntry


### PR DESCRIPTION
Utility API for retrieving all valid authority aliases for a given authority URL, in priority order.