### PR TITLE
Use Base64URL encoding for broker key in test code

### DIFF
--- a/ADAL/src/broker/ios/ADBrokerKeyHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerKeyHelper.m
@@ -278,7 +278,7 @@ static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
 
 + (void)setSymmetricKey:(NSString *)base64Key
 {
-    s_symmetricKeyOverride = base64Key ? [[NSData alloc] initWithBase64EncodedString:base64Key options:0] : nil;
+    s_symmetricKeyOverride = base64Key ? [NSString adBase64UrlDecodeData:base64Key] : nil;
 }
 
 @end

--- a/ADAL/tests/unit/ios/ADBrokerKeyHelperTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerKeyHelperTests.m
@@ -55,7 +55,7 @@ enum {
 
 - (void)testv1Decrypt
 {
-    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
+    [ADBrokerKeyHelper setSymmetricKey:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"];
     ADBrokerKeyHelper* keyHelper = [[ADBrokerKeyHelper alloc] init];
     ADAuthenticationError* error = nil;
     
@@ -73,7 +73,7 @@ enum {
 
 - (void)testv2Decrypt
 {
-    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
+    [ADBrokerKeyHelper setSymmetricKey:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"];
     ADBrokerKeyHelper* keyHelper = [[ADBrokerKeyHelper alloc] init];
     ADAuthenticationError* error = nil;
     

--- a/ADAL/tests/unit/ios/ADBrokerMessageTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerMessageTests.m
@@ -98,7 +98,7 @@
 
 - (void)testBrokerv2Message
 {
-    [ADBrokerKeyHelper setSymmetricKey:@"BU+bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U="];
+    [ADBrokerKeyHelper setSymmetricKey:@"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U"];
     
     NSString* v2Base64UrlEncryptedPayload = @"TKQ6mTbSf_FgBnb5mvtnSQXQ4_LajVjSNPjymF1wI2ZQWzGSvut3mWziWV0Xvti_ULCFD39BwuFJykXxrtsHZeuynfHRdpUXnhm4qZoAiRfjgY37HBbYbXW3FLzQWvUTCBFz3S9MWpPQE1bJmgke8NisoZ7jlj_gJh-nkfL_Kqg_q7f-AGHvF_TKZoZajosKjbSXzSrW5jLVEA8evIezJS_mIAIUTxxtyoDr1XnQmL2obbi2xLsdbfUDQYpRM2fVLQchO3P_J0TlJrTlR7NAuGnjRUckQHXRsR0-qSK0zF_4rxlClrQgJOudWKpZCVVeUhHMNYzhehLNfABphLeAc_Vxbo7yf0pgKo482ThT86Zb438eSqHivrB8f3VGSx8jRd6MusubxG6VAE5iaHC3xzDumwxAC95QNzv4CspKl5Q";
      


### PR DESCRIPTION
We use base64URL in product code, so this reduces the complexity between test and product code.