### PR TITLE
ADKeychainTokenCache - Adding error check for getting all users in keychain.

### DIFF
--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -393,7 +393,11 @@ static ADKeychainTokenCache* s_defaultCache = nil;
 {
     AD_LOG_WARN(nil, @"Removing all items for client %@", clientId);
     
-    NSArray* items = [self allItems:nil];
+    NSArray* items = [self allItems:error];
+    if (!items)
+    {
+        return NO;
+    }
     
     for (ADTokenCacheItem * item in items)
     {
@@ -414,6 +418,10 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     AD_LOG_WARN(nil, @"userid = %@", userId);
     
     NSArray* items = [self allItems:nil];
+    if (!items)
+    {
+        return NO;
+    }
     
     for (ADTokenCacheItem * item in items)
     {
@@ -433,7 +441,11 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     AD_LOG_WARN_PII(nil, @"userId <%@>", userId);
 
     NSArray *items = [self allItems:nil];
-
+    if (!items)
+    {
+        return NO;
+    }
+    
     for (ADTokenCacheItem *item in items)
     {
         if ([userId isEqualToString:[[item userInformation] userId]]


### PR DESCRIPTION
It was missing a check for retrieval of items. 

For reference: ADKeychainTokenCache's allItems method return nil in case of an error.