### PR TITLE
Authority validation revision

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -148,18 +148,15 @@
     [[ADTelemetry sharedInstance] startEvent:telemetryRequestId eventName:AD_TELEMETRY_EVENT_AUTHORITY_VALIDATION];
     
     ADAuthorityValidation* authorityValidation = [ADAuthorityValidation sharedInstance];
-    [authorityValidation validateAuthority:_requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:_requestParams
+                      validateAuthority:_context.validateAuthority
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          ADTelemetryAPIEvent* event = [[ADTelemetryAPIEvent alloc] initWithName:AD_TELEMETRY_EVENT_AUTHORITY_VALIDATION
                                                                         context:_requestParams];
          [event setAuthorityValidationStatus:validated ? AD_TELEMETRY_VALUE_YES:AD_TELEMETRY_VALUE_NO];
          [event setAuthority:_context.authority];
          [[ADTelemetry sharedInstance] stopEvent:telemetryRequestId event:event];
-         if (!_context.validateAuthority && error && [error.protocolCode isEqualToString:@"invalid_instance"])
-         {
-             error = nil;
-         }
          
          if (error)
          {
@@ -169,8 +166,7 @@
          {
              [self validatedAcquireToken:wrappedCallback];
          }
-     }];
-    
+     }];    
 }
 
 - (BOOL)checkExtraQueryParameters

--- a/ADAL/src/validation/ADAuthorityValidation.h
+++ b/ADAL/src/validation/ADAuthorityValidation.h
@@ -52,14 +52,18 @@ typedef void(^ADAuthorityValidationCallback)(BOOL validated, ADAuthenticationErr
 // Cache - AAD
 
 /*!
- Validates an authority.
+ Checks an authority.
+ For AAD, if metadata exists for an endpoint, we’ll want to retrieve that regardless of
+ whether authority validation is turned on.
  
  @param requestParams        Request parameters
+ @param validateAuthority    authority validation check
  @param completionBlock      The block to execute upon completion.
-
+ 
  */
-- (void)validateAuthority:(ADRequestParameters*)requestParams
-          completionBlock:(ADAuthorityValidationCallback)completionBlock;
+- (void)checkAuthority:(ADRequestParameters*)requestParams
+     validateAuthority:(BOOL)validateAuthority
+       completionBlock:(ADAuthorityValidationCallback)completionBlock;
 
 - (void)addInvalidAuthority:(NSString *)authority;
 

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -182,12 +182,17 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
         }
         
         // Validate ADFS authority
-        [self validateADFSAuthority:authorityURL domain:upnSuffix requestParams:requestParams completionBlock:completionBlock];
+        [self validateADFSAuthority:authorityURL
+                             domain:upnSuffix
+                      requestParams:requestParams
+                    completionBlock:completionBlock];
     }
     else
     {
         // Validate AAD authority
-        [self validateAADAuthority:authorityURL requestParams:requestParams completionBlock:^(BOOL validated, ADAuthenticationError *error)
+        [self validateAADAuthority:authorityURL
+                     requestParams:requestParams
+                   completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
              if (!validateAuthority && error && [error.protocolCode isEqualToString:@"invalid_instance"])
              {

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -166,7 +166,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     {
         if (!validateAuthority)
         {
-            completionBlock(YES, nil);
+            completionBlock(NO, nil);
             return;
         }
         

--- a/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
@@ -64,7 +64,7 @@
 
 
 
-- (void)testValidateAuthority_whenSchemeIsHttp_shouldFailWithError
+- (void)testCheckAuthority_whenSchemeIsHttp_shouldFailWithError
 {
     NSString *authority = @"http://invalidscheme.com";
     ADRequestParameters* requestParams = [ADRequestParameters new];
@@ -75,8 +75,9 @@
     [requestParams setAuthority:authority];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated, @"\"%@\" should come back invalid.", authority);
          XCTAssertNotNil(error);
@@ -87,7 +88,7 @@
     [self waitForExpectationsWithTimeout:1 handler:nil];
 }
 
-- (void)testValidateAuthority_whenAuthorityUrlIsInvalid_shouldFailWithError
+- (void)testCheckAuthority_whenAuthorityUrlIsInvalid_shouldFailWithError
 {
     NSString *authority = @"https://Invalid URL 2305 8 -0238460-820-386";
     ADRequestParameters* requestParams = [ADRequestParameters new];
@@ -98,8 +99,9 @@
     [requestParams setAuthority:authority];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated, @"\"%@\" should come back invalid.", authority);
          XCTAssertNotNil(error);
@@ -111,7 +113,7 @@
 }
 
 // Tests a normal authority
-- (void)testValidateAuthority_whenAuthorityValid_shouldPass
+- (void)testCheckAuthority_whenAuthorityValid_shouldPass
 {
     NSString* authority = @"https://login.windows-ppe.net/common";
     
@@ -123,8 +125,9 @@
     [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse validAuthority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate valid authority."];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError * error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError * error)
      {
          XCTAssertTrue(validated);
          XCTAssertNil(error);
@@ -138,7 +141,7 @@
 }
 
 //Ensures that an invalid authority is not approved
-- (void)testValidateAuthority_whenAuthorityInvalid_shouldReturnError
+- (void)testCheckAuthority_whenAuthorityInvalid_shouldReturnError
 {
     NSString* authority = @"https://myfakeauthority.microsoft.com/contoso.com";
     
@@ -150,8 +153,9 @@
     [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError * error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError * error)
      {
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
@@ -264,7 +268,7 @@
     XCTAssertFalse(record.validated);
 }
 
-- (void)testValidateAuthority_whenHostUnreachable_shouldFail
+- (void)testCheckAuthority_whenHostUnreachable_shouldFail
 {
     NSString* authority = @"https://login.windows.net/contoso.com";
     
@@ -288,14 +292,15 @@
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority when server is unreachable."];
     
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
-    {
-        XCTAssertFalse(validated);
-        XCTAssertNotNil(error);
-        
-        [expectation fulfill];
-    }];
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
+     {
+         XCTAssertFalse(validated);
+         XCTAssertNotNil(error);
+         
+         [expectation fulfill];
+     }];
     
     [self waitForExpectationsWithTimeout:1 handler:nil];
     
@@ -530,11 +535,11 @@
                              clientId:TEST_CLIENT_ID
                           redirectUri:TEST_REDIRECT_URL
                       completionBlock:^(ADAuthenticationResult *result)
-    {
-        XCTAssertNotNil(result);
-        XCTAssertEqual(result.status, AD_SUCCEEDED);
-        [expectation2 fulfill];
-    }];
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         [expectation2 fulfill];
+     }];
     
     [self waitForExpectations:@[expectation1, expectation2] timeout:1.0];
 }
@@ -744,3 +749,4 @@ CreateAuthContext(NSString *authority,
 }
 
 @end
+

--- a/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
@@ -270,7 +270,7 @@
 }
 
 // test
-- (void)testCheckAuthority_whenValidationTurnedOff_shouldPass
+- (void)testCheckAuthority_whenValidationTurnedOffAndAdfsAuthority_shouldPass
 {
     {
         NSString* authority = @"https://login.windows.com/adfs";

--- a/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/ADFSAuthorityValidationIntegrationTests.m
@@ -47,7 +47,7 @@
     [super tearDown];
 }
 
-- (void)testAdfsNormalOnPrems
+- (void)testCheckAuthority_whenAuthorityOnPremsValid_shouldPass
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -69,8 +69,9 @@
                                                                           authority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertTrue(validated);
          XCTAssertNil(error);
@@ -83,7 +84,7 @@
     XCTAssertTrue([authorityValidation isAuthorityValidated:[NSURL URLWithString:authority] domain:upnSuffix]);
 }
 
-- (void)testAdfsNormalOnCloud
+- (void)testCheckAuthority_whenAuthorityOnCloudValid_shouldPass
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -108,8 +109,9 @@
                                                                           authority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertTrue(validated);
          XCTAssertNil(error);
@@ -122,7 +124,7 @@
     XCTAssertTrue([authorityValidation isAuthorityValidated:[NSURL URLWithString:authority] domain:upnSuffix]);
 }
 
-- (void)testAdfsInvalidDrs
+- (void)testCheckAuthority_whenInvalidDrs_shuoldFail
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -142,8 +144,9 @@
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
     
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
@@ -157,7 +160,7 @@
 }
 
 // test invalid webfinger - 400
-- (void)testAdfsInvalidWebfinger
+- (void)testCheckAuthority_whenInvalidWebFinger_shouldFail
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -178,8 +181,9 @@
                                                                             authority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
@@ -193,7 +197,7 @@
 }
 
 // test invalid webfinger - 200 but not match
-- (void)testAdfsInvalidWebFingerNotTrusted
+- (void)testCheckAuthority_whenWebFingerNotTrusted_shouldFail
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -214,8 +218,9 @@
                                                                                       authority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
@@ -229,7 +234,7 @@
 }
 
 // test invalid webfinger - not reachable
-- (void)testAdfsUnreachableWebFinger
+- (void)testCheckAuthority_whenWebFingerNotReachable_shouldFail
 {
     NSString* authority = @"https://login.windows.com/adfs";
     NSString* upn       = @"someuser@somehost.com";
@@ -250,8 +255,9 @@
                                                                                 authority:authority]];
     
     XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
-    [authorityValidation validateAuthority:requestParams
-                           completionBlock:^(BOOL validated, ADAuthenticationError *error)
+    [authorityValidation checkAuthority:requestParams
+                      validateAuthority:YES
+                        completionBlock:^(BOOL validated, ADAuthenticationError *error)
      {
          XCTAssertFalse(validated);
          XCTAssertNotNil(error);
@@ -263,4 +269,31 @@
     XCTAssertFalse([authorityValidation isAuthorityValidated:[NSURL URLWithString:authority] domain:upnSuffix]);
 }
 
+// test
+- (void)testCheckAuthority_whenValidationTurnedOff_shouldPass
+{
+    {
+        NSString* authority = @"https://login.windows.com/adfs";
+        
+        ADAuthorityValidation* authorityValidation = [[ADAuthorityValidation alloc] init];
+        
+        ADRequestParameters* requestParams = [ADRequestParameters new];
+        requestParams.authority = authority;
+        requestParams.correlationId = [NSUUID UUID];
+        
+        XCTestExpectation* expectation = [self expectationWithDescription:@"validateAuthority"];
+        [authorityValidation checkAuthority:requestParams
+                          validateAuthority:NO
+                            completionBlock:^(BOOL validated, ADAuthenticationError *error)
+         {
+             XCTAssertFalse(validated);
+             XCTAssertNil(error);
+             
+             [expectation fulfill];
+         }];
+        [self waitForExpectationsWithTimeout:1 handler:nil];
+}
+
+
+}
 @end


### PR DESCRIPTION
Related to #1079 , adding a checking for ADFS authority when validateAuthority is turned off.

In doing so, API was refactored for clarity (Feel free to suggest a different name).
Integration tests were also revised and one extra case was added - ADFS authority with validateAuthority turned off.

