### PR TITLE
Fix allowSilent Flow 

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -287,17 +287,17 @@
         [req setRequestDictionary:requestData];
         [req sendRequest:^(ADAuthenticationError *error, NSDictionary * parameters)
          {
-             if (error)
+             if (error && ![parameters objectForKey:@"url"]) // auth code and OAuth2 error could be in endURL
              {
                  requestCompletion(error, nil);
                  [req invalidate];
                  return;
              }
              
-             NSURL* endURL = nil;
-             
-             //OAuth2 error may be passed by the server
-             endURL = [parameters objectForKey:@"url"];
+             //Auth code and OAuth2 error may be passed in endURL
+             NSURL* endURL = [parameters objectForKey:@"url"];
+             error = nil;
+
              if (!endURL)
              {
                  // If the request was not silent only then launch the webview


### PR DESCRIPTION
Fixed the allowSilent code path. Previously the allowSilent code path is broken because it errors out early even for `unsupported url error`. 
We don't want to error out early because auth code and oauth2 error may be returned in that url.

Now issue fixed and unit test is also added. (Currently that code path is only used by broker SDK).