### PR TITLE
Version in Test Apps

### DIFF
--- a/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
+++ b/Samples/MyTestMacOSApp/MyTestMacOSApp/ADTestAppAcquireTokenWindowController.m
@@ -101,6 +101,8 @@
 {
     [super windowDidLoad];
     
+    self.window.title = [NSString stringWithFormat:@"Acquire Token (%@)", ADAL_VERSION_NSSTRING];
+    
     [self.window.contentView addSubview:_acquireSettingsView];
     [_authView setHidden:YES];
     [self.window.contentView addSubview:_authView];

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -197,6 +197,7 @@
     _resultView.layer.cornerRadius = 8.0f;
     _resultView.backgroundColor = [UIColor colorWithRed:0.96f green:0.96f blue:0.96f alpha:1.0f];
     _resultView.editable = NO;
+    _resultView.text = [NSString stringWithFormat:@"ADAL %@", ADAL_VERSION_NSSTRING];
     [layout addView:_resultView key:@"result"];
     
     UIView* contentView = [layout contentView];


### PR DESCRIPTION
Add the current version into the window title (Mac) or result view (iOS) so you can know at a glance if you're on the right version app for testing.