### PR TITLE
Add remove token cache item for a specific user

### DIFF
--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -395,28 +395,19 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     AD_LOG_WARN_DICT(([NSString stringWithFormat:@"Removing all items for client <%@>", clientId]), nil,
                      (@{ @"operation" : @"removeAllForClientId:", @"clientId" : clientId }), nil);
     
-    BOOL deleteSuccessful = YES;
     NSArray* items = [self allItems:nil];
-    
-    ADAuthenticationError* adError = nil;
     
     for (ADTokenCacheItem * item in items)
     {
         if ([clientId isEqualToString:[item clientId] ])
         {
-            [self removeItem:item error:&adError];
-            if (adError)
+            if (![self removeItem:item error:error])
             {
-                deleteSuccessful = NO;
-                
-                if (error)
-                {
-                    *error = adError;
-                }
+                return NO;
             }
         }
     }
-    return deleteSuccessful;
+    return YES;
 }
 
 - (BOOL)removeAllForUserId:(NSString * __nonnull)userId
@@ -427,28 +418,20 @@ static ADKeychainTokenCache* s_defaultCache = nil;
                        (@{ @"operation" : @"removeAllForUserId:clientId:", @"clientId" : clientId, @"userId" : userId }),
                        @"userId: %@", userId);
     
-    BOOL deleteSuccessful = YES;
     NSArray* items = [self allItems:nil];
-    
-    ADAuthenticationError* adError = nil;
     
     for (ADTokenCacheItem * item in items)
     {
         if ([userId isEqualToString:[[item userInformation] userId]]
             && [clientId isEqualToString:[item clientId]])
         {
-            [self removeItem:item error:&adError];
-            if (adError)
+            if (![self removeItem:item error:error])
             {
-                deleteSuccessful = NO;
-                if (error)
-                {
-                    *error = adError;
-                }
+                return NO;
             }
         }
     }
-    return deleteSuccessful;
+    return YES;
 }
 
 - (BOOL)removeAllForUserId:(NSString *)userId error:(ADAuthenticationError *__autoreleasing  _Nullable *)error
@@ -456,27 +439,19 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     AD_LOG_WARN_DICT(([NSString stringWithFormat:@"Removing all items for user <%@>", userId]), nil,
                      (@{ @"operation" : @"removeAllForClientId:", @"userId" : userId }), nil);
 
-    BOOL deleteSuccessful = YES;
     NSArray *items = [self allItems:nil];
-
-    ADAuthenticationError *adError = nil;
 
     for (ADTokenCacheItem *item in items)
     {
         if ([userId isEqualToString:[[item userInformation] userId]])
         {
-            [self removeItem:item error:&adError];
-            if (adError)
+            if (![self removeItem:item error:error])
             {
-                deleteSuccessful = NO;
-                if (error)
-                {
-                    *error = adError;
-                }
+                return NO;
             }
         }
     }
-    return deleteSuccessful;
+    return YES;
 }
 
 - (BOOL)cleanTombstoneIfNecessary

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -399,12 +399,10 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     
     for (ADTokenCacheItem * item in items)
     {
-        if ([clientId isEqualToString:[item clientId] ])
+        if ([clientId isEqualToString:[item clientId]]
+            && ![self removeItem:item error:error])
         {
-            if (![self removeItem:item error:error])
-            {
-                return NO;
-            }
+            return NO;
         }
     }
     return YES;
@@ -423,12 +421,10 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     for (ADTokenCacheItem * item in items)
     {
         if ([userId isEqualToString:[[item userInformation] userId]]
-            && [clientId isEqualToString:[item clientId]])
+            && [clientId isEqualToString:[item clientId]]
+            && ![self removeItem:item error:error])
         {
-            if (![self removeItem:item error:error])
-            {
-                return NO;
-            }
+            return NO;
         }
     }
     return YES;
@@ -443,12 +439,10 @@ static ADKeychainTokenCache* s_defaultCache = nil;
 
     for (ADTokenCacheItem *item in items)
     {
-        if ([userId isEqualToString:[[item userInformation] userId]])
+        if ([userId isEqualToString:[[item userInformation] userId]]
+            && ![self removeItem:item error:error])
         {
-            if (![self removeItem:item error:error])
-            {
-                return NO;
-            }
+            return NO;
         }
     }
     return YES;

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -451,6 +451,35 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     return deleteSuccessful;
 }
 
+- (BOOL)removeAllForUserId:(NSString *)userId error:(ADAuthenticationError *__autoreleasing  _Nullable *)error
+{
+    AD_LOG_WARN_DICT_F(([NSString stringWithFormat:@"Removing all items for user %@", userId]), nil,
+                       (@{ @"operation" : @"removeAllForUserId:clientId:", @"userId" : userId }),
+                       nil);
+
+    BOOL deleteSuccessful = YES;
+    NSArray *items = [self allItems:nil];
+
+    ADAuthenticationError *adError = nil;
+
+    for (ADTokenCacheItem *item in items)
+    {
+        if ([userId isEqualToString:[[item userInformation] userId]])
+        {
+            [self removeItem:item error:&adError];
+            if (adError)
+            {
+                deleteSuccessful = NO;
+                if (error)
+                {
+                    *error = adError;
+                }
+            }
+        }
+    }
+    return deleteSuccessful;
+}
+
 - (BOOL)cleanTombstoneIfNecessary
 {
     //Check whether it is time to clean tombstones

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -453,9 +453,8 @@ static ADKeychainTokenCache* s_defaultCache = nil;
 
 - (BOOL)removeAllForUserId:(NSString *)userId error:(ADAuthenticationError *__autoreleasing  _Nullable *)error
 {
-    AD_LOG_WARN_DICT_F(([NSString stringWithFormat:@"Removing all items for user %@", userId]), nil,
-                       (@{ @"operation" : @"removeAllForUserId:clientId:", @"userId" : userId }),
-                       nil);
+    AD_LOG_WARN_DICT(([NSString stringWithFormat:@"Removing all items for user <%@>", userId]), nil,
+                     (@{ @"operation" : @"removeAllForClientId:", @"userId" : userId }), nil);
 
     BOOL deleteSuccessful = YES;
     NSArray *items = [self allItems:nil];

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -433,7 +433,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
 - (BOOL)removeAllForUserId:(NSString *)userId error:(ADAuthenticationError *__autoreleasing  _Nullable *)error
 {
     AD_LOG_WARN_DICT(([NSString stringWithFormat:@"Removing all items for user <%@>", userId]), nil,
-                     (@{ @"operation" : @"removeAllForClientId:", @"userId" : userId }), nil);
+                     (@{ @"operation" : @"removeAllForUserId:", @"userId" : userId }), nil);
 
     NSArray *items = [self allItems:nil];
 

--- a/ADAL/src/public/ios/ADKeychainTokenCache.h
+++ b/ADAL/src/public/ios/ADKeychainTokenCache.h
@@ -80,14 +80,24 @@
  Returns nil in case of error. */
 - (nullable NSArray<ADTokenCacheItem *> *)allItems:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
+/* Removes a token cache item from the keychain */
 - (BOOL)removeItem:(nonnull ADTokenCacheItem *)item
              error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
+/* Removes all token cache items for a specific client from the keychain.
+ */
 - (BOOL)removeAllForClientId:(NSString * __nonnull)clientId
                        error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
+/* Removes all token cache items for a specific user and a specific clientId from the keychain
+ */
 - (BOOL)removeAllForUserId:(NSString * __nonnull)userId
                   clientId:(NSString * __nonnull)clientId
+                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/* Removes all token cache items for a specific user from the keychain
+ */
+- (BOOL)removeAllForUserId:(NSString * __nonnull)userId
                      error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
 
 @end

--- a/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
@@ -341,7 +341,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     [self verifyCacheContainsItem:item4];
 }
 
-- (void)testRemoveAllForUserId
+- (void)testRemoveAllForUserIdAndClientId
 {
     XCTAssertTrue([self count] == 0, "Start empty.");
     
@@ -374,6 +374,44 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     [self verifyCacheContainsItem:item3];
     [self verifyCacheContainsItem:item4];
 }
+
+- (void)testRemoveAllForUserId
+{
+    XCTAssertTrue([self count] == 0, "Start empty.");
+    
+    ADAuthenticationError* error;
+    XCTAssertNotNil([mStore allItems:&error]);
+    ADAssertNoError;
+    
+    //add two items with the same user ID but differnet client ID
+    ADTokenCacheItem* item1 = [self adCreateCacheItem:@"eric@contoso.com"];
+    [item1 setClientId:@"client 1"];
+    [mStore addOrUpdateItem:item1 correlationId:nil error:&error];
+    ADTokenCacheItem* item2 = [self adCreateCacheItem:@"eric@contoso.com"];
+    [item2 setClientId:@"client 2"];
+    [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
+    //add another two more items with different user ID but with same client ID as above
+    ADTokenCacheItem* item3 = [self adCreateCacheItem:@"jack@contoso.com"];
+    [item3 setClientId:@"client 1"];
+    [mStore addOrUpdateItem:item3 correlationId:nil error:&error];
+    ADTokenCacheItem* item4 = [self adCreateCacheItem:@"rose@contoso.com"];
+    [item4 setClientId:@"client 2"];
+    [mStore addOrUpdateItem:item4 correlationId:nil error:&error];
+
+    ADAssertNoError;
+    XCTAssertEqual([self count], 4);
+    XCTAssertEqual([self tombstoneCount], 0);
+    
+    //remove items with user ID as @"eric@contoso.com" and client ID as TEST_CLIENT_ID
+    [mStore removeAllForUserId:@"eric@contoso.com" error:&error];
+    ADAssertNoError;
+    XCTAssertEqual([self count], 2);
+    XCTAssertEqual([self tombstoneCount], 2);
+    //only item3 and item4 are left in cache while the other twi should be tombstones
+    [self verifyCacheContainsItem:item3];
+    [self verifyCacheContainsItem:item4];
+}
+
 
 - (void)verifyCacheContainsItem: (ADTokenCacheItem*) item
 {


### PR DESCRIPTION
Add to public API that enables apps to delete all token cache items for a specific user.

Add few missing comments for other remove methods in the  ADKeychainTokenCache.h