### PR TITLE
Integration test for simple Brokered Auth case

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -348,6 +348,9 @@
 		D66A9F291F7998D300144011 /* ADTokenCacheTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D66A9F271F7998D300144011 /* ADTokenCacheTestUtil.m */; };
 		D66A9F2A1F7998D300144011 /* ADTokenCacheTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D66A9F271F7998D300144011 /* ADTokenCacheTestUtil.m */; };
 		D66A9F2B1F7998D300144011 /* ADTokenCacheTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D66A9F271F7998D300144011 /* ADTokenCacheTestUtil.m */; };
+		D6771E001F749CE100D0DCDC /* ADBrokerIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = D6771DFF1F749CE100D0DCDC /* ADBrokerIntegrationTests.m */; };
+		D6771E031F749FD800D0DCDC /* ADApplicationTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D6771E021F749FD800D0DCDC /* ADApplicationTestUtil.m */; };
+		D6771E041F749FD800D0DCDC /* ADApplicationTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D6771E021F749FD800D0DCDC /* ADApplicationTestUtil.m */; };
 		D67D3D351F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
 		D67D3D361F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
 		D67D3D371F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */ = {isa = PBXBuildFile; fileRef = D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */; };
@@ -762,6 +765,9 @@
 		D66A9F1B1F76D05900144011 /* NSURL+ADTestUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSURL+ADTestUtil.m"; sourceTree = "<group>"; };
 		D66A9F261F7998D300144011 /* ADTokenCacheTestUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTokenCacheTestUtil.h; sourceTree = "<group>"; };
 		D66A9F271F7998D300144011 /* ADTokenCacheTestUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheTestUtil.m; sourceTree = "<group>"; };
+		D6771DFF1F749CE100D0DCDC /* ADBrokerIntegrationTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADBrokerIntegrationTests.m; sourceTree = "<group>"; };
+		D6771E011F749FD800D0DCDC /* ADApplicationTestUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADApplicationTestUtil.h; sourceTree = "<group>"; };
+		D6771E021F749FD800D0DCDC /* ADApplicationTestUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADApplicationTestUtil.m; sourceTree = "<group>"; };
 		D67D3D331F382F8B00660F32 /* NSDictionary+ADTestUtil.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+ADTestUtil.h"; sourceTree = "<group>"; };
 		D67D3D341F382F8B00660F32 /* NSDictionary+ADTestUtil.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+ADTestUtil.m"; sourceTree = "<group>"; };
 		D67D3D391F38502900660F32 /* ADTestCase.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestCase.h; sourceTree = "<group>"; };
@@ -1435,6 +1441,7 @@
 			isa = PBXGroup;
 			children = (
 				B23FC03D1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m */,
+				D6771DFF1F749CE100D0DCDC /* ADBrokerIntegrationTests.m */,
 				B20DC5DC1F0D97DD00957806 /* ADAL_iOS_ITs-Info.plist */,
 			);
 			path = ios;
@@ -1451,6 +1458,7 @@
 		D632B5491F50AE6B001173F1 /* util */ = {
 			isa = PBXGroup;
 			children = (
+				D6771E051F74A4D200D0DCDC /* ios */,
 				D632B54A1F50AE6B001173F1 /* ADAuthorityValidation+TestUtil.h */,
 				D632B54B1F50AE6B001173F1 /* ADAuthorityValidation+TestUtil.m */,
 				D632B5501F50AEDC001173F1 /* ADAadAuthorityCache+TestUtil.h */,
@@ -1508,6 +1516,15 @@
 				D6669FAE1F1D4F51002492C5 /* ADWebFingerRequest.m */,
 			);
 			path = validation;
+			sourceTree = "<group>";
+		};
+		D6771E051F74A4D200D0DCDC /* ios */ = {
+			isa = PBXGroup;
+			children = (
+				D6771E011F749FD800D0DCDC /* ADApplicationTestUtil.h */,
+				D6771E021F749FD800D0DCDC /* ADApplicationTestUtil.m */,
+			);
+			path = ios;
 			sourceTree = "<group>";
 		};
 		D6D8A83D1D4FD12300D20DE6 /* ios */ = {
@@ -2022,6 +2039,7 @@
 				96C75D281E303DC40038D1EC /* ADTestURLSession.m in Sources */,
 				D6D4D4981F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				D62256511F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
+				D6771E031F749FD800D0DCDC /* ADApplicationTestUtil.m in Sources */,
 				D67D3D4E1F43B17000660F32 /* ADAadAuthorityCacheTests.m in Sources */,
 				234F3CE71F35161C00DE4AA4 /* ADAuthenticationContextTests.m in Sources */,
 				601BEE311C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m in Sources */,
@@ -2175,6 +2193,7 @@
 				D62256521F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
 				B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				B20DC5891F0D96A100957806 /* ADTelemetryTestDispatcher.m in Sources */,
+				D6771E041F749FD800D0DCDC /* ADApplicationTestUtil.m in Sources */,
 				D66A9F1D1F76D05900144011 /* NSURL+ADTestUtil.m in Sources */,
 				B20DC6121F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5951F0D96A100957806 /* ADTestURLSessionDataTask.m in Sources */,
@@ -2187,6 +2206,7 @@
 				B20DC5981F0D96A100957806 /* ADTestURLSession.m in Sources */,
 				D67D3D471F422C3200660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
+				D6771E001F749CE100D0DCDC /* ADBrokerIntegrationTests.m in Sources */,
 				B20D8FF51F60A3490021DA25 /* ADTelemetryIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2427,7 +2447,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = YES;
-				PRODUCT_BUNDLE_IDENTIFIER = com.MSOpenTech.UnitTestHostApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.unittesthost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -2455,7 +2475,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				MTL_ENABLE_DEBUG_INFO = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.MSOpenTech.UnitTestHostApp;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.unittesthost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};

--- a/ADAL/UnitTestHostApp/Info.plist
+++ b/ADAL/UnitTestHostApp/Info.plist
@@ -16,6 +16,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>x-msauth-unittest</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/ADAL/UnitTestHostApp/UnitTestHostApp.entitlements
+++ b/ADAL/UnitTestHostApp/UnitTestHostApp.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>keychain-access-groups</key>
 	<array>
-		<string>$(AppIdentifierPrefix)com.MSOpenTech.UnitTestHostApp</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.unittesthost</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin</string>
 	</array>

--- a/ADAL/src/broker/ios/ADBrokerKeyHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerKeyHelper.m
@@ -276,6 +276,11 @@ static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
     _symmetricKey = symmetricKey;
 }
 
++ (NSData *)symmetricKey
+{
+    return s_symmetricKeyOverride;
+}
+
 + (void)setSymmetricKey:(NSString *)base64Key
 {
     s_symmetricKeyOverride = base64Key ? [NSString adBase64UrlDecodeData:base64Key] : nil;

--- a/ADAL/tests/ADTestAuthorityValidationResponse.h
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.h
@@ -25,6 +25,10 @@
 + (ADTestURLResponse*)validAuthority:(NSString *)authority;
 + (ADTestURLResponse *)validAuthority:(NSString *)authority
                          withMetadata:(NSArray *)metadata;
++ (ADTestURLResponse *)validAuthority:(NSString *)authority
+                          trustedHost:(NSString *)trustedHost
+                         withMetadata:(NSArray *)metadata;
+
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority;
 
 + (ADTestURLResponse*)validDrsPayload:(NSString *)domain

--- a/ADAL/tests/ADTestAuthorityValidationResponse.m
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.m
@@ -25,7 +25,7 @@
 #import "NSURL+ADExtensions.h"
 
 
-#define DEFAULT_TRUSTED_HOST "login.microsoftonline.com"
+#define DEFAULT_TRUSTED_HOST @"login.microsoftonline.com"
 
 @implementation ADTestAuthorityValidationResponse
 
@@ -37,7 +37,14 @@
 + (ADTestURLResponse *)validAuthority:(NSString *)authority
                          withMetadata:(NSArray *)metadata
 {
-    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://" DEFAULT_TRUSTED_HOST "/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, [authority lowercaseString]];
+    return [self validAuthority:authority trustedHost:DEFAULT_TRUSTED_HOST withMetadata:metadata];
+}
+
++ (ADTestURLResponse *)validAuthority:(NSString *)authority
+                          trustedHost:(NSString *)trustedHost
+                         withMetadata:(NSArray *)metadata
+{
+    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://%@/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, trustedHost, [authority lowercaseString]];
     ADTestURLResponse *response = [ADTestURLResponse new];
     response.requestURL = [NSURL URLWithString:authorityValidationURL];
     [response setResponseURL:@"https://idontmatter.com" code:200 headerFields:@{}];
@@ -56,7 +63,7 @@
 
 + (ADTestURLResponse *)invalidAuthority:(NSString *)authority
 {
-    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://" DEFAULT_TRUSTED_HOST "/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, [authority lowercaseString]];
+    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://%@/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, DEFAULT_TRUSTED_HOST, [authority lowercaseString]];
     ADTestURLResponse *response = [ADTestURLResponse requestURLString:authorityValidationURL
                                                     responseURLString:@"https://idontmatter.com"
                                                          responseCode:400

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -29,7 +29,10 @@
 #import "ADTestCase.h"
 #import "ADClientMetrics.h"
 #import "ADAuthorityValidation+TestUtil.h"
+
+#if TARGET_OS_IPHONE
 #import "ADApplicationTestUtil.h"
+#endif
 
 @implementation ADTestCase
 
@@ -45,8 +48,11 @@
     [ADTestURLSession clearResponses];
     [[ADClientMetrics getInstance] clearMetrics];
     [ADAuthorityValidation clearAadCache];
+    
+#if TARGET_OS_IPHONE
     [ADApplicationTestUtil reset];
-
+#endif
+    
     [super tearDown];
 }
 

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -29,6 +29,7 @@
 #import "ADTestCase.h"
 #import "ADClientMetrics.h"
 #import "ADAuthorityValidation+TestUtil.h"
+#import "ADApplicationTestUtil.h"
 
 @implementation ADTestCase
 
@@ -44,6 +45,7 @@
     [ADTestURLSession clearResponses];
     [[ADClientMetrics getInstance] clearMetrics];
     [ADAuthorityValidation clearAadCache];
+    [ADApplicationTestUtil reset];
 
     [super tearDown];
 }

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -49,14 +49,11 @@
 
 - (void)setUp {
     [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
+    [[ADKeychainTokenCache keychainCacheForGroup:nil] testRemoveAll:nil];
 }
 
 - (void)tearDown {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
     [super tearDown];
-    
-    [[ADKeychainTokenCache keychainCacheForGroup:nil] testRemoveAll:nil];
 }
 
 + (NSURL *)createV2BrokerResponse:(NSDictionary *)parameters

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -186,7 +186,7 @@
         [expectation fulfill];
     }];
     
-    [self waitForExpectations:@[expectation] timeout:100000.0];
+    [self waitForExpectations:@[expectation] timeout:1.0];
     
     ADKeychainTokenCache *tokenCache = (ADKeychainTokenCache *)[context tokenCacheStore].dataSource;
     

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -1,0 +1,198 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <CommonCrypto/CommonCryptor.h>
+#import <CommonCrypto/CommonDigest.h>
+#import <XCTest/XCTest.h>
+#import "XCTestCase+TestHelperMethods.h"
+
+#import "NSDictionary+ADExtensions.h"
+#import "NSString+ADHelperMethods.h"
+#import "NSURL+ADTestUtil.h"
+
+#import "ADApplicationTestUtil.h"
+#import "ADAuthenticationContext+Internal.h"
+#import "ADBrokerHelper.h"
+#import "ADBrokerKeyHelper.h"
+#import "ADKeychainTokenCache+Internal.h"
+#import "ADTokenCache+Internal.h"
+#import "ADTokenCacheItem.h"
+#import "ADTokenCacheTestUtil.h"
+#import "ADUserInformation.h"
+
+
+@interface ADBrokerIntegrationTests : ADTestCase
+
+@end
+
+@implementation ADBrokerIntegrationTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+    
+    [[ADKeychainTokenCache keychainCacheForGroup:nil] testRemoveAll:nil];
+}
+
++ (NSURL *)createV2BrokerResponse:(NSDictionary *)parameters
+                      redirectUri:(NSString *)redirectUri
+{
+    NSData *payload = [[parameters adURLFormEncode] dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *brokerKey = [ADBrokerKeyHelper symmetricKey];
+    
+    size_t bufferSize = [payload length] + kCCBlockSizeAES128;
+    void *buffer = malloc(bufferSize);
+    size_t numBytesEncrypted = 0;
+    
+    CCCryptorStatus cryptStatus = CCCrypt(kCCEncrypt, kCCAlgorithmAES128, kCCOptionPKCS7Padding,
+                                          [brokerKey bytes], kCCKeySizeAES256,
+                                          NULL /* initialization vector (optional) */,
+                                          [payload bytes], [payload length], /* input */
+                                          buffer, bufferSize, /* output */
+                                          &numBytesEncrypted);
+    if (cryptStatus != kCCSuccess)
+    {
+        return nil;
+    }
+    
+    unsigned char hash[CC_SHA256_DIGEST_LENGTH];
+    CC_SHA256([payload bytes], (CC_LONG)[payload length], hash);
+    NSMutableString *fingerprint = [NSMutableString stringWithCapacity:CC_SHA256_DIGEST_LENGTH * 3];
+    for (int i = 0; i < CC_SHA256_DIGEST_LENGTH; ++i)
+    {
+        [fingerprint appendFormat:@"%02x", hash[i]];
+    }
+    
+    NSDictionary *message =
+    @{
+      @"msg_protocol_ver" : @"2",
+      @"response" :  [NSString adBase64UrlEncodeData:[NSData dataWithBytesNoCopy:buffer length:numBytesEncrypted]],
+      @"hash" : [fingerprint uppercaseString],
+      };
+    
+    return [NSURL URLWithString:[NSString stringWithFormat:@"%@?%@", redirectUri, [message adURLFormEncode]]];
+}
+
+- (ADAuthenticationContext *)getBrokerTestContext:(NSString *)authority
+{
+    ADAuthenticationContext *context =
+    [[ADAuthenticationContext alloc] initWithAuthority:authority
+                                     validateAuthority:YES
+                                           sharedGroup:nil
+                                                 error:nil];
+    
+    NSAssert(context, @"If this is failing for whatever reason you should probably fix it before trying to run tests.");
+    [context setCorrelationId:TEST_CORRELATION_ID];
+    [context setCredentialsType:AD_CREDENTIALS_AUTO];
+    
+    return context;
+}
+
+- (void)testBroker_whenSimpleAcquireToken_shouldSucceed
+{
+    NSString *authority = @"https://login.windows.net/common";
+    NSString *brokerKey = @"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U";
+    NSString *redirectUri = @"x-msauth-unittest://com.microsoft.unittesthost";
+    [ADBrokerKeyHelper setSymmetricKey:brokerKey];
+    
+    [ADApplicationTestUtil onOpenURL:^BOOL(NSURL *url, NSDictionary<NSString *,id> *options) {
+        (void)options;
+        
+        NSDictionary *expectedParams =
+        @{
+          @"authority" : authority,
+          @"resource" : TEST_RESOURCE,
+          @"username_type" : @"",
+          @"max_protocol_ver" : @"2",
+          @"broker_key" : brokerKey,
+          @"client_version" : ADAL_VERSION_NSSTRING,
+          @"force" : @"NO",
+          @"redirect_uri" : redirectUri,
+          @"username" : @"",
+          @"client_id" : TEST_CLIENT_ID,
+          @"correlation_id" : TEST_CORRELATION_ID,
+          @"skip_cache" : @"NO",
+          @"extra_qp" : @"",
+          @"claims" : @"",
+          };
+        
+        NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams adURLFormEncode]];
+        NSURL *expectedURL = [NSURL URLWithString:expectedUrlString];
+        XCTAssertTrue([expectedURL matchesURL:url]);
+        
+        NSDictionary *responseParams =
+        @{
+          @"authority" : authority,
+          @"resource" : TEST_RESOURCE,
+          @"client_id" : TEST_CLIENT_ID,
+          @"id_token" : [[self adCreateUserInformation:TEST_USER_ID] rawIdToken],
+          @"access_token" : @"i-am-a-access-token",
+          @"refresh_token" : @"i-am-a-refresh-token",
+          @"foci" : @"1",
+          @"expires_in" : @"3600"
+          };
+        
+        [ADAuthenticationContext handleBrokerResponse:[ADBrokerIntegrationTests createV2BrokerResponse:responseParams redirectUri:redirectUri]];
+        return YES;
+    }];
+    
+    NSArray *metadata = @[ @{ @"preferred_network" : @"login.microsoftonline.com",
+                              @"preferred_cache" : @"login.windows.net",
+                              @"aliases" : @[ @"login.windows.net", @"login.microsoftonline.com"] } ];
+    ADTestURLResponse *validationResponse =
+    [ADTestAuthorityValidationResponse validAuthority:authority
+                                          trustedHost:@"login.windows.net"
+                                         withMetadata:metadata];
+    [ADTestURLSession addResponses:@[validationResponse]];
+    
+    ADAuthenticationContext *context = [self getBrokerTestContext:authority];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token callback"];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:[NSURL URLWithString:redirectUri]
+                      completionBlock:^(ADAuthenticationResult *result)
+    {
+        XCTAssertNotNil(result);
+        XCTAssertEqual(result.status, AD_SUCCEEDED);
+        
+        XCTAssertEqualObjects(result.tokenCacheItem.accessToken, @"i-am-a-access-token");
+        XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, @"i-am-a-refresh-token");
+        
+        [expectation fulfill];
+    }];
+    
+    [self waitForExpectations:@[expectation] timeout:100000.0];
+    
+    ADKeychainTokenCache *tokenCache = (ADKeychainTokenCache *)[context tokenCacheStore].dataSource;
+    
+    XCTAssertEqualObjects([tokenCache getAT:authority], @"i-am-a-access-token");
+    XCTAssertEqualObjects([tokenCache getMRRT:authority], @"i-am-a-refresh-token");
+    XCTAssertEqualObjects([tokenCache getFRT:authority], @"i-am-a-refresh-token");
+}
+
+@end

--- a/ADAL/tests/util/ios/ADApplicationTestUtil.h
+++ b/ADAL/tests/util/ios/ADApplicationTestUtil.h
@@ -21,33 +21,12 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+
 #import <Foundation/Foundation.h>
-#import "ADAuthenticationError.h"
 
-#define kChosenCipherKeySize    kCCKeySizeAES256
-#define kSymmetricKeyTag        "com.microsoft.adBrokerKey"
+@interface ADApplicationTestUtil : NSObject
 
-@interface ADBrokerKeyHelper : NSObject
-{
-    NSData * _symmetricTag;
-    NSData * _symmetricKey;
-}
-
-- (id)init;
-
-- (BOOL)createBrokerKey:(ADAuthenticationError* __autoreleasing*)error;
-- (BOOL)deleteSymmetricKey: (ADAuthenticationError* __autoreleasing*) error;
-- (NSData*)getBrokerKey:(ADAuthenticationError* __autoreleasing*)error;
-- (NSData*)decryptBrokerResponse:(NSData*)response
-                         version:(NSInteger)version
-                           error:(ADAuthenticationError* __autoreleasing*)error;
-- (NSData*)decryptBrokerResponse:(NSData *)response
-                             key:(const void*)key
-                            size:(size_t)size
-                           error:(ADAuthenticationError *__autoreleasing *)error;
-
-// NOTE: Used for testing purposes only. Does not change keychain entries.
-+ (void)setSymmetricKey:(NSString *)base64Key;
-+ (NSData *)symmetricKey;
++ (void)onOpenURL:(BOOL (^)(NSURL *url, NSDictionary<NSString *, id> *options))openUrlBlock;
++ (void)reset;
 
 @end

--- a/ADAL/tests/util/ios/ADApplicationTestUtil.m
+++ b/ADAL/tests/util/ios/ADApplicationTestUtil.m
@@ -21,33 +21,57 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
-#import "ADAuthenticationError.h"
+#import "ADApplicationTestUtil.h"
 
-#define kChosenCipherKeySize    kCCKeySizeAES256
-#define kSymmetricKeyTag        "com.microsoft.adBrokerKey"
+BOOL (^s_onOpenUrl)(NSURL *url, NSDictionary<NSString *, id> *options) = nil;
 
-@interface ADBrokerKeyHelper : NSObject
+@implementation ADApplicationTestUtil
+
++ (void)onOpenURL:(BOOL (^)(NSURL *url, NSDictionary<NSString *, id> *options))openUrlBlock
 {
-    NSData * _symmetricTag;
-    NSData * _symmetricKey;
+    s_onOpenUrl = openUrlBlock;
 }
 
-- (id)init;
++ (void)reset
+{
+    s_onOpenUrl = nil;
+}
 
-- (BOOL)createBrokerKey:(ADAuthenticationError* __autoreleasing*)error;
-- (BOOL)deleteSymmetricKey: (ADAuthenticationError* __autoreleasing*) error;
-- (NSData*)getBrokerKey:(ADAuthenticationError* __autoreleasing*)error;
-- (NSData*)decryptBrokerResponse:(NSData*)response
-                         version:(NSInteger)version
-                           error:(ADAuthenticationError* __autoreleasing*)error;
-- (NSData*)decryptBrokerResponse:(NSData *)response
-                             key:(const void*)key
-                            size:(size_t)size
-                           error:(ADAuthenticationError *__autoreleasing *)error;
+@end
 
-// NOTE: Used for testing purposes only. Does not change keychain entries.
-+ (void)setSymmetricKey:(NSString *)base64Key;
-+ (NSData *)symmetricKey;
+
+@interface UIApplication (TestOverride)
+
+@end
+
+
+#pragma push
+#pragma clang diagnostic ignored "-Wobjc-protocol-method-implementation"
+@implementation UIApplication (TestOverride)
+
+- (BOOL)openURL:(NSURL *)url
+{
+    if (!s_onOpenUrl)
+    {
+        NSAssert(s_onOpenUrl, @"Some test isn't properly waiting for the flow to complete");
+    }
+    
+    return s_onOpenUrl(url, nil);
+}
+
+- (BOOL)canOpenURL:(NSURL *)url
+{
+    (void)url;
+    return YES;
+}
+
+- (void)openURL:(NSURL*)url
+        options:(NSDictionary<NSString *, id> *)options
+completionHandler:(void (^ __nullable)(BOOL success))completionHandler
+{
+    completionHandler(s_onOpenUrl(url, options));
+}
+
+#pragma pop
 
 @end


### PR DESCRIPTION
This is a test code only change to establish a baseline test for working broker auth in normal order.

* Modify unit test host so that it passes redirect uri check
* Add ADApplicationTestUtil to intercept UIApplication’s openURL and canOpenURL