### PR TITLE
Parse http headers and error domain from broker

### DIFF
--- a/ADAL/src/ADAuthenticationError+Internal.h
+++ b/ADAL/src/ADAuthenticationError+Internal.h
@@ -68,8 +68,9 @@
                               errorDetails:(NSString *)errorDetails
                              correlationId:(NSUUID *)correlationId;
 
-+ (ADAuthenticationError *)errorWithDomain:(NSErrorDomain)domain
++ (ADAuthenticationError *)errorWithDomain:(NSString *)domain
                                       code:(NSInteger)code
+                         protocolErrorCode:(NSString *)protocolCode
                               errorDetails:(NSString *)errorDetails
                              correlationId:(NSUUID *)correlationId;
 

--- a/ADAL/src/ADAuthenticationError.m
+++ b/ADAL/src/ADAuthenticationError.m
@@ -160,6 +160,20 @@ NSString* const ADNonHttpsRedirectError = @"The server has redirected to a non-h
                                 userInfo:error.userInfo];
 }
 
++ (ADAuthenticationError *)errorWithDomain:(NSString *)domain
+                                      code:(NSInteger)code
+                         protocolErrorCode:(NSString *)protocolCode
+                              errorDetails:(NSString *)errorDetails
+                             correlationId:(NSUUID *)correlationId
+{
+    return [self errorWithDomainInternal:domain
+                                    code:code
+                       protocolErrorCode:protocolCode
+                            errorDetails:errorDetails
+                           correlationId:correlationId
+                                userInfo:nil];
+}
+
 + (ADAuthenticationError*)errorFromAuthenticationError:(NSInteger)code
                                           protocolCode:(NSString *)protocolCode
                                           errorDetails:(NSString *)errorDetails

--- a/ADAL/tests/unit/ios/ADBrokerMessageTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerMessageTests.m
@@ -139,10 +139,10 @@
 
 - (void)testBrokerMessage_whenBrokerKeychainError_shouldCreateErrorWithKeychainErrorDomain
 {
-    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    NSDictionary *resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
     [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
 
-    NSDictionary* brokerMessage =
+    NSDictionary *brokerMessage =
     @{
       @"code" : @"(null)",
       @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
@@ -152,10 +152,10 @@
       @"x-broker-app-ver" : @"2.1.0"
       };
 
-    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
-    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    NSString *brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL *brokerUrl = [NSURL URLWithString:brokerUrlStr];
 
-    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker keychain error."];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Broker keychain error."];
     [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
      {
          XCTAssertNotNil(result.error);
@@ -175,10 +175,10 @@
 
 - (void)testBrokerMessage_whenBrokerHttpError_shouldCreateErrorWithHttpErrorDomain
 {
-    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    NSDictionary *resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
     [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
     
-    NSDictionary* brokerMessage =
+    NSDictionary *brokerMessage =
     @{
       @"code" : @"(null)",
       @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
@@ -189,10 +189,10 @@
       @"x-broker-app-ver" : @"2.1.0"
       };
     
-    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
-    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    NSString *brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL *brokerUrl = [NSURL URLWithString:brokerUrlStr];
     
-    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker http error."];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Broker http error."];
     [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
      {
          XCTAssertNotNil(result.error);
@@ -213,10 +213,10 @@
 
 - (void)testBrokerMessage_whenBrokerServerError_shouldCreateErrorWithServerErrorDomain
 {
-    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    NSDictionary *resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
     [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
     
-    NSDictionary* brokerMessage =
+    NSDictionary *brokerMessage =
     @{
       @"code" : @"Refresh token is rejected due to inactivity.",
       @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
@@ -226,10 +226,10 @@
       @"x-broker-app-ver" : @"2.1.0"
       };
     
-    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
-    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    NSString *brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL *brokerUrl = [NSURL URLWithString:brokerUrlStr];
     
-    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker keychain error."];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"Broker keychain error."];
     [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
      {
          XCTAssertNotNil(result.error);

--- a/ADAL/tests/unit/ios/ADBrokerMessageTests.m
+++ b/ADAL/tests/unit/ios/ADBrokerMessageTests.m
@@ -137,5 +137,114 @@
     XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kAdalResumeDictionaryKey]);
 }
 
+- (void)testBrokerMessage_whenBrokerKeychainError_shouldCreateErrorWithKeychainErrorDomain
+{
+    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+
+    NSDictionary* brokerMessage =
+    @{
+      @"code" : @"(null)",
+      @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
+      @"error_code" : @"-25300",
+      @"error_description" : @"Keychain failed during read operation",
+      @"error_domain" : ADKeychainErrorDomain,
+      @"x-broker-app-ver" : @"2.1.0"
+      };
+
+    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker keychain error."];
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result.error);
+         XCTAssertEqualObjects(result.error.domain, ADKeychainErrorDomain);
+         XCTAssertEqual(result.error.code, -25300);
+         XCTAssertEqualObjects(result.error.errorDetails, @"Keychain failed during \"Broker keychain access\" operation");
+         XCTAssertEqualObjects(result.error.protocolCode, nil); //keychain error does not has protocolCode
+
+         [expectation fulfill];
+     }];
+
+    XCTAssertTrue([ADAuthenticationContext handleBrokerResponse:brokerUrl]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kAdalResumeDictionaryKey]);
+}
+
+- (void)testBrokerMessage_whenBrokerHttpError_shouldCreateErrorWithHttpErrorDomain
+{
+    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+    
+    NSDictionary* brokerMessage =
+    @{
+      @"code" : @"(null)",
+      @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
+      @"error_code" : @"429",
+      @"error_description" : @"(3239 bytes)",
+      @"error_domain" : ADHTTPErrorCodeDomain,
+      @"http_headers" : @"Retry-After=120&Connection=Keep-alive&x-ms-clitelem=1%2C0%2C0%2C%2C",
+      @"x-broker-app-ver" : @"2.1.0"
+      };
+    
+    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker http error."];
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result.error);
+         XCTAssertEqualObjects(result.error.domain, ADHTTPErrorCodeDomain);
+         XCTAssertEqual(result.error.code, 429);
+         XCTAssertEqualObjects(result.error.errorDetails, @"(3239 bytes)");
+         XCTAssertEqualObjects(result.error.protocolCode, nil); //http error does not has protocolCode
+         XCTAssertEqualObjects(result.error.userInfo[ADHTTPHeadersKey][@"Retry-After"], @"120");
+         
+         [expectation fulfill];
+     }];
+    
+    XCTAssertTrue([ADAuthenticationContext handleBrokerResponse:brokerUrl]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kAdalResumeDictionaryKey]);
+}
+
+- (void)testBrokerMessage_whenBrokerServerError_shouldCreateErrorWithServerErrorDomain
+{
+    NSDictionary* resumeDictionary = @{ @"redirect_uri" : @"ms-outlook://" };
+    [[NSUserDefaults standardUserDefaults] setObject:resumeDictionary forKey:kAdalResumeDictionaryKey];
+    
+    NSDictionary* brokerMessage =
+    @{
+      @"code" : @"Refresh token is rejected due to inactivity.",
+      @"correlation_id" : @"EC021F91-FAD9-41C6-A7B8-BD09D050E7C0",
+      @"error_code" : @"202",
+      @"error_description" : @"fake error description",
+      @"error_domain" : ADOAuthServerErrorDomain,
+      @"x-broker-app-ver" : @"2.1.0"
+      };
+    
+    NSString* brokerUrlStr = [NSString stringWithFormat:@"ms-outlook://?%@", [brokerMessage adURLFormEncode]];
+    NSURL* brokerUrl = [NSURL URLWithString:brokerUrlStr];
+    
+    XCTestExpectation* expectation = [self expectationWithDescription:@"Broker keychain error."];
+    [ADBrokerNotificationManager.sharedInstance enableNotifications:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result.error);
+         XCTAssertEqualObjects(result.error.domain, ADOAuthServerErrorDomain);
+         XCTAssertEqual(result.error.code, 202);
+         XCTAssertEqualObjects(result.error.errorDetails, @"fake error description");
+         XCTAssertEqualObjects(result.error.protocolCode, @"Refresh token is rejected due to inactivity."); //keychain error does not has protocolCode
+         
+         [expectation fulfill];
+     }];
+    
+    XCTAssertTrue([ADAuthenticationContext handleBrokerResponse:brokerUrl]);
+    [self waitForExpectationsWithTimeout:1.0 handler:nil];
+    
+    XCTAssertNil([[NSUserDefaults standardUserDefaults] objectForKey:kAdalResumeDictionaryKey]);
+}
 
 @end


### PR DESCRIPTION
Changes are made to parse the error domain and http headers from broker.

Now it will create error objects with different error domains according to `error_domain` value from broker.

I notice that we seems never create error objects with `ADBrokerResponseErrorDomain`? (probably we can verify it by telemetry :))