### PR TITLE
Add ability to build specific targets to build script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,8 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS="\"iOS Framework\""
-        - BUILD_TARGETS="\"iOS Test App\" \"iOS Automation Test App\" \"Sample Swift App\""
-        - BUILD_TARGETS="\"Mac Framework\""
-        - BUILD_TARGETS="\"Mac Test App\""
-
+        - BUILD_TARGETS=ios_framework ios_test_app ios_auto_app sample_swift_app
+        - BUILD_TARGETS=mac_framework mac_test_app
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
  - gem install xcpretty -N

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,9 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS=ios_framework ios_test_app ios_auto_app sample_swift_app
-        - BUILD_TARGETS=mac_framework mac_test_app
+        - BUILD_TARGETS="ios_framework ios_test_app ios_auto_app sample_swift_app"
+        - BUILD_TARGETS="mac_framework mac_test_app"
+        
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
  - gem install xcpretty -N

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS="ios_framework ios_test_app ios_auto_app sample_swift_app"
-        - BUILD_TARGETS="mac_framework mac_test_app"
+        - BUILD_TARGETS='ios_framework ios_test_app ios_auto_app sample_swift_app'
+        - BUILD_TARGETS='mac_framework mac_test_app'
         
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ before_script:
 
 script:  
 # Run the ADAL build script
-  - ./build.py --no-clean --targets $BUILD_TARGETS
+  - ./build.py --no-clean --targets $(BUILD_TARGETS)
   - sonar-scanner
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS="iOS Framework"
-        - BUILD_TARGETS="iOS Test App" "iOS Automation Test App" "Sample Swift App"
-        - BUILD_TARGETS="Mac Framework"
-        - BUILD_TARGETS="Mac Test App"
+        - BUILD_TARGETS="\"iOS Framework\""
+        - BUILD_TARGETS="\"iOS Test App\" \"iOS Automation Test App\" \"Sample Swift App\""
+        - BUILD_TARGETS="\"Mac Framework\""
+        - BUILD_TARGETS="\"Mac Test App\""
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS="\"iOS Framework\""
-        - BUILD_TARGETS="\"iOS Test App\" \"iOS Automation Test App\" \"Sample Swift App\""
-        - BUILD_TARGETS="\"Mac Framework\""
-        - BUILD_TARGETS="\"Mac Test App\""
+        - BUILD_TARGETS="iOS Framework"
+        - BUILD_TARGETS="iOS Test App" "iOS Automation Test App" "Sample Swift App"
+        - BUILD_TARGETS="Mac Framework"
+        - BUILD_TARGETS="Mac Test App"
 
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
@@ -36,7 +36,7 @@ before_script:
 
 script:  
 # Run the ADAL build script
-  - ./build.py --no-clean --targets $(BUILD_TARGETS)
+  - ./build.py --no-clean --targets $BUILD_TARGETS
   - sonar-scanner
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,15 +17,6 @@ addons:
 cache:
    directories:
       - '$HOME/.sonar/cache'
-
-env:
-    matrix:
-        - BUILD_TARGETS='ios_framework'
-        - BUILD_TARGETS='ios_test_app'
-        - BUILD_TARGETS='ios_auto_app'
-        - BUILD_TARGETS='sample_swift_app'
-        - BUILD_TARGETS='mac_framework'
-        - BUILD_TARGETS='mac_test_app'
         
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
@@ -38,7 +29,7 @@ before_script:
 
 script:  
 # Run the ADAL build script
-  - ./build.py --no-clean --targets $BUILD_TARGETS
+  - ./build.py --no-clean
   - sonar-scanner
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,13 @@ cache:
    directories:
       - '$HOME/.sonar/cache'
 
+env:
+    matrix:
+        - BUILD_TARGETS="\"iOS Framework\""
+        - BUILD_TARGETS="\"iOS Test App\" \"iOS Automation Test App\" \"Sample Swift App\""
+        - BUILD_TARGETS="\"Mac Framework\""
+        - BUILD_TARGETS="\"Mac Test App\""
+
 # Set up our rubygems (slather and xcpretty, namely)
 install: 
  - gem install xcpretty -N
@@ -29,7 +36,7 @@ before_script:
 
 script:  
 # Run the ADAL build script
-  - ./build.py --no-clean
+  - ./build.py --no-clean --targets $BUILD_TARGETS
   - sonar-scanner
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,12 @@ cache:
 
 env:
     matrix:
-        - BUILD_TARGETS='ios_framework ios_test_app ios_auto_app sample_swift_app'
-        - BUILD_TARGETS='mac_framework mac_test_app'
+        - BUILD_TARGETS='ios_framework'
+        - BUILD_TARGETS='ios_test_app'
+        - BUILD_TARGETS='ios_auto_app'
+        - BUILD_TARGETS='sample_swift_app'
+        - BUILD_TARGETS='mac_framework'
+        - BUILD_TARGETS='mac_test_app'
         
 # Set up our rubygems (slather and xcpretty, namely)
 install: 

--- a/build.py
+++ b/build.py
@@ -298,6 +298,9 @@ args = parser.parse_args()
 clean = args.no_clean
 use_xcpretty = args.no_xcpretty
 
+if (args.targets != None) :
+	print "Targets specified: " + str(args.targets)
+
 targets = []
 
 for spec in target_specifiers :

--- a/build.py
+++ b/build.py
@@ -51,6 +51,7 @@ class ColorValues:
 target_specifiers = [
 	{
 		"name" : "iOS Framework",
+		"target" : "ios_framework",
 		"scheme" : "ADAL",
 		"operations" : [ "build", "test", "codecov" ],
 		"min_warn_codecov" : 70.0,
@@ -59,18 +60,21 @@ target_specifiers = [
 	},
 	{
 		"name" : "iOS Test App",
+		"target" : "ios_test_app",
 		"scheme" : "MyTestiOSApp",
 		"operations" : [ "build" ],
 		"platform" : "iOS"
 	},
 	{
 		"name" : "iOS Automation Test App",
+		"target" : "ios_auto_app",
 		"scheme" : "ADALAutomation",
 		"operations" : [ "build" ],
 		"platform" : "iOS"
 	},
 	{
 		"name" : "Sample Swift App",
+		"target" : "sample_swift_app",
 		"scheme" : "SampleSwiftApp",
 		"operations" : [ "build" ],
 		"platform" : "iOS",
@@ -78,6 +82,7 @@ target_specifiers = [
 	},
 	{
 		"name" : "Mac Framework",
+		"target" : "mac_framework",
 		"scheme" : "ADAL Mac",
 		"operations" : [ "build", "test", "codecov" ],
 		"min_warn_codecov" : 70.0,
@@ -85,6 +90,7 @@ target_specifiers = [
 	},
 	{
 		"name" : "Mac Test App",
+		"target" : "mac_test_app",
 		"scheme" : "MyTestMacOSApp",
 		"operations" : [ "build" ],
 		"platform" : "Mac"
@@ -304,7 +310,7 @@ if (args.targets != None) :
 targets = []
 
 for spec in target_specifiers :
-	if (args.targets == None or spec["name"] in args.targets) :
+	if (args.targets == None or spec["target"] in args.targets) :
 		targets.append(BuildTarget(spec))
 
 # start by cleaning up any derived data that might be lying around

--- a/build.py
+++ b/build.py
@@ -28,6 +28,7 @@ import traceback
 import sys
 import re
 import os
+import argparse
 
 from timeit import default_timer as timer
 
@@ -288,18 +289,20 @@ class BuildTarget:
 
 clean = True
 
-for arg in sys.argv :
-	if (arg == "--no-clean") :
-		clean = False
-	if (arg == "--no-xcpretty") :
-		use_xcpretty = False
-#	if ("--scheme" in arg)
-		
+parser = argparse.ArgumentParser(description='ADAL SDK Build Script')
+parser.add_argument('--no-clean', action='store_false', help="Skips the clean build products step")
+parser.add_argument('--no-xcpretty', action='store_false', help="Show raw xcodebuild output instead of using xcpretty")
+parser.add_argument('--targets', nargs='+', help="Specify individual targets to run")
+args = parser.parse_args()
+
+clean = args.no_clean
+use_xcpretty = args.no_xcpretty
 
 targets = []
 
 for spec in target_specifiers :
-	targets.append(BuildTarget(spec))
+	if (args.targets == None or spec["name"] in args.targets) :
+		targets.append(BuildTarget(spec))
 
 # start by cleaning up any derived data that might be lying around
 if (clean) :

--- a/build.py
+++ b/build.py
@@ -365,3 +365,4 @@ if code_coverage :
 			target.print_coverage(True)
 
 sys.exit(final_status)
+


### PR DESCRIPTION
Add the ability to specify targets to build in our build script this will make it easier to use the build matrix functionality to split off our builds into separate sub builds to parallelize on Travis in the future