### PR TITLE
Add junit and cobetura reporting to build script

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,5 +1,8 @@
 # .slather.yml
 
-coverage_service: coveralls
-xcodeproj: ADALiOS/ADALiOS.xcodeproj
-ignore: ADALiOS/ADALiOSTests/*
+coverage_service: cobertura_xml
+workspace: ADAL.xcworkspace
+xcodeproj: ADAL/ADAL.xcodeproj
+source_directory: ADAL/src
+output_directory: reports/codecov
+ignore: ADAL/tests/**

--- a/build.py
+++ b/build.py
@@ -196,7 +196,7 @@ class BuildTarget:
 		
 		try:
 			settings_blob = subprocess.check_output(command, shell=True)
-		except CalledProcessError as e:
+		except subprocess.CalledProcessError as e:
 			print "Failed to get build settings:"
 			print e.output
 			

--- a/build.py
+++ b/build.py
@@ -164,8 +164,9 @@ class BuildTarget:
 		
 		# The shallow analyzer is buggy. Stupidly buggy, causing random failures that didn't fail the build on things like
 		# headers not being found. If Apple can't make this reliable then we should short circuit it out of our build
+		
 		if (operation == "build") :
-			command += " RUN_CLANG_STATIC_ANALYZER=NO"
+			command += " RUN_CLANG_STATIC_ANALYZER=NO ONLY_ACTIVE_ARCH=YES VALID_ARCHS=x86_64"
 		
 		if (operation != None and "codecov" in self.operations) :
 			command += " -enableCodeCoverage YES"
@@ -177,8 +178,8 @@ class BuildTarget:
 			command += " | xcpretty"
 			
 		if (use_junit and xcpretty and operation == "test") :
-				command += " -r junit"
-				command += " -o reports/test/" +  self.target + "-junit.xml"
+			command += " -r junit"
+			command += " -o reports/test/" +  self.target + "-junit.xml"
 		
 		return command
 	

--- a/build.py
+++ b/build.py
@@ -195,9 +195,9 @@ class BuildTarget:
 		start = timer()
 		
 		try:
-			settings_blob = subprocess.check_output(command, shell=True)
+			settings_blob = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
 		except subprocess.CalledProcessError as e:
-			print "Failed to get build settings:"
+			print "Failed to get build settings (exit code: " + e.returncode + ")"
 			print e.output
 			
 			raise e

--- a/build.py
+++ b/build.py
@@ -193,15 +193,21 @@ class BuildTarget:
 		print command
 		
 		start = timer()
-        
-		settings_blob = subprocess.check_output(command, shell=True)
+		
+		try:
+			settings_blob = subprocess.check_output(command, shell=True)
+		except CalledProcessError as e:
+			print "Failed to get build settings:"
+			print e.output
+			
+			raise e
+			
 		if (show_build_settings) :
 			print settings_blob
 			print "travis_fold:end:" + (self.name + "_settings").replace(" ", "_")
 		
 		settings_blob = settings_blob.decode("utf-8")
 		settings_blob = settings_blob.split("\n")
-        
 		settings = {}
 		
 		for line in settings_blob :

--- a/build.py
+++ b/build.py
@@ -43,6 +43,7 @@ default_workspace = "ADAL.xcworkspace"
 default_config = "Debug"
 
 use_xcpretty = True
+use_junit = False
 show_build_settings = False
 
 class ColorValues:
@@ -173,6 +174,8 @@ class BuildTarget:
 		
 		if (xcpretty) :
 			command += " | xcpretty"
+			if (use_junit) :
+				command += " -r junit"
 		
 		return command
 	
@@ -367,14 +370,14 @@ parser.add_argument('--no-clean', action='store_false', help="Skips the clean bu
 parser.add_argument('--no-xcpretty', action='store_false', help="Show raw xcodebuild output instead of using xcpretty")
 parser.add_argument('--show-build-settings', action='store_true',  help="Show xcodebuild's settings output")
 parser.add_argument('--targets', nargs='+', help="Specify individual targets to run")
+parser.add_argument('--junit', action='store_true', help="Use junit reporting for test results (requires xcpretty)")
 args = parser.parse_args()
 
 clean = args.no_clean
 use_xcpretty = args.no_xcpretty
+use_junit = args.junit
 show_build_settings = args.show_build_settings
 
-
-subprocess.call("printenv", shell=True)
 subprocess.call("xcodebuild -version", shell=True)
 
 if (args.targets != None) :

--- a/build.py
+++ b/build.py
@@ -178,7 +178,7 @@ class BuildTarget:
 			
 		if (use_junit and xcpretty and operation == "test") :
 				command += " -r junit"
-				command += " -o reports/" +  self.target + "-junit.xml"
+				command += " -o reports/test/" +  self.target + "-junit.xml"
 		
 		return command
 	

--- a/build.py
+++ b/build.py
@@ -373,6 +373,8 @@ clean = args.no_clean
 use_xcpretty = args.no_xcpretty
 show_build_settings = args.show_build_settings
 
+
+subprocess.call("printenv", shell=True)
 subprocess.call("xcodebuild -version", shell=True)
 
 if (args.targets != None) :

--- a/build.py
+++ b/build.py
@@ -169,7 +169,7 @@ class BuildTarget:
 			command += " -enableCodeCoverage YES"
 
 		if (self.platform == "iOS") :
-			command += " " + ios_sim_flags + " " + ios_sim_dest
+			command += " " + ios_sim_flags + " " + ios_sim_dest + " SUPPORTED_PLATFORMS=iOS"
 		
 		if (xcpretty) :
 			command += " | xcpretty"

--- a/build.py
+++ b/build.py
@@ -373,6 +373,8 @@ clean = args.no_clean
 use_xcpretty = args.no_xcpretty
 show_build_settings = args.show_build_settings
 
+subprocess.call("xcodebuild -version", shell=True)
+
 if (args.targets != None) :
 	print "Targets specified: " + str(args.targets)
 

--- a/build.py
+++ b/build.py
@@ -197,7 +197,7 @@ class BuildTarget:
 		try:
 			settings_blob = subprocess.check_output(command, stderr=subprocess.STDOUT, shell=True)
 		except subprocess.CalledProcessError as e:
-			print "Failed to get build settings (exit code: " + e.returncode + ")"
+			print "Failed to get build settings (exit code: " + str(e.returncode) + ")"
 			print e.output
 			
 			raise e

--- a/build.py
+++ b/build.py
@@ -120,6 +120,7 @@ def print_operation_end(name, operation, exit_code, start_time) :
 class BuildTarget:
 	def __init__(self, target):
 		self.name = target["name"]
+		self.target = target["target"]
 		self.project = target.get("project")
 		self.workspace = target.get("workspace")
 		if (self.workspace == None and self.project == None) :
@@ -174,8 +175,10 @@ class BuildTarget:
 		
 		if (xcpretty) :
 			command += " | xcpretty"
-			if (use_junit) :
+			
+		if (use_junit and xcpretty and operation == "test") :
 				command += " -r junit"
+				command += " -o reports/" +  self.target + "-junit.xml"
 		
 		return command
 	


### PR DESCRIPTION
Add `--junit` and `--slather` flags to the build script. These make it easier to collect results out of a build run and process them in VSTS so that they light up various dashboard features.