### PR TITLE
Improve ADAuthenticationErrorConverter

### DIFF
--- a/ADAL/src/ADAuthenticationErrorConverter.m
+++ b/ADAL/src/ADAuthenticationErrorConverter.m
@@ -29,6 +29,8 @@ static NSDictionary *s_errorDomainMapping;
 static NSDictionary *s_errorCodeMapping;
 static NSDictionary *s_userInfoKeyMapping;
 
+#define NSNUMBER(n) [NSNumber numberWithInteger:(n)]
+
 @interface ADAuthenticationError (ErrorConverterUtil)
 + (ADAuthenticationError *)errorWithDomainInternal:(NSString *)domain
                                               code:(NSInteger)code
@@ -47,9 +49,10 @@ static NSDictionary *s_userInfoKeyMapping;
                              };
     
     s_errorCodeMapping = @{
-                           //sample format is like @"MSIDErrorDomain|-10000":@"-20000"
-                           @"MSIDErrorDomain|-51001":@"212",
-                           @"MSIDErrorDomain|-51301":@"101"
+                           MSIDErrorDomain:@{
+                                   NSNUMBER(MSIDErrorServerInvalidResponse) : NSNUMBER(AD_ERROR_SERVER_INVALID_RESPONSE),
+                                   NSNUMBER(MSIDErrorDeveloperAuthorityValidation) : NSNUMBER(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION)
+                                   }
                            };
     
     s_userInfoKeyMapping = @{MSIDHTTPHeadersKey : ADHTTPHeadersKey};
@@ -69,13 +72,12 @@ static NSDictionary *s_userInfoKeyMapping;
         domain = s_errorDomainMapping[domain];
     }
     
-    //Map errorCode. Note that errorCode must be mapped together with domain
+    //Map errorCode
     NSInteger errorCode = msidError.code;
-    NSString *mapKey = [NSString stringWithFormat:@"%@|%ld", msidError.domain, (long)errorCode];
-    NSString *mapValue = s_errorCodeMapping[mapKey];
-    if (![NSString msidIsStringNilOrBlank:mapValue])
+    NSNumber *mappedErrorCode = s_errorCodeMapping[msidError.domain][NSNUMBER(msidError.code)];
+    if (mappedErrorCode)
     {
-        errorCode = [mapValue integerValue];
+        errorCode = [mappedErrorCode integerValue];
     }
     
     NSMutableDictionary *userInfo = [NSMutableDictionary new];

--- a/ADAL/src/ADAuthenticationErrorConverter.m
+++ b/ADAL/src/ADAuthenticationErrorConverter.m
@@ -29,8 +29,6 @@ static NSDictionary *s_errorDomainMapping;
 static NSDictionary *s_errorCodeMapping;
 static NSDictionary *s_userInfoKeyMapping;
 
-#define NSNUMBER(n) [NSNumber numberWithInteger:(n)]
-
 @interface ADAuthenticationError (ErrorConverterUtil)
 + (ADAuthenticationError *)errorWithDomainInternal:(NSString *)domain
                                               code:(NSInteger)code
@@ -50,8 +48,8 @@ static NSDictionary *s_userInfoKeyMapping;
     
     s_errorCodeMapping = @{
                            MSIDErrorDomain:@{
-                                   NSNUMBER(MSIDErrorServerInvalidResponse) : NSNUMBER(AD_ERROR_SERVER_INVALID_RESPONSE),
-                                   NSNUMBER(MSIDErrorDeveloperAuthorityValidation) : NSNUMBER(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION)
+                                   @(MSIDErrorServerInvalidResponse) : @(AD_ERROR_SERVER_INVALID_RESPONSE),
+                                   @(MSIDErrorDeveloperAuthorityValidation) : @(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION)
                                    }
                            };
     
@@ -72,12 +70,19 @@ static NSDictionary *s_userInfoKeyMapping;
         domain = s_errorDomainMapping[domain];
     }
     
-    //Map errorCode
     NSInteger errorCode = msidError.code;
-    NSNumber *mappedErrorCode = s_errorCodeMapping[msidError.domain][NSNUMBER(msidError.code)];
-    if (mappedErrorCode)
+    //If the domain is in s_errorCodeMapping, it means errorCode mapping is needed
+    if (s_errorCodeMapping[msidError.domain])
     {
-        errorCode = [mappedErrorCode integerValue];
+        NSNumber *mappedErrorCode = s_errorCodeMapping[msidError.domain][@(msidError.code)];
+        if (mappedErrorCode)
+        {
+            errorCode = [mappedErrorCode integerValue];
+        }
+        else
+        {
+            MSID_LOG_ERROR(nil, @"ADAuthenticationErrorConverter could not find the error code mapping entry for domain (%@) + error code (%ld).", msidError.domain, msidError.code);
+        }
     }
     
     NSMutableDictionary *userInfo = [NSMutableDictionary new];

--- a/ADAL/src/ADAuthenticationErrorConverter.m
+++ b/ADAL/src/ADAuthenticationErrorConverter.m
@@ -48,8 +48,14 @@ static NSDictionary *s_userInfoKeyMapping;
     
     s_errorCodeMapping = @{
                            MSIDErrorDomain:@{
-                                   @(MSIDErrorServerInvalidResponse) : @(AD_ERROR_SERVER_INVALID_RESPONSE),
-                                   @(MSIDErrorDeveloperAuthorityValidation) : @(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION)
+                                   @(MSIDErrorInternal):@(AD_ERROR_UNEXPECTED),
+                                   @(MSIDErrorInvalidInternalParameter):@(AD_ERROR_UNEXPECTED),
+                                   @(MSIDErrorInvalidDeveloperParameter):@(AD_ERROR_DEVELOPER_INVALID_ARGUMENT),
+                                   @(MSIDErrorInteractionRequired):@(AD_ERROR_SERVER_USER_INPUT_NEEDED),
+                                   @(MSIDErrorCacheMultipleUsers):@(AD_ERROR_CACHE_MULTIPLE_USERS),
+                                   @(MSIDErrorTokenCacheItemFailure):@(AD_ERROR_CACHE_BAD_FORMAT),
+                                   @(MSIDErrorServerInvalidResponse):@(AD_ERROR_SERVER_INVALID_RESPONSE),
+                                   @(MSIDErrorDeveloperAuthorityValidation):@(AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION)
                                    }
                            };
     
@@ -63,16 +69,17 @@ static NSDictionary *s_userInfoKeyMapping;
         return nil;
     }
     
-    //Map domain
+    // Map domain
     NSString *domain = msidError.domain;
     if (domain && s_errorDomainMapping[domain])
     {
         domain = s_errorDomainMapping[domain];
     }
     
+    // Map errorCode
+    // errorCode mapping is needed only if domain is in s_errorCodeMapping
     NSInteger errorCode = msidError.code;
-    //If the domain is in s_errorCodeMapping, it means errorCode mapping is needed
-    if (s_errorCodeMapping[msidError.domain])
+    if (msidError.domain && msidError.code && s_errorCodeMapping[msidError.domain])
     {
         NSNumber *mappedErrorCode = s_errorCodeMapping[msidError.domain][@(msidError.code)];
         if (mappedErrorCode)

--- a/ADAL/tests/unit/ADAuthenticationErrorConverterTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorConverterTests.m
@@ -41,12 +41,12 @@
     [super tearDown];
 }
 
-- (void)testErrorConversion_whenPassInNil_ShouldReturnNil {
+- (void)testErrorConversion_whenPassInNil_shouldReturnNil {
     NSError *adalError = [ADAuthenticationErrorConverter ADAuthenticationErrorFromMSIDError:nil];
     XCTAssertNil(adalError);
 }
 
-- (void)testErrorConversion_whenOnlyErrorDomainIsMapped_ErrorCodeShouldBeKept {
+- (void)testErrorConversion_whenOnlyErrorDomainIsMapped_shouldKeepErrorCode {
     NSInteger errorCode = -9999;
     NSString *errorDescription = @"a fake error description.";
     NSString *oauthError = @"a fake oauth error message.";
@@ -67,6 +67,37 @@
     XCTAssertNotNil(adalError);
     XCTAssertEqualObjects(adalError.domain, ADAuthenticationErrorDomain);
     XCTAssertEqual(adalError.code, errorCode);
+    XCTAssertEqualObjects(adalError.errorDetails, errorDescription);
+    XCTAssertEqualObjects(adalError.protocolCode, oauthError);
+    XCTAssertEqualObjects(adalError.userInfo[NSUnderlyingErrorKey], underlyingError);
+    XCTAssertEqualObjects(adalError.userInfo[ADHTTPHeadersKey], httpHeaders);
+}
+
+- (void)testErrorConversion_whenBothErrorDomainAndCodeAreMapped_shouldMapBoth {
+    NSString *domain = MSIDErrorDomain;
+    NSString *expectedDomain = ADAuthenticationErrorDomain;
+    NSInteger errorCode = MSIDErrorDeveloperAuthorityValidation;
+    NSInteger expectedMappedErrorCode = AD_ERROR_DEVELOPER_AUTHORITY_VALIDATION;
+    
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSError *underlyingError = [NSError errorWithDomain:NSOSStatusErrorDomain code:errSecItemNotFound userInfo:nil];
+    NSUUID *correlationId = [NSUUID UUID];
+    NSDictionary *httpHeaders = @{@"fake header key" : @"fake header value"};
+    
+    NSError *msidError = MSIDCreateError(domain,
+                                         errorCode,
+                                         errorDescription,
+                                         oauthError,
+                                         nil,
+                                         underlyingError,
+                                         correlationId,
+                                         @{MSIDHTTPHeadersKey : httpHeaders});
+    ADAuthenticationError *adalError = [ADAuthenticationErrorConverter ADAuthenticationErrorFromMSIDError:msidError];
+    
+    XCTAssertNotNil(adalError);
+    XCTAssertEqualObjects(adalError.domain, expectedDomain);
+    XCTAssertEqual(adalError.code, expectedMappedErrorCode);
     XCTAssertEqualObjects(adalError.errorDetails, errorDescription);
     XCTAssertEqualObjects(adalError.protocolCode, oauthError);
     XCTAssertEqualObjects(adalError.userInfo[NSUnderlyingErrorKey], underlyingError);


### PR DESCRIPTION
Improve the mapping format to avoid using hard-coded numbers in `ADAuthenticationErrorConverter`.