### PR TITLE
Always go to authority validation endpoint

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -145,12 +145,6 @@
         return;
     }
     
-    if (!_context.validateAuthority)
-    {
-        [self validatedAcquireToken:wrappedCallback];
-        return;
-    }
-    
     [[ADTelemetry sharedInstance] startEvent:telemetryRequestId eventName:AD_TELEMETRY_EVENT_AUTHORITY_VALIDATION];
     
     ADAuthorityValidation* authorityValidation = [ADAuthorityValidation sharedInstance];
@@ -162,6 +156,11 @@
          [event setAuthorityValidationStatus:validated ? AD_TELEMETRY_VALUE_YES:AD_TELEMETRY_VALUE_NO];
          [event setAuthority:_context.authority];
          [[ADTelemetry sharedInstance] stopEvent:telemetryRequestId event:event];
+         if (!_context.validateAuthority && error && [error.protocolCode isEqualToString:@"invalid_instance"])
+         {
+             error = nil;
+         }
+         
          if (error)
          {
              wrappedCallback([ADAuthenticationResult resultFromError:error correlationId:_requestParams.correlationId]);

--- a/ADAL/src/validation/ADAuthorityValidation.h
+++ b/ADAL/src/validation/ADAuthorityValidation.h
@@ -61,6 +61,8 @@ typedef void(^ADAuthorityValidationCallback)(BOOL validated, ADAuthenticationErr
 - (void)validateAuthority:(ADRequestParameters*)requestParams
           completionBlock:(ADAuthorityValidationCallback)completionBlock;
 
+- (void)addInvalidAuthority:(NSString *)authority;
+
 - (NSURL *)networkUrlForAuthority:(NSURL *)authority
                           context:(id<ADRequestContext>)context;
 - (NSURL *)cacheUrlForAuthority:(NSURL *)authority

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -356,6 +356,11 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 }
 
 
+- (void)addInvalidAuthority:(NSString *)authority
+{
+    [_aadCache addInvalidRecord:[NSURL URLWithString:authority] oauthError:nil context:nil];
+}
+
 #pragma mark - ADFS authority validation
 - (void)validateADFSAuthority:(NSURL *)authority
                        domain:(NSString *)domain

--- a/ADAL/tests/ADTestAuthorityValidationResponse.h
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.h
@@ -30,6 +30,8 @@
                          withMetadata:(NSArray *)metadata;
 
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority;
++ (ADTestURLResponse*)invalidAuthority:(NSString *)authority
+                           trustedHost:(NSString *)trustedHost;
 
 + (ADTestURLResponse*)validDrsPayload:(NSString *)domain
                               onPrems:(BOOL)onPrems

--- a/ADAL/tests/ADTestAuthorityValidationResponse.m
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.m
@@ -63,7 +63,13 @@
 
 + (ADTestURLResponse *)invalidAuthority:(NSString *)authority
 {
-    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://%@/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, DEFAULT_TRUSTED_HOST, [authority lowercaseString]];
+    return [self invalidAuthority:authority trustedHost:DEFAULT_TRUSTED_HOST];
+}
+
++ (ADTestURLResponse*)invalidAuthority:(NSString *)authority
+                           trustedHost:(NSString *)trustedHost
+{
+    NSString* authorityValidationURL = [NSString stringWithFormat:@"https://%@/common/discovery/instance?api-version=" AAD_AUTHORITY_VALIDATION_API_VERSION "&authorization_endpoint=%@/oauth2/authorize&x-client-Ver=" ADAL_VERSION_STRING, trustedHost, [authority lowercaseString]];
     ADTestURLResponse *response = [ADTestURLResponse requestURLString:authorityValidationURL
                                                     responseURLString:@"https://idontmatter.com"
                                                          responseCode:400

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -39,6 +39,7 @@
 #import "ADTelemetryTestDispatcher.h"
 #import "ADUserIdentifier.h"
 #import "ADTestAuthenticationViewController.h"
+#import "ADAuthorityValidation.h"
 
 const int sAsyncContextTimeout = 10;
 
@@ -67,6 +68,7 @@ const int sAsyncContextTimeout = 10;
 - (void)setUp
 {
     [super setUp];
+    [[ADAuthorityValidation sharedInstance] addInvalidAuthority:TEST_AUTHORITY];
 }
 
 - (void)tearDown

--- a/ADAL/tests/integration/ios/ADAcquireTokenPkeyAuthTests.m
+++ b/ADAL/tests/integration/ios/ADAcquireTokenPkeyAuthTests.m
@@ -56,8 +56,9 @@
     [context.tokenCacheStore.dataSource addOrUpdateItem:[self adCreateMRRTCacheItem] correlationId:nil error:&error];
     XCTAssertNil(error);
     
-    [ADTestURLSession addResponses:@[[self defaultTokenEndpointPkeyAuthChallenge],
-                                        [self defaultPkeyAuthNoWPJResponse]]];
+    [ADTestURLSession addResponses:@[[ADTestAuthorityValidationResponse invalidAuthority:TEST_AUTHORITY trustedHost:@"login.windows.net"],
+                                     [self defaultTokenEndpointPkeyAuthChallenge],
+                                     [self defaultPkeyAuthNoWPJResponse]]];
     
     XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilent should return new token."];
     


### PR DESCRIPTION
If metadata exists for an endpoint we’ll want to retrieve that regardless of whether authority validation is turned on, end the flow on an invalid authority if validateAuthority was set to NO.