### PR TITLE
Authority Migration Cache Writing

### DIFF
--- a/ADAL/src/cache/ADTokenCacheAccessor.m
+++ b/ADAL/src/cache/ADTokenCacheAccessor.m
@@ -87,6 +87,9 @@
                                                       userId:userId
                                                correlationId:[context correlationId]
                                                        error:&adError];
+        item.storageAuthority = item.authority;
+        item.authority = _authority;
+        
         if (item)
         {
             return item;
@@ -292,7 +295,7 @@
         multiRefreshTokenItem.accessToken = nil;
         multiRefreshTokenItem.resource = nil;
         multiRefreshTokenItem.expiresOn = nil;
-        [_dataSource addOrUpdateItem:multiRefreshTokenItem correlationId:correlationId error:nil];
+        [self addOrUpdateItem:multiRefreshTokenItem context:context error:nil];
         ADTelemetryCacheEvent* event = [[ADTelemetryCacheEvent alloc] initWithName:AD_TELEMETRY_EVENT_TOKEN_CACHE_WRITE
                                                                            context:context];
         [event setIsMRRT:AD_TELEMETRY_VALUE_YES];
@@ -310,7 +313,7 @@
             ADTokenCacheItem* frtItem = [multiRefreshTokenItem copy];
             NSString* fociClientId = [ADTokenCacheAccessor familyClientId:familyId];
             frtItem.clientId = fociClientId;
-            [_dataSource addOrUpdateItem:frtItem correlationId:correlationId error:nil];
+            [self addOrUpdateItem:frtItem context:context error:nil];
             
             ADTelemetryCacheEvent* event = [[ADTelemetryCacheEvent alloc] initWithName:AD_TELEMETRY_EVENT_TOKEN_CACHE_WRITE
                                                                                context:context];
@@ -323,13 +326,27 @@
     
     AD_LOG_VERBOSE_F(@"Token cache store", correlationId, @"Storing access token for resource: %@", cacheItem.resource);
     [[ADTelemetry sharedInstance] startEvent:telemetryRequestId eventName:AD_TELEMETRY_EVENT_TOKEN_CACHE_WRITE];
-    [_dataSource addOrUpdateItem:cacheItem correlationId:correlationId error:nil];
+    [self addOrUpdateItem:cacheItem context:context error:nil];
     cacheItem.refreshToken = savedRefreshToken;//Restore for the result
     ADTelemetryCacheEvent* event = [[ADTelemetryCacheEvent alloc] initWithName:AD_TELEMETRY_EVENT_TOKEN_CACHE_WRITE
                                                                        context:context];
     [event setTokenType:AD_TELEMETRY_VALUE_ACCESS_TOKEN];
     [event setSpeInfo:cacheItem.speInfo];
     [[ADTelemetry sharedInstance] stopEvent:telemetryRequestId event:event];
+}
+
+- (BOOL)addOrUpdateItem:(nonnull ADTokenCacheItem *)item
+                context:(id<ADRequestContext>)context
+                  error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    NSURL *oldAuthority = [NSURL URLWithString:item.authority];
+    NSURL *newAuthority = [[ADAuthorityValidation sharedInstance] cacheUrlForAuthority:oldAuthority context:context];
+    
+    item.authority = [newAuthority absoluteString];
+    BOOL ret = [_dataSource addOrUpdateItem:item correlationId:context.correlationId error:error];
+    item.authority = [oldAuthority absoluteString];
+    
+    return ret;
 }
 
 - (void)removeItemFromCache:(ADTokenCacheItem *)cacheItem
@@ -342,52 +359,52 @@
         return;
     }
     
-    NSUUID* correlationId = [context correlationId];
-    [[ADTelemetry sharedInstance] startEvent:[context telemetryRequestId] eventName:AD_TELEMETRY_EVENT_TOKEN_CACHE_DELETE];
-    BOOL removed = NO;
-    //The refresh token didn't work. We need to tombstone this refresh item in the cache.
-    ADTokenCacheKey* exactKey = [cacheItem extractKey:nil];
-    if (exactKey)
-    {
-        ADTokenCacheItem* existing = [_dataSource getItemWithKey:exactKey userId:cacheItem.userInformation.userId correlationId:correlationId error:nil];
-        if ([refreshToken isEqualToString:existing.refreshToken])//If still there, attempt to remove
-        {
-            AD_LOG_VERBOSE_F(@"Token cache store", correlationId, @"Tombstoning cache for resource: %@", cacheItem.resource);
-            //update tombstone property before update the tombstone in cache
-            [existing makeTombstone:@{ @"correlationId" : [correlationId UUIDString],
-                                       @"errorDetails" : [error errorDetails],
-                                       @"protocolCode" : [error protocolCode] }];
-            [_dataSource addOrUpdateItem:existing correlationId:correlationId error:nil];
-            removed = YES;
-        }
-    }
     
-    if (!removed)
-    {
-        //Now try finding a broad refresh token in the cache and tombstone it accordingly
-        ADTokenCacheKey* broadKey = [ADTokenCacheKey keyWithAuthority:_authority
-                                                             resource:nil
-                                                             clientId:cacheItem.clientId
-                                                                error:nil];
-        if (broadKey)
-        {
-            ADTokenCacheItem* broadItem = [_dataSource getItemWithKey:broadKey userId:cacheItem.userInformation.userId correlationId:correlationId error:nil];
-            if (broadItem && [refreshToken isEqualToString:broadItem.refreshToken])//Remove if still there
-            {
-                AD_LOG_VERBOSE_F(@"Token cache store", correlationId, @"Tombstoning multi-resource refresh token for authority: %@", _authority);
-                //update tombstone property before update the tombstone in cache
-                [broadItem makeTombstone:@{ @"correlationId" : [correlationId UUIDString],
-                                            @"errorDetails" : [error errorDetails],
-                                            @"protocolCode" : [error protocolCode] }];
-                [_dataSource addOrUpdateItem:broadItem correlationId:correlationId error:nil];
-            }
-        }
-    }
     ADTelemetryCacheEvent* event = [[ADTelemetryCacheEvent alloc] initWithName:AD_TELEMETRY_EVENT_TOKEN_CACHE_DELETE
                                                                        context:context];
-    
     [event setSpeInfo:cacheItem.speInfo];
+    [[ADTelemetry sharedInstance] startEvent:[context telemetryRequestId] eventName:AD_TELEMETRY_EVENT_TOKEN_CACHE_DELETE];
+    [self removeImpl:cacheItem refreshToken:refreshToken context:context error:error];
     [[ADTelemetry sharedInstance] stopEvent:[context telemetryRequestId] event:event];
+}
+
+- (void)removeImpl:(ADTokenCacheItem *)cacheItem
+      refreshToken:(NSString *)refreshToken
+           context:(id<ADRequestContext>)context
+             error:(ADAuthenticationError *)error
+{
+    //The refresh token didn't work. We need to tombstone this refresh item in the cache.
+    ADTokenCacheKey* cacheKey = [cacheItem extractKey:nil];
+    if (!cacheKey)
+    {
+        return;
+    }
+    
+    NSUUID* correlationId = [context correlationId];
+    
+    ADTokenCacheItem* existing = [_dataSource getItemWithKey:cacheKey
+                                                      userId:cacheItem.userInformation.userId
+                                               correlationId:correlationId
+                                                       error:nil];
+    if (!existing)
+    {
+        existing = [_dataSource getItemWithKey:[cacheKey mrrtKey]
+                                        userId:cacheItem.userInformation.userId
+                                 correlationId:correlationId
+                                         error:nil];
+    }
+    
+    if (!existing || ![refreshToken isEqualToString:existing.refreshToken])
+    {
+        return;
+    }
+    
+    AD_LOG_VERBOSE_F(@"Token cache store", correlationId, @"Tombstoning cache for resource: %@", cacheItem.resource);
+    //update tombstone property before update the tombstone in cache
+    [existing makeTombstone:@{ @"correlationId" : [correlationId UUIDString],
+                               @"errorDetails" : [error errorDetails],
+                               @"protocolCode" : [error protocolCode] }];
+    [_dataSource addOrUpdateItem:existing correlationId:correlationId error:nil];
 }
 
 @end

--- a/ADAL/src/cache/ADTokenCacheAccessor.m
+++ b/ADAL/src/cache/ADTokenCacheAccessor.m
@@ -342,6 +342,9 @@
     NSURL *oldAuthority = [NSURL URLWithString:item.authority];
     NSURL *newAuthority = [[ADAuthorityValidation sharedInstance] cacheUrlForAuthority:oldAuthority context:context];
     
+    // The authority used to retrieve the item over the network can differ from the preferred authority used to
+    // cache the item. As it would be awkward to cache an item using an authority other then the one we store
+    // it with we switch it out before saving it to cache.
     item.authority = [newAuthority absoluteString];
     BOOL ret = [_dataSource addOrUpdateItem:item correlationId:context.correlationId error:error];
     item.authority = [oldAuthority absoluteString];

--- a/ADAL/src/cache/ADTokenCacheItem+Internal.h
+++ b/ADAL/src/cache/ADTokenCacheItem+Internal.h
@@ -41,6 +41,12 @@
 
 @end
 
+@interface ADTokenCacheItem ()
+
+@property NSString *storageAuthority;
+
+@end
+
 @interface ADTokenCacheItem (Internal)
 
 - (void)checkCorrelationId:(NSDictionary*)response

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -30,6 +30,9 @@
 #import "ADTokenCacheItem+Internal.h"
 
 @implementation ADTokenCacheItem
+{
+    NSString *_storageAuthority;
+}
 
 @synthesize accessToken = _accessToken;
 @synthesize accessTokenType = _accessTokenType;
@@ -37,7 +40,7 @@
 @synthesize refreshToken = _refreshToken;
 @synthesize sessionKey = _sessionKey;
 @synthesize familyId = _familyId;
-@synthesize storageAuthority;
+@synthesize storageAuthority = _storageAuthority;
 
 + (void)load
 {
@@ -91,10 +94,9 @@
 
 - (ADTokenCacheKey*)extractKey:(ADAuthenticationError* __autoreleasing *)error
 {
-    NSString *storageAuthority = self.storageAuthority;
-    if (storageAuthority)
+    if (_storageAuthority)
     {
-        return [ADTokenCacheKey keyWithAuthority:storageAuthority
+        return [ADTokenCacheKey keyWithAuthority:_storageAuthority
                                         resource:_resource
                                         clientId:_clientId
                                            error:error];

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -37,6 +37,7 @@
 @synthesize refreshToken = _refreshToken;
 @synthesize sessionKey = _sessionKey;
 @synthesize familyId = _familyId;
+@synthesize storageAuthority;
 
 + (void)load
 {
@@ -90,6 +91,15 @@
 
 - (ADTokenCacheKey*)extractKey:(ADAuthenticationError* __autoreleasing *)error
 {
+    NSString *storageAuthority = self.storageAuthority;
+    if (storageAuthority)
+    {
+        return [ADTokenCacheKey keyWithAuthority:storageAuthority
+                                        resource:_resource
+                                        clientId:_clientId
+                                           error:error];
+    }
+    
     return [ADTokenCacheKey keyWithAuthority:_authority
                                     resource:_resource
                                     clientId:_clientId

--- a/ADAL/src/cache/ADTokenCacheKey.h
+++ b/ADAL/src/cache/ADTokenCacheKey.h
@@ -55,5 +55,7 @@
 /*! The application client identifier */
 @property (readonly) NSString* clientId;
 
+- (ADTokenCacheKey *)mrrtKey;
+
 
 @end

--- a/ADAL/src/cache/ADTokenCacheKey.m
+++ b/ADAL/src/cache/ADTokenCacheKey.m
@@ -155,4 +155,9 @@
     return key;
 }
 
+- (ADTokenCacheKey *)mrrtKey
+{
+    return [[self class] keyWithAuthority:_authority resource:nil clientId:_clientId error:nil];
+}
+
 @end

--- a/ADAL/src/validation/ADAuthorityValidation.h
+++ b/ADAL/src/validation/ADAuthorityValidation.h
@@ -63,6 +63,8 @@ typedef void(^ADAuthorityValidationCallback)(BOOL validated, ADAuthenticationErr
 
 - (NSURL *)networkUrlForAuthority:(NSURL *)authority
                           context:(id<ADRequestContext>)context;
+- (NSURL *)cacheUrlForAuthority:(NSURL *)authority
+                        context:(id<ADRequestContext>)context;
 - (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority;
 
 @end

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -326,6 +326,25 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     return url;
 }
 
+- (NSURL *)cacheUrlForAuthority:(NSURL *)authority
+                        context:(id<ADRequestContext>)context
+{
+    if ([ADHelpers isADFSInstanceURL:authority])
+    {
+        return authority;
+    }
+    
+    NSURL *url = [_aadCache cacheUrlForAuthority:authority];
+    if (!url)
+    {
+        AD_LOG_WARN(@"No cached preferred_cache for authority", context.correlationId, nil);
+        return authority;
+    }
+    
+    
+    return url;
+}
+
 - (NSArray<NSURL *> *)cacheAliasesForAuthority:(NSURL *)authority
 {
     if ([ADHelpers isADFSInstanceURL:authority])

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -141,6 +141,8 @@
 - (ADTokenCacheItem *)adCreateATCacheItem;
 - (ADTokenCacheItem *)adCreateATCacheItem:(NSString *)resource
                                    userId:(NSString *)userId;
+
++ (ADTokenCacheItem *)adCreateMRRTCacheItem;
 - (ADTokenCacheItem *)adCreateMRRTCacheItem;
 - (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId;
 - (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -146,17 +146,17 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     return item;
 }
 
-- (ADTokenCacheItem *)adCreateMRRTCacheItem
++ (ADTokenCacheItem *)adCreateMRRTCacheItem
 {
     return [self adCreateMRRTCacheItem:TEST_USER_ID familyId:nil];
 }
 
-- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
++ (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
 {
     return [self adCreateMRRTCacheItem:userId familyId:nil];
 }
 
-- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
++ (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
                                    familyId:(NSString *)foci
 {
     // A MRRT item is just a refresh token, it doesn't have a specified resource
@@ -172,6 +172,22 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     }
     
     return item;
+}
+
+- (ADTokenCacheItem *)adCreateMRRTCacheItem
+{
+    return [[self class] adCreateMRRTCacheItem:TEST_USER_ID familyId:nil];
+}
+
+- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
+{
+    return [[self class] adCreateMRRTCacheItem:userId familyId:nil];
+}
+
+- (ADTokenCacheItem *)adCreateMRRTCacheItem:(NSString *)userId
+                                   familyId:(NSString *)foci
+{
+    return [[self class] adCreateMRRTCacheItem:userId familyId:foci];
 }
 
 - (ADTokenCacheItem *)adCreateFRTCacheItem
@@ -207,7 +223,7 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     return key;
 }
 
-- (ADUserInformation *)adCreateUserInformation:(NSString*)userId
++ (ADUserInformation *)adCreateUserInformation:(NSString*)userId
 {
     NSAssert(userId, @"userId cannot be nil!");
     NSDictionary* part1_claims = @{ @"typ" : @"JWT",
@@ -237,6 +253,11 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     // If you're hitting this you might as well fix it before trying to run other tests.
     NSAssert(userInfo, @"Failed to create a userinfo object from a static idtoken. Something must have horribly broke,");
     return userInfo;
+}
+
+- (ADUserInformation *)adCreateUserInformation:(NSString*)userId
+{
+    return [[self class] adCreateUserInformation:userId];
 }
 
 - (ADTestURLResponse *)adResponseBadRefreshToken:(NSString *)refreshToken

--- a/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
@@ -432,48 +432,106 @@
     [self waitForExpectations:@[expectation1, expectation2] timeout:1.0];
 }
 
+static ADTokenCacheItem *getToken(ADTokenCache *tokenCache, NSString *authority, NSString *clientId, NSString *resource)
+{
+    ADTokenCacheKey *key = [ADTokenCacheKey keyWithAuthority:authority resource:resource clientId:clientId error:nil];
+    return [tokenCache getItemsWithKey:key userId:TEST_USER_ID correlationId:TEST_CORRELATION_ID error:nil].firstObject;
+}
 
-- (void)testAcquireTokenSilent_whenDifferentPreferredCache_shouldUsePreferred
+static NSString *getMRRT(ADTokenCache *tokenCache, NSString *authority)
+{
+    return getToken(tokenCache, authority, TEST_CLIENT_ID, nil).refreshToken;
+}
+
+static NSString *getFRT(ADTokenCache *tokenCache, NSString *authority)
+{
+    return getToken(tokenCache, authority, @"foci-1", nil).refreshToken;
+}
+
+static NSString *getAT(ADTokenCache *tokenCache, NSString *authority)
+{
+    return getToken(tokenCache, authority, TEST_CLIENT_ID, TEST_RESOURCE).accessToken;
+}
+
+
+static NSString *s_doNotUseRT = @"do not use me";
+
+static ADTestURLResponse *
+CreateAuthorityValidationResponse(NSString *contextAuthority,
+                                  NSString *networkAuthority,
+                                  NSString *cacheAuthority)
+{
+    NSURL *contextUrl = [NSURL URLWithString:contextAuthority];
+    NSURL *networkUrl = networkAuthority ? [NSURL URLWithString:networkAuthority] : contextUrl;
+    NSURL *cacheUrl = cacheAuthority ? [NSURL URLWithString:cacheAuthority] : contextUrl;
+    
+    NSMutableSet *aliases = [NSMutableSet new];
+    [aliases addObject:[contextUrl adHostWithPortIfNecessary]];
+    [aliases addObject:[networkUrl adHostWithPortIfNecessary]];
+    [aliases addObject:[cacheUrl adHostWithPortIfNecessary]];
+    
+    NSArray *metadata = @[ @{ @"preferred_network" : [networkUrl adHostWithPortIfNecessary],
+                              @"preferred_cache" : [cacheUrl adHostWithPortIfNecessary],
+                              @"aliases" : [aliases allObjects] } ];
+    return [ADTestAuthorityValidationResponse validAuthority:[networkUrl absoluteString] withMetadata:metadata];
+}
+
+static ADTokenCache *
+CreateMRRTTokenCache(NSString *preferredAuthority,
+                     NSString *doNotUseAuthority)
+{
+    // Cache Setup
+    ADTokenCache *tokenCache = [ADTokenCache new];
+    
+    ADTokenCacheItem *mrrt = [XCTestCase adCreateMRRTCacheItem];
+    mrrt.authority = preferredAuthority;
+    [tokenCache addOrUpdateItem:mrrt correlationId:nil error:nil];
+    
+    // Also add a MRRT in the non-preferred lcoation to ignore
+    if (doNotUseAuthority)
+    {
+        ADTokenCacheItem *otherMrrt = [XCTestCase adCreateMRRTCacheItem];
+        otherMrrt.authority = doNotUseAuthority;
+        otherMrrt.refreshToken = s_doNotUseRT;
+        [tokenCache addOrUpdateItem:otherMrrt correlationId:nil error:nil];
+    }
+    
+    return tokenCache;
+}
+
+static ADAuthenticationContext *
+CreateAuthContext(NSString *authority,
+                  ADTokenCache *tokenCache)
+{
+    ADAuthenticationContext *context = [ADAuthenticationContext authenticationContextWithAuthority:authority error:nil];
+    [context setTokenCacheStore:tokenCache];
+    [context setCorrelationId:TEST_CORRELATION_ID];
+    
+    return context;
+}
+
+- (void)testAcquireTokenSilent_whenNoPreferredCache_shouldWriteToPreferred
 {
     NSString *authority = @"https://login.contoso.com/common";
     NSString *preferredAuthority = @"https://login.contoso.net/common";
     NSString *updatedAT = @"updated-access-token";
     NSString *updatedRT = @"updated-refresh-token";
-    NSString *doNotUseRT = @"do not use me";
     
-    // Network Setup
-    NSArray *metadata = @[ @{ @"preferred_network" : @"login.contoso.com",
-                              @"preferred_cache" : @"login.contoso.net",
-                              @"aliases" : @[ @"login.contoso.net", @"login.contoso.com"] } ];
-    ADTestURLResponse *validationResponse = [ADTestAuthorityValidationResponse validAuthority:authority withMetadata:metadata];
-    ADTestURLResponse *tokenResponse = [self adResponseRefreshToken:TEST_REFRESH_TOKEN
-                                                          authority:authority
-                                                           resource:TEST_RESOURCE
-                                                           clientId:TEST_CLIENT_ID
-                                                      correlationId:TEST_CORRELATION_ID
-                                                    newRefreshToken:updatedRT
-                                                     newAccessToken:updatedAT
-                                                   additionalFields:@{ @"foci" : @"1" }];
-    
+    // Network Responses
+    ADTestURLResponse *tokenResponse =
+    [self adResponseRefreshToken:TEST_REFRESH_TOKEN
+                       authority:authority
+                        resource:TEST_RESOURCE
+                        clientId:TEST_CLIENT_ID
+                   correlationId:TEST_CORRELATION_ID
+                 newRefreshToken:updatedRT
+                  newAccessToken:updatedAT
+                additionalFields:@{ @"foci" : @"1" }];
+    ADTestURLResponse *validationResponse = CreateAuthorityValidationResponse(authority, nil, preferredAuthority);
     [ADTestURLSession addResponses:@[validationResponse, tokenResponse]];
     
-    ADTokenCache *tokenCache = [ADTokenCache new];
-    
-    // Add an MRRT in the preferred location to use
-    ADTokenCacheItem *mrrt = [self adCreateMRRTCacheItem];
-    mrrt.authority = preferredAuthority;
-    [tokenCache addOrUpdateItem:mrrt correlationId:nil error:nil];
-    
-    // Also add a MRRT in the non-preferred lcoation to ignore
-    ADTokenCacheItem *otherMrrt = [self adCreateMRRTCacheItem];
-    mrrt.refreshToken = doNotUseRT;
-    [tokenCache addOrUpdateItem:otherMrrt correlationId:nil error:nil];
-    
-    ADAuthenticationContext *context = [ADAuthenticationContext authenticationContextWithAuthority:authority error:nil];
-    XCTAssertNotNil(context);
-    [context setTokenCacheStore:tokenCache];
-    [context setCorrelationId:TEST_CORRELATION_ID];
-    
+    ADTokenCache *tokenCache = CreateMRRTTokenCache(authority, nil);
+    ADAuthenticationContext *context = CreateAuthContext(authority, tokenCache);
     
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token"];
     [context acquireTokenSilentWithResource:TEST_RESOURCE
@@ -491,6 +549,112 @@
      }];
     
     [self waitForExpectations:@[expectation] timeout:1.0];
+    
+    // Make sure the cache properly updated the AT, MRRT and FRT...
+    XCTAssertEqualObjects(getMRRT(tokenCache, preferredAuthority), updatedRT);
+    XCTAssertEqualObjects(getFRT(tokenCache, preferredAuthority), updatedRT);
+    XCTAssertEqualObjects(getAT(tokenCache, preferredAuthority), updatedAT);
+    
+    // And that the non-preferred location did not get touched
+    XCTAssertEqualObjects(getMRRT(tokenCache, authority), TEST_REFRESH_TOKEN);
+    XCTAssertNil(getFRT(tokenCache, authority));
+    XCTAssertNil(getAT(tokenCache, authority));
+}
+
+- (void)testAcquireTokenSilent_whenDifferentPreferredCache_shouldUsePreferred
+{
+    NSString *authority = @"https://login.contoso.com/common";
+    NSString *preferredAuthority = @"https://login.contoso.net/common";
+    NSString *updatedAT = @"updated-access-token";
+    NSString *updatedRT = @"updated-refresh-token";
+    
+    // Network Responses
+    ADTestURLResponse *tokenResponse =
+    [self adResponseRefreshToken:TEST_REFRESH_TOKEN
+                       authority:authority
+                        resource:TEST_RESOURCE
+                        clientId:TEST_CLIENT_ID
+                   correlationId:TEST_CORRELATION_ID
+                 newRefreshToken:updatedRT
+                  newAccessToken:updatedAT
+                additionalFields:@{ @"foci" : @"1" }];
+    ADTestURLResponse *validationResponse = CreateAuthorityValidationResponse(authority, nil, preferredAuthority);
+    [ADTestURLSession addResponses:@[validationResponse, tokenResponse]];
+    
+    ADTokenCache *tokenCache = CreateMRRTTokenCache(preferredAuthority, authority);
+    ADAuthenticationContext *context = CreateAuthContext(authority, tokenCache);
+    
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token"];
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         
+         // Make sure the cache authority didn't change
+         XCTAssertEqualObjects(result.tokenCacheItem.authority, authority);
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+    
+    // Make sure the cache properly updated the AT, MRRT and FRT...
+    XCTAssertEqualObjects(getMRRT(tokenCache, preferredAuthority), updatedRT);
+    XCTAssertEqualObjects(getFRT(tokenCache, preferredAuthority), updatedRT);
+    XCTAssertEqualObjects(getAT(tokenCache, preferredAuthority), updatedAT);
+    
+    // And that the non-preferred location did not get touched
+    XCTAssertEqualObjects(getMRRT(tokenCache, authority), s_doNotUseRT);
+    XCTAssertNil(getFRT(tokenCache, authority));
+    XCTAssertNil(getAT(tokenCache, authority));
+}
+
+- (void)testAcquireTokenSilent_whenDifferentPreferredCacheAndTokenFails_shouldTombstoneCorrectToken
+{
+    NSString *authority = @"https://login.contoso.com/common";
+    NSString *preferredAuthority = @"https://login.contoso.net/common";
+    
+    // Network Responses
+    ADTestURLResponse *tokenResponse =
+    [self adResponseBadRefreshToken:TEST_REFRESH_TOKEN
+                          authority:authority
+                           resource:TEST_RESOURCE
+                           clientId:TEST_CLIENT_ID
+     // invalid_grant should result in ADAL tombstoning the token
+                         oauthError:@"invalid_grant"
+                      correlationId:TEST_CORRELATION_ID];
+    
+    ADTestURLResponse *validationResponse = CreateAuthorityValidationResponse(authority, nil, preferredAuthority);
+    [ADTestURLSession addResponses:@[validationResponse, tokenResponse]];
+    
+    ADTokenCache *tokenCache = CreateMRRTTokenCache(preferredAuthority, authority);
+    ADAuthenticationContext *context = CreateAuthContext(authority, tokenCache);
+    
+    __block XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token"];
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+    
+    // Make sure the cache properly updated the AT, MRRT and FRT...
+    ADTokenCacheItem *preferredMRRT = getToken(tokenCache, preferredAuthority, TEST_CLIENT_ID, nil);
+    XCTAssertNotNil(preferredMRRT.tombstone);
+    
+    // And that the non-preferred location did not get touched
+    XCTAssertEqualObjects(getMRRT(tokenCache, authority), s_doNotUseRT);
+    XCTAssertNil(getFRT(tokenCache, authority));
+    XCTAssertNil(getAT(tokenCache, authority));
 }
 
 @end


### PR DESCRIPTION
* Write new tokens only to the preferred cache location
* Tokens should be tombstoned in the correct location regardless of preferred cache location