### PR TITLE
Set Authority Validation API version to 1.1

### DIFF
--- a/ADAL/src/validation/ADAuthorityValidationRequest.h
+++ b/ADAL/src/validation/ADAuthorityValidationRequest.h
@@ -25,7 +25,7 @@
 
 // TODO: Set this to 1.1 once PROD deployment goes through to allow it.
 
-#define AAD_AUTHORITY_VALIDATION_API_VERSION "1.0"
+#define AAD_AUTHORITY_VALIDATION_API_VERSION "1.1"
 
 @class ADAuthorityValidationResponse;
 


### PR DESCRIPTION
This is required so we get extended metadata from the server