### PR TITLE
When we're getting a new access token from broker result include the …

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -403,6 +403,10 @@
 		D69A721B1D4FF68300E91DB3 /* ADAggregatedDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401B51D37658C0020EAAB /* ADAggregatedDispatcher.m */; };
 		D69A721C1D4FF68300E91DB3 /* ADTelemetryDefaultEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 600401AA1D3443D30020EAAB /* ADTelemetryDefaultEvent.m */; };
 		D6B658861EF8AB5B006CB0C6 /* SecurityInterface.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D6B658851EF8AB5B006CB0C6 /* SecurityInterface.framework */; };
+		D6BA664F20167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */; };
+		D6BA665020167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */; };
+		D6BA665120167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */; };
+		D6BA665220167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */; };
 		D6D4D4981F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D4D4971F2FCD8600CC1859 /* ADTestURLResponse.m */; };
 		D6D4D4991F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D4D4971F2FCD8600CC1859 /* ADTestURLResponse.m */; };
 		D6D4D49A1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */ = {isa = PBXBuildFile; fileRef = D6D4D4971F2FCD8600CC1859 /* ADTestURLResponse.m */; };
@@ -805,6 +809,9 @@
 		D68040311D22F686007A61AC /* ADWebAuthResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADWebAuthResponse.h; sourceTree = "<group>"; };
 		D68040321D22F686007A61AC /* ADWebAuthResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADWebAuthResponse.m; sourceTree = "<group>"; };
 		D6B658851EF8AB5B006CB0C6 /* SecurityInterface.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SecurityInterface.framework; path = Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk/System/Library/Frameworks/SecurityInterface.framework; sourceTree = DEVELOPER_DIR; };
+		D6BA664D20167BA2001085EC /* ADRefreshResponseBuilder.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADRefreshResponseBuilder.h; sourceTree = "<group>"; };
+		D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADRefreshResponseBuilder.m; sourceTree = "<group>"; };
+		D6BA665320167E15001085EC /* ADTestConstants.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTestConstants.h; sourceTree = "<group>"; };
 		D6D4D4961F2FCD8600CC1859 /* ADTestURLResponse.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTestURLResponse.h; sourceTree = "<group>"; };
 		D6D4D4971F2FCD8600CC1859 /* ADTestURLResponse.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestURLResponse.m; sourceTree = "<group>"; };
 		D6D8A83E1D4FD14100D20DE6 /* ADKeychainUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADKeychainUtil.h; sourceTree = "<group>"; };
@@ -1086,6 +1093,7 @@
 				D67D3D391F38502900660F32 /* ADTestCase.h */,
 				D67D3D3A1F38502900660F32 /* ADTestCase.m */,
 				D67D3D3F1F38538100660F32 /* ADTest.pch */,
+				D6BA665320167E15001085EC /* ADTestConstants.h */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -1496,6 +1504,8 @@
 				D66A9F1B1F76D05900144011 /* NSURL+ADTestUtil.m */,
 				D66A9F261F7998D300144011 /* ADTokenCacheTestUtil.h */,
 				D66A9F271F7998D300144011 /* ADTokenCacheTestUtil.m */,
+				D6BA664D20167BA2001085EC /* ADRefreshResponseBuilder.h */,
+				D6BA664E20167BA2001085EC /* ADRefreshResponseBuilder.m */,
 			);
 			path = util;
 			sourceTree = "<group>";
@@ -2091,6 +2101,7 @@
 				B20DC6011F0D998A00957806 /* ADTokenCacheKeyTests.m in Sources */,
 				B20DC5F71F0D998A00957806 /* ADClientMetricsTests.m in Sources */,
 				D66A9F1C1F76D05900144011 /* NSURL+ADTestUtil.m in Sources */,
+				D6BA664F20167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */,
 				B20DC6211F0DA4BF00957806 /* ADWebAuthControllerTests.m in Sources */,
 				D67D3D351F382F8B00660F32 /* NSDictionary+ADTestUtil.m in Sources */,
 			);
@@ -2189,6 +2200,7 @@
 				D6D4D49A1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				B20DC6061F0D998A00957806 /* ADUserInformationTests.m in Sources */,
 				D632B5541F50AEDC001173F1 /* ADAadAuthorityCache+TestUtil.m in Sources */,
+				D6BA665120167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */,
 				B20DC60A1F0D998A00957806 /* NSURLExtensionsTests.m in Sources */,
 				B20DC6021F0D998A00957806 /* ADTokenCacheKeyTests.m in Sources */,
 				B20DC5FA1F0D998A00957806 /* ADHelpersTests.m in Sources */,
@@ -2234,6 +2246,7 @@
 				B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				B20DC5891F0D96A100957806 /* ADTelemetryTestDispatcher.m in Sources */,
 				D6771E041F749FD800D0DCDC /* ADApplicationTestUtil.m in Sources */,
+				D6BA665020167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */,
 				D66A9F1D1F76D05900144011 /* NSURL+ADTestUtil.m in Sources */,
 				B20DC6121F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC5951F0D96A100957806 /* ADTestURLSessionDataTask.m in Sources */,
@@ -2265,6 +2278,7 @@
 				B20DC5C71F0D96A700957806 /* ADTestURLSession.m in Sources */,
 				D67D3D461F422C3000660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */,
 				D66A9F2B1F7998D300144011 /* ADTokenCacheTestUtil.m in Sources */,
+				D6BA665220167BA2001085EC /* ADRefreshResponseBuilder.m in Sources */,
 				D632B54F1F50AE6B001173F1 /* ADAuthorityValidation+TestUtil.m in Sources */,
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				D62256541F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -28,21 +28,23 @@
 
 @interface ADRequestParameters : NSObject <ADRequestContext>
 {
-    NSString* _authority;
-    NSString* _resource;
-    NSString* _clientId;
-    NSString* _redirectUri;
-    ADUserIdentifier* _identifier;
-    ADTokenCacheAccessor* _tokenCache;
+    NSString *_authority;
+    NSString *_resource;
+    NSString *_clientId;
+    NSString *_redirectUri;
+    NSString *_scope;
+    ADUserIdentifier *_identifier;
+    ADTokenCacheAccessor *_tokenCache;
     BOOL _extendedLifetime;
-    NSUUID* _correlationId;
-    NSString* _telemetryRequestId;
+    NSUUID *_correlationId;
+    NSString *_telemetryRequestId;
 }
 
 @property (retain, nonatomic) NSString* authority;
 @property (retain, nonatomic) NSString* resource;
 @property (retain, nonatomic) NSString* clientId;
 @property (retain, nonatomic) NSString* redirectUri;
+@property (retain, nonatomic) NSString* scope;
 @property (retain, nonatomic) ADUserIdentifier* identifier;
 @property (retain, nonatomic) ADTokenCacheAccessor* tokenCache;
 @property BOOL extendedLifetime;

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -121,6 +121,11 @@
         [request_data setObject:[_requestParams resource] forKey:OAUTH2_RESOURCE];
     }
     
+    if (![NSString adIsStringNilOrBlank:_requestParams.scope])
+    {
+        request_data[OAUTH2_SCOPE] = _requestParams.scope;
+    }
+    
     ADWebAuthRequest* webReq =
     [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:[[_requestParams authority] stringByAppendingString:OAUTH2_TOKEN_SUFFIX]]
                                   context:_requestParams];

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -376,6 +376,19 @@
              // If we got back a valid RT but no access token then replay the RT for a new AT
              if (result.status == AD_SUCCEEDED && result.tokenCacheItem.accessToken == nil)
              {
+                 if (_requestParams.scope == nil)
+                 {
+                    [self setScope:@"openid"];
+                 }
+                 else
+                 {
+                     NSArray *scopes = [_requestParams.scope componentsSeparatedByString:@" "];
+                     if (![scopes containsObject:@"openid"])
+                     {
+                         [self setScope:[NSString stringWithFormat:@"openid %@", _requestParams.scope]];
+                     }
+                 }
+                 
                  [self getAccessToken:completionBlock];
                  return;
              }
@@ -497,9 +510,9 @@
                                          [_requestParams clientId], OAUTH2_CLIENT_ID,
                                          [_requestParams redirectUri], OAUTH2_REDIRECT_URI,
                                          nil];
-    if (![NSString adIsStringNilOrBlank:_scope])
+    if (![NSString adIsStringNilOrBlank:_requestParams.scope])
     {
-        [request_data setValue:_scope forKey:OAUTH2_SCOPE];
+        [request_data setValue:_requestParams.scope forKey:OAUTH2_SCOPE];
     }
     
     [self executeRequest:request_data

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -98,7 +98,7 @@
 // Encodes the state parameter for a protocol message
 - (NSString *)encodeProtocolState
 {
-    return [[[NSMutableDictionary dictionaryWithObjectsAndKeys:[_requestParams authority], @"a", [_requestParams resource], @"r", _scope, @"s", nil]
+    return [[[NSMutableDictionary dictionaryWithObjectsAndKeys:[_requestParams authority], @"a", [_requestParams resource], @"r", _requestParams.scope, @"s", nil]
              adURLFormEncode] adBase64UrlEncode];
 }
 
@@ -270,9 +270,9 @@
                        @"1", @"nux",
                        @"none", @"prompt", nil];
         
-        if (_scope)
+        if (![NSString adIsStringNilOrBlank:_requestParams.scope])
         {
-            [requestData setObject:_scope forKey:OAUTH2_SCOPE];
+            [requestData setObject:_requestParams.scope forKey:OAUTH2_SCOPE];
         }
         
         if ([_requestParams identifier] && [[_requestParams identifier] isDisplayable] && ![NSString adIsStringNilOrBlank:[_requestParams identifier].userId])

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -53,7 +53,6 @@
     
     ADPromptBehavior _promptBehavior;
     
-    NSString* _scope;
     NSString* _queryParams;
     NSString* _claims;
     

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -81,6 +81,10 @@ static dispatch_semaphore_t s_interactionLock = nil;
     }
     
     request->_context = context;
+    ADRequestParameters *params = [ADRequestParameters new];
+    params.authority = context.authority;
+    params.tokenCache = context.tokenCacheStore;
+    request->_requestParams = params;
     
     return request;
 }
@@ -128,12 +132,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
 
 - (void)setScope:(NSString *)scope
 {
-    CHECK_REQUEST_STARTED;
-    if (_scope == scope)
-    {
-        return;
-    }
-    _scope = [scope copy];
+    _requestParams.scope = scope;
 }
 
 - (void)setExtraQueryParameters:(NSString *)queryParams

--- a/ADAL/tests/ADTestConstants.h
+++ b/ADAL/tests/ADTestConstants.h
@@ -21,27 +21,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-#import <Foundation/Foundation.h>
+#ifndef ADTestConstants_h
+#define ADTestConstants_h
 
-#import "ADTokenCache.h"
-#if TARGET_OS_IPHONE
-#import "ADKeychainTokenCache.h"
-#endif
+#define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
+#define TEST_REDIRECT_URL_STRING @"urn:ietf:wg:oauth:2.0:oob"
+#define TEST_REDIRECT_URL [NSURL URLWithString:TEST_REDIRECT_URL_STRING]
+#define TEST_RESOURCE @"resource"
+#define TEST_USER_ID @"eric_cartman@contoso.com"
+#define TEST_CLIENT_ID @"c3c7f5e5-7153-44d4-90e6-329686d48d76"
+#define TEST_ACCESS_TOKEN @"access token"
+#define TEST_ACCESS_TOKEN_TYPE @"access token type"
+#define TEST_REFRESH_TOKEN @"refresh token"
+#define TEST_UPDATE_REFRESH_TOKEN @"updated refresh token"
+#define TEST_CORRELATION_ID ({NSUUID *testID = [[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"]; testID;})
 
-@protocol ADTokenCacheTestUtil
 
-- (NSString *)getAT:(NSString *)authority;
-- (NSString *)getMRRT:(NSString *)authority;
-- (ADTokenCacheItem *)getMRRTItem:(NSString *)authority;
-- (NSString *)getFRT:(NSString *)authority;
-- (ADTokenCacheItem *)getFRTItem:(NSString *)authority;
-
-@end
-
-@interface ADTokenCache (TestUtil) <ADTokenCacheTestUtil>
-@end
-
-#if TARGET_OS_IPHONE
-@interface ADKeychainTokenCache (TestUtil) <ADTokenCacheTestUtil>
-@end
-#endif
+#endif /* ADTestConstants_h */

--- a/ADAL/tests/XCTestCase+TestHelperMethods.h
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.h
@@ -25,19 +25,9 @@
 #import "ADAuthenticationError.h"
 #import "ADAL_Internal.h"
 #import "ADTelemetry.h"
+#import "ADTestConstants.h"
 
 #define ADTAssertContains(_str, _contains) XCTAssertTrue([_str containsString:_contains], "%@ does not contain \"%@\"", _str, _contains)
-
-#define TEST_AUTHORITY @"https://login.windows.net/contoso.com"
-#define TEST_REDIRECT_URL_STRING @"urn:ietf:wg:oauth:2.0:oob"
-#define TEST_REDIRECT_URL [NSURL URLWithString:TEST_REDIRECT_URL_STRING]
-#define TEST_RESOURCE @"resource"
-#define TEST_USER_ID @"eric_cartman@contoso.com"
-#define TEST_CLIENT_ID @"c3c7f5e5-7153-44d4-90e6-329686d48d76"
-#define TEST_ACCESS_TOKEN @"access token"
-#define TEST_ACCESS_TOKEN_TYPE @"access token type"
-#define TEST_REFRESH_TOKEN @"refresh token"
-#define TEST_CORRELATION_ID ({NSUUID *testID = [[NSUUID alloc] initWithUUIDString:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"]; testID;})
 
 @class ADTokenCacheItem;
 @class ADUserInformation;
@@ -45,6 +35,9 @@
 @class ADTestURLResponse;
 
 @interface XCTestCase (HelperMethods)
+
++ (ADUserInformation *)adCreateUserInformation:(NSString *)userId
+                                      tenantId:(NSString *)tid;
 
 - (void)adAssertStringEquals:(NSString *)actual
             stringExpression:(NSString *)expression

--- a/ADAL/tests/XCTestCase+TestHelperMethods.m
+++ b/ADAL/tests/XCTestCase+TestHelperMethods.m
@@ -223,19 +223,25 @@ volatile int sAsyncExecuted;//The number of asynchronous callbacks executed.
     return key;
 }
 
-+ (ADUserInformation *)adCreateUserInformation:(NSString*)userId
++ (ADUserInformation *)adCreateUserInformation:(NSString *)userId
+{
+    return [self adCreateUserInformation:userId tenantId:@"6fd1f5cd-a94c-4335-889b-6c598e6d8048"];
+}
+
++ (ADUserInformation *)adCreateUserInformation:(NSString *)userId
+                                      tenantId:(NSString *)tid
 {
     NSAssert(userId, @"userId cannot be nil!");
     NSDictionary* part1_claims = @{ @"typ" : @"JWT",
                                     @"alg" : @"none" };
     
     NSDictionary* idtoken_claims = @{ @"aud" : @"c3c7f5e5-7153-44d4-90e6-329686d48d76",
-                                      @"iss" : @"https://sts.windows.net/6fd1f5cd-a94c-4335-889b-6c598e6d8048",
+                                      @"iss" : [NSString stringWithFormat:@"https://sts.windows.net/%@", tid],
                                       @"iat" : @"1387224169",
                                       @"nbf" : @"1387224169",
                                       @"exp" : @"1387227769",
                                       @"ver" : @"1.0",
-                                      @"tid" : @"6fd1f5cd-a94c-4335-889b-6c598e6d8048",
+                                      @"tid" : tid,
                                       @"oid" : @"53c6acf2-2742-4538-918d-e78257ec8516",
                                       @"upn" : userId,
                                       @"unique_name" : userId,

--- a/ADAL/tests/util/ADRefreshResponseBuilder.h
+++ b/ADAL/tests/util/ADRefreshResponseBuilder.h
@@ -23,25 +23,27 @@
 
 #import <Foundation/Foundation.h>
 
-#import "ADTokenCache.h"
-#if TARGET_OS_IPHONE
-#import "ADKeychainTokenCache.h"
-#endif
+@interface ADRefreshResponseBuilder : NSObject
 
-@protocol ADTokenCacheTestUtil
+@property (copy, readwrite, nonnull) NSString *authority;
+@property (copy, readwrite, nonnull) NSString *clientId;
+@property (copy, readwrite, nonnull) NSString *resource;
+@property (copy, readwrite, nonnull) NSUUID *correlationId;
 
-- (NSString *)getAT:(NSString *)authority;
-- (NSString *)getMRRT:(NSString *)authority;
-- (ADTokenCacheItem *)getMRRTItem:(NSString *)authority;
-- (NSString *)getFRT:(NSString *)authority;
-- (ADTokenCacheItem *)getFRTItem:(NSString *)authority;
+@property (copy, readwrite, nonnull) NSString *oldRefreshToken;
+
+@property (readonly, nonnull) NSMutableDictionary *requestHeaders;
+@property (readonly, nonnull) NSMutableDictionary *requestBody;
+
+@property (readwrite) NSInteger responseCode;
+@property (readonly, nonnull) NSMutableDictionary *responseHeaders;
+@property (readonly, nonnull) NSMutableDictionary *responseBody;
+
+@property (copy, readwrite, nonnull) NSString *updatedRefreshToken;
+@property (copy, readwrite, nonnull) NSString *updatedAccessToken;
+@property (copy, readwrite, nonnull) NSDate *expirationTime;
+@property (copy, readwrite, nullable) NSString *updatedIdToken;
+
+- (nonnull ADTestURLResponse *)response;
 
 @end
-
-@interface ADTokenCache (TestUtil) <ADTokenCacheTestUtil>
-@end
-
-#if TARGET_OS_IPHONE
-@interface ADKeychainTokenCache (TestUtil) <ADTokenCacheTestUtil>
-@end
-#endif

--- a/ADAL/tests/util/ADRefreshResponseBuilder.m
+++ b/ADAL/tests/util/ADRefreshResponseBuilder.m
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADRefreshResponseBuilder.h"
+#import "ADOAuth2Constants.h"
+#import "ADTestConstants.h"
+
+@implementation ADRefreshResponseBuilder
+
+- (id)init
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    self.authority = TEST_AUTHORITY;
+    self.clientId = TEST_CLIENT_ID;
+    self.resource = TEST_RESOURCE;
+    
+    self.oldRefreshToken = TEST_REFRESH_TOKEN;
+    self.updatedAccessToken = TEST_ACCESS_TOKEN;
+    self.updatedRefreshToken = TEST_UPDATE_REFRESH_TOKEN;
+    self.expirationTime = [NSDate dateWithTimeIntervalSinceNow:3600.0];
+    
+    self.correlationId = TEST_CORRELATION_ID;
+    
+    _requestHeaders = [[ADTestURLResponse defaultHeaders] mutableCopy];
+    _requestBody = [NSMutableDictionary new];
+    
+    _responseHeaders = [NSMutableDictionary new];
+    _responseBody = [NSMutableDictionary new];
+    
+    self.responseCode = 200;
+    
+    return self;
+}
+
+- (nonnull ADTestURLResponse *)response
+{
+    NSString* requestUrlString = [NSString stringWithFormat:@"%@/oauth2/token?x-client-Ver=" ADAL_VERSION_STRING, self.authority];
+    
+    _requestHeaders[@"client-request-id"] = [self.correlationId UUIDString];
+    
+    NSMutableDictionary *requestBody = [NSMutableDictionary new];
+    requestBody[OAUTH2_GRANT_TYPE] = @"refresh_token";
+    requestBody[OAUTH2_REFRESH_TOKEN] = self.oldRefreshToken;
+    requestBody[OAUTH2_RESOURCE] = self.resource;
+    requestBody[OAUTH2_CLIENT_ID] = self.clientId;
+    [requestBody addEntriesFromDictionary:_requestBody];
+    
+    NSMutableDictionary *responseBody = [NSMutableDictionary new];
+    responseBody[OAUTH2_REFRESH_TOKEN] = self.updatedRefreshToken;
+    responseBody[OAUTH2_ACCESS_TOKEN] = self.updatedAccessToken;
+    responseBody[OAUTH2_RESOURCE] = self.resource;
+    [responseBody addEntriesFromDictionary:_responseBody];
+    if (_updatedIdToken) {
+        responseBody[OAUTH2_ID_TOKEN] = _updatedIdToken;
+    }
+    
+    ADTestURLResponse* response =
+    [ADTestURLResponse requestURLString:requestUrlString
+                         requestHeaders:_requestHeaders
+                      requestParamsBody:requestBody
+                      responseURLString:@"https://contoso.com"
+                           responseCode:self.responseCode
+                       httpHeaderFields:_responseHeaders
+                       dictionaryAsJSON:responseBody];
+    
+    return response;
+}
+
+@end

--- a/ADAL/tests/util/ADTokenCacheTestUtil.m
+++ b/ADAL/tests/util/ADTokenCacheTestUtil.m
@@ -39,34 +39,44 @@ static ADTokenCacheItem *getToken(id<ADTokenCacheDataSource> tokenCache, NSStrin
     return [tokenCache getItemsWithKey:key userId:TEST_USER_ID correlationId:TEST_CORRELATION_ID error:nil].firstObject;
 }
 
-static NSString *getMRRT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
+static ADTokenCacheItem *getMRRT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
 {
-    return getToken(tokenCache, authority, TEST_CLIENT_ID, nil).refreshToken;
+    return getToken(tokenCache, authority, TEST_CLIENT_ID, nil);
 }
 
-static NSString *getFRT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
+static ADTokenCacheItem *getFRT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
 {
-    return getToken(tokenCache, authority, @"foci-1", nil).refreshToken;
+    return getToken(tokenCache, authority, @"foci-1", nil);
 }
 
-static NSString *getAT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
+static ADTokenCacheItem *getAT(id<ADTokenCacheDataSource> tokenCache, NSString *authority)
 {
-    return getToken(tokenCache, authority, TEST_CLIENT_ID, TEST_RESOURCE).accessToken;
+    return getToken(tokenCache, authority, TEST_CLIENT_ID, TEST_RESOURCE);
 }
 
 @implementation ADTokenCache (TestUtil)
 
 - (NSString *)getAT:(NSString *)authority
 {
-    return getAT(self, authority);
+    return getAT(self, authority).accessToken;
 }
 
 - (NSString *)getMRRT:(NSString *)authority
+{
+    return getMRRT(self, authority).refreshToken;
+}
+
+- (ADTokenCacheItem *)getMRRTItem:(NSString *)authority
 {
     return getMRRT(self, authority);
 }
 
 - (NSString *)getFRT:(NSString *)authority
+{
+    return getFRT(self, authority).refreshToken;
+}
+
+- (ADTokenCacheItem *)getFRTItem:(NSString *)authority
 {
     return getFRT(self, authority);
 }
@@ -78,15 +88,25 @@ static NSString *getAT(id<ADTokenCacheDataSource> tokenCache, NSString *authorit
 
 - (NSString *)getAT:(NSString *)authority
 {
-    return getAT(self, authority);
+    return getAT(self, authority).accessToken;
 }
 
 - (NSString *)getMRRT:(NSString *)authority
+{
+    return getMRRT(self, authority).refreshToken;
+}
+
+- (ADTokenCacheItem *)getMRRTItem:(NSString *)authority
 {
     return getMRRT(self, authority);
 }
 
 - (NSString *)getFRT:(NSString *)authority
+{
+    return getFRT(self, authority).refreshToken;
+}
+
+- (ADTokenCacheItem *)getFRTItem:(NSString *)authority
 {
     return getFRT(self, authority);
 }


### PR DESCRIPTION
…"openid" scope so we get an updated idtoken as well