### PR TITLE
Change 'Builds for' to 7.1 to be able to compile with Xcode 9

### DIFF
--- a/ADALiOS/ADALiOS/ADAL_iPad_Storyboard.storyboard
+++ b/ADALiOS/ADALiOS/ADAL_iPad_Storyboard.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13C1021" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" initialViewController="DaP-pW-mnj">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" colorMatched="YES" initialViewController="DaP-pW-mnj">
+    <device id="ipad9_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment version="1536" defaultVersion="1792" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment version="1808" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Authentication View Controller-->
@@ -16,15 +20,15 @@
                             <webView tag="106" contentMode="scaleToFill" id="s1f-g9-Kf9">
                                 <rect key="frame" x="0.0" y="0.0" width="540" height="620"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" hidesWhenStopped="YES" animating="YES" style="whiteLarge" id="eov-Iv-rha">
                                 <rect key="frame" x="251" y="292" width="37" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <color key="color" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </activityIndicatorView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="S0O-Kh-zdY">
                         <barButtonItem key="leftBarButtonItem" systemItem="cancel" id="hRD-0N-cJA">
@@ -49,6 +53,7 @@
                 <navigationController storyboardIdentifier="LogonNavigator" definesPresentationContext="YES" modalPresentationStyle="formSheet" id="DaP-pW-mnj" sceneMemberID="viewController">
                     <modalFormSheetSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="uxq-zN-5N6">
+                        <rect key="frame" x="0.0" y="0.0" width="540" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -60,9 +65,4 @@
             <point key="canvasLocation" x="73" y="806"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
 </document>

--- a/ADALiOS/ADALiOS/ADAL_iPhone_Storyboard.storyboard
+++ b/ADALiOS/ADALiOS/ADAL_iPhone_Storyboard.storyboard
@@ -1,8 +1,12 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13C1021" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" initialViewController="Hml-Uj-EMT">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" colorMatched="YES" initialViewController="Hml-Uj-EMT">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
-        <deployment version="1536" identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
+        <deployment version="1808" identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Navigation Controller-->
@@ -10,6 +14,7 @@
             <objects>
                 <navigationController storyboardIdentifier="LogonNavigator" definesPresentationContext="YES" id="Hml-Uj-EMT" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" id="d1T-rc-yVs">
+                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <connections>
@@ -25,21 +30,21 @@
             <objects>
                 <viewController id="GcB-iz-KCM" customClass="ADAuthenticationViewController" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="UxT-im-uCY">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
                             <webView tag="105" contentMode="scaleToFill" id="aQj-zZ-Grp">
-                                <rect key="frame" x="0.0" y="0.0" width="320" height="480"/>
+                                <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </webView>
                             <activityIndicatorView opaque="NO" contentMode="scaleToFill" hidesWhenStopped="YES" animating="YES" style="whiteLarge" id="k7f-19-G6V">
-                                <rect key="frame" x="142" y="220" width="37" height="37"/>
+                                <rect key="frame" x="169" y="312" width="37" height="37"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMinX="YES" flexibleMaxX="YES" flexibleMinY="YES" flexibleMaxY="YES"/>
-                                <color key="color" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                                <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             </activityIndicatorView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <navigationItem key="navigationItem" id="rFS-lD-Be8">
                         <barButtonItem key="leftBarButtonItem" tag="106" systemItem="cancel" id="vgh-pA-bN7">
@@ -58,9 +63,4 @@
             <point key="canvasLocation" x="765" y="247"/>
         </scene>
     </scenes>
-    <simulatedMetricsContainer key="defaultSimulatedMetrics">
-        <simulatedStatusBarMetrics key="statusBar"/>
-        <simulatedOrientationMetrics key="orientation"/>
-        <simulatedScreenMetrics key="destination"/>
-    </simulatedMetricsContainer>
 </document>


### PR DESCRIPTION
When ADALiOS 1.2.9 was used in the application built in Xcode 9 following errors occurred:

```
PhaseScriptExecution [CP]\ Copy\ Pods\ Resources /Users/michal/Library/Developer/Xcode/DerivedData/TestADALApplication-exrbqazytjuiyrbawpnorpjbxhag/Build/Intermediates.noindex/TestADALApplication.build/Debug-iphonesimulator/TestADALApplication.build/Script-D052870319FD1354EA77F50A.sh
    cd /Users/michal/git/TestADALApplication
    /bin/sh -c /Users/michal/Library/Developer/Xcode/DerivedData/TestADALApplication-exrbqazytjuiyrbawpnorpjbxhag/Build/Intermediates.noindex/TestADALApplication.build/Debug-iphonesimulator/TestADALApplication.build/Script-D052870319FD1354EA77F50A.sh

ibtool --reference-external-strings-file --errors --warnings --notices --minimum-deployment-target 9.0 --output-format human-readable-text --compile /Users/michal/Library/Developer/Xcode/DerivedData/TestApp-exrbqazytjuiyrbawpnorpjbxhag/Build/Products/Debug-iphonesimulator/TestApp.app/ADAL_iPad_Storyboard.storyboardc /Users/michal/git/TestApp/Pods/ADALiOS/ADALiOS/ADALiOS/ADAL_iPad_Storyboard.storyboard --sdk /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator11.0.sdk --target-device ipad
/* com.apple.ibtool.document.warnings */
/Users/michal/git/TestADALApplication/Pods/ADALiOS/ADALiOS/ADALiOS/ADAL_iPad_Storyboard.storyboard:global: warning: This file is set to build for a version older than the deployment target. Functionality may be limited. [9]
/* com.apple.ibtool.document.errors */
/Users/michal/git/TestADALApplication/Pods/ADALiOS/ADALiOS/ADALiOS/ADAL_iPad_Storyboard.storyboard:global: error: Compiling IB documents for earlier than iOS 7 is no longer supported. [12]
Command /bin/sh failed with exit code 1
```

This happened because Storyboards were built for ealier version then 7.1. I set the 'Builds for' field to 7.1.