### PR TITLE
Allow about:blank page to load

### DIFF
--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -274,7 +274,7 @@ NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
 
     if ([[requestURL lowercaseString] isEqualToString:@"about:blank"])
     {
-        return NO;
+        return YES;
     }
     
     if ([[[request.URL scheme] lowercaseString] isEqualToString:@"browser"])


### PR DESCRIPTION
Some customers' html page depends on the behaviour of loading about:blank page. Therefore change to allow blank page to load.

After investigation, the change won't cause AD_ERROR_SERVER_NON_HTTPS_REDIRECT error unless the if statement is removed completely.