### PR TITLE
Moved legacy cache components under tests

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -50,7 +50,6 @@
 		234F3CE71F35161C00DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CE51F35159500DE4AA4 /* ADAuthenticationContextTests.m */; };
 		234F3CED1F35182500DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */; };
 		234F3CEE1F35182600DE4AA4 /* ADAuthenticationContextTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */; };
-		23F32F1C1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F32F1B1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m */; };
 		236BF3C0204F93FE006E3897 /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CF5E202040ED3500D348AF /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m */; };
 		236BF3CD20521942006E3897 /* ADUserInformation+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 236BF3C820521382006E3897 /* ADUserInformation+Internal.m */; };
 		236BF3CE20521943006E3897 /* ADUserInformation+Internal.m in Sources */ = {isa = PBXBuildFile; fileRef = 236BF3C820521382006E3897 /* ADUserInformation+Internal.m */; };
@@ -70,6 +69,7 @@
 		23CF5E212040ED3500D348AF /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CF5E202040ED3500D348AF /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m */; };
 		23CF5E2B2040EFB300D348AF /* ADTokenCacheItem+MSIDTokens.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CF5E292040EE4B00D348AF /* ADTokenCacheItem+MSIDTokens.m */; };
 		23CF5E2C2040EFB400D348AF /* ADTokenCacheItem+MSIDTokens.m in Sources */ = {isa = PBXBuildFile; fileRef = 23CF5E292040EE4B00D348AF /* ADTokenCacheItem+MSIDTokens.m */; };
+		23F32F1C1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23F32F1B1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m */; };
 		290750AC1E380F32000F0C29 /* ADTelemetryCollectionRules.h in Headers */ = {isa = PBXBuildFile; fileRef = 290750AA1E380F32000F0C29 /* ADTelemetryCollectionRules.h */; };
 		2949ABC01E395FC400F56C57 /* ADTelemetryCollectionRules.m in Sources */ = {isa = PBXBuildFile; fileRef = 290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */; };
 		2949ABC11E39605F00F56C57 /* ADTelemetryCollectionRules.m in Sources */ = {isa = PBXBuildFile; fileRef = 290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */; };
@@ -249,6 +249,9 @@
 		B267CA1B1EE0E9FF00C0B5A8 /* ADNegotiateHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */; };
 		B267CA1C1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */; };
 		B267CA1D1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */; };
+		B2822A2F2055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
+		B2822A302055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
+		B2822A342055DBF900390B6E /* ADLegacyKeychainTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */; };
 		B2908C0E1FCA4E5900AFE98E /* ADTelemetryIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 234F3D091F43B07000DE4AA4 /* ADTelemetryIntegrationTests.m */; };
 		B299FF1A1F22BE32004A2CB9 /* NSString+ADURLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B299FF191F22BE32004A2CB9 /* NSString+ADURLExtensions.m */; };
 		B299FF1B1F22BE74004A2CB9 /* NSString+ADURLExtensions.m in Sources */ = {isa = PBXBuildFile; fileRef = B299FF191F22BE32004A2CB9 /* NSString+ADURLExtensions.m */; };
@@ -446,26 +449,19 @@
 			remoteGlobalIDString = 04AB6D411D9D619B007E9A83;
 			remoteInfo = UnitTestHostApp;
 		};
-		23F32F201FFD793100B2905E /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D626FFC01FBD1B1300EE4487 /* IdentityCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 231CE99D1FE86EA300E95D3E;
-			remoteInfo = MSIDTestsHostApp;
-		};
-		2332E010200EAE4200BDBCA3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D626FFC01FBD1B1300EE4487 /* IdentityCore.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = 231CE99D1FE86EA300E95D3E;
-			remoteInfo = MSIDTestsHostApp;
-		};
 		23658C82201023F70055CE7D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 8B0965A217F25770002BDFB8 /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = D64C1F471DB9B05900850036;
 			remoteInfo = ADALAutomation;
+		};
+		23F32F201FFD793100B2905E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D626FFC01FBD1B1300EE4487 /* IdentityCore.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 231CE99D1FE86EA300E95D3E;
+			remoteInfo = MSIDTestsHostApp;
 		};
 		9453C45C1C5866D8006B9E79 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -693,7 +689,6 @@
 		234F3CEB1F35180B00DE4AA4 /* ADAuthenticationContextTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAuthenticationContextTests.m; sourceTree = "<group>"; };
 		234F3CEF1F3519A300DE4AA4 /* ADAuthenticationContextTests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADAuthenticationContextTests.h; sourceTree = "<group>"; };
 		234F3D091F43B07000DE4AA4 /* ADTelemetryIntegrationTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTelemetryIntegrationTests.m; sourceTree = "<group>"; };
-		23F32F1B1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheToMSIDMacTokenCacheTests.m; sourceTree = "<group>"; };
 		23658C7D201023F70055CE7D /* ADALiOSUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ADALiOSUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		23658C81201023F70055CE7D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		236BF3C720521382006E3897 /* ADUserInformation+Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADUserInformation+Internal.h"; sourceTree = "<group>"; };
@@ -721,6 +716,7 @@
 		23CF5E202040ED3500D348AF /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheItemIntegrationWithMSIDTokensTests.m; sourceTree = "<group>"; };
 		23CF5E282040EE4B00D348AF /* ADTokenCacheItem+MSIDTokens.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADTokenCacheItem+MSIDTokens.h"; sourceTree = "<group>"; };
 		23CF5E292040EE4B00D348AF /* ADTokenCacheItem+MSIDTokens.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "ADTokenCacheItem+MSIDTokens.m"; sourceTree = "<group>"; };
+		23F32F1B1FFD793000B2905E /* ADTokenCacheToMSIDMacTokenCacheTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheToMSIDMacTokenCacheTests.m; sourceTree = "<group>"; };
 		290750AA1E380F32000F0C29 /* ADTelemetryCollectionRules.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADTelemetryCollectionRules.h; sourceTree = "<group>"; };
 		290750AB1E380F32000F0C29 /* ADTelemetryCollectionRules.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTelemetryCollectionRules.m; sourceTree = "<group>"; };
 		3889BE1E1E5C929600743037 /* ADClientCertAuthHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADClientCertAuthHandler.h; sourceTree = "<group>"; };
@@ -895,6 +891,10 @@
 		B23FC03D1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenPkeyAuthTests.m; sourceTree = "<group>"; };
 		B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADNegotiateHandler.h; sourceTree = "<group>"; };
 		B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADNegotiateHandler.m; sourceTree = "<group>"; };
+		B2822A2C2055D67200390B6E /* ADLegacyMacTokenCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADLegacyMacTokenCache.h; sourceTree = "<group>"; };
+		B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADLegacyMacTokenCache.m; sourceTree = "<group>"; };
+		B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADLegacyKeychainTokenCache.m; sourceTree = "<group>"; };
+		B2822A332055DBF900390B6E /* ADLegacyKeychainTokenCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADLegacyKeychainTokenCache.h; sourceTree = "<group>"; };
 		B299FF181F22BE32004A2CB9 /* NSString+ADURLExtensions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSString+ADURLExtensions.h"; sourceTree = "<group>"; };
 		B299FF191F22BE32004A2CB9 /* NSString+ADURLExtensions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSString+ADURLExtensions.m"; sourceTree = "<group>"; };
 		B299FF1D1F22C338004A2CB9 /* ADURLExtensionsTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADURLExtensionsTest.m; sourceTree = "<group>"; };
@@ -1743,6 +1743,7 @@
 		B20DC5D41F0D976300957806 /* integration */ = {
 			isa = PBXGroup;
 			children = (
+				B2822A282055D63200390B6E /* legacytest */,
 				B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */,
 				234F3D091F43B07000DE4AA4 /* ADTelemetryIntegrationTests.m */,
 				B20DC6111F0D9A5500957806 /* AADAuthorityValidationIntegrationTests.m */,
@@ -1796,6 +1797,17 @@
 			path = mac;
 			sourceTree = "<group>";
 		};
+		B2822A282055D63200390B6E /* legacytest */ = {
+			isa = PBXGroup;
+			children = (
+				B2822A332055DBF900390B6E /* ADLegacyKeychainTokenCache.h */,
+				B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */,
+				B2822A2C2055D67200390B6E /* ADLegacyMacTokenCache.h */,
+				B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */,
+			);
+			path = legacytest;
+			sourceTree = "<group>";
+		};
 		D626FFC11FBD1B1300EE4487 /* Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -1806,7 +1818,6 @@
 				D626FFCC1FBD1B1300EE4487 /* IdentityCoreTests.xctest */,
 				D626FFCE1FBD1B1300EE4487 /* IdentityCoreTests.xctest */,
 				23F32F211FFD793100B2905E /* MSIDTestsHostApp.app */,
-				2332E011200EAE4200BDBCA3 /* MSIDTestsHostApp.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -2450,13 +2461,6 @@
 			remoteRef = 23F32F201FFD793100B2905E /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		2332E011200EAE4200BDBCA3 /* MSIDTestsHostApp.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = MSIDTestsHostApp.app;
-			remoteRef = 2332E010200EAE4200BDBCA3 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
 		D62600001FBD253E00EE4487 /* libIdentityTest.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -2826,6 +2830,7 @@
 				D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */,
 				B20DC60F1F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				D62256521F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
+				B2822A2F2055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */,
 				B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				04930F7D1FEC8C0F00FC4DCD /* MSIDAadAuthorityCache+TestUtil.m in Sources */,
 				B20DC5891F0D96A100957806 /* ADTelemetryTestDispatcher.m in Sources */,
@@ -2845,6 +2850,7 @@
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
 				D6771E001F749CE100D0DCDC /* ADBrokerIntegrationTests.m in Sources */,
 				B200BC4420180A57000A81FD /* ADWipeTokensTelemetryTests.m in Sources */,
+				B2822A342055DBF900390B6E /* ADLegacyKeychainTokenCache.m in Sources */,
 				B20D8FF51F60A3490021DA25 /* ADTelemetryIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2868,6 +2874,7 @@
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				D62256541F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
 				B2908C0E1FCA4E5900AFE98E /* ADTelemetryIntegrationTests.m in Sources */,
+				B2822A302055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */,
 				B20DC6101F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */,
 				236BF3C0204F93FE006E3897 /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m in Sources */,

--- a/ADAL/tests/integration/ios/ADKeychainTokenCacheToMSIDKeychainTokenCacheTests.m
+++ b/ADAL/tests/integration/ios/ADKeychainTokenCacheToMSIDKeychainTokenCacheTests.m
@@ -23,8 +23,7 @@
 
 #import <XCTest/XCTest.h>
 #import "XCTestCase+TestHelperMethods.h"
-#import "ADKeychainTokenCache.h"
-#import "ADKeychainTokenCache+Internal.h"
+#import "ADLegacyKeychainTokenCache.h"
 #import "ADTokenCacheItem.h"
 #import "ADUserInformation.h"
 #import "MSIDKeychainTokenCache.h"
@@ -59,7 +58,7 @@
 
 - (void)test_saveADALTokenInADALKeychain_MSIDKeychainShouldFindMSIDToken
 {
-    ADKeychainTokenCache *adKeychainTokenCache = [ADKeychainTokenCache new];
+    ADLegacyKeychainTokenCache *adKeychainTokenCache = [ADLegacyKeychainTokenCache new];
     NSDate *date = [NSDate new];
     NSDictionary *additionalServerInfo = @{@"key1": @"value1"};
     NSData *sessionKey = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
@@ -119,7 +118,7 @@
     XCTAssertTrue(result);
     
     ADTokenCacheKey *key = [ADTokenCacheKey keyWithAuthority:TEST_AUTHORITY resource:TEST_RESOURCE clientId:TEST_CLIENT_ID error:nil];
-    ADKeychainTokenCache *adKeychainTokenCache = [ADKeychainTokenCache new];
+    ADLegacyKeychainTokenCache *adKeychainTokenCache = [ADLegacyKeychainTokenCache new];
     ADTokenCacheItem *item = [adKeychainTokenCache getItemWithKey:key userId:TEST_USER_ID correlationId:nil error:&error];
     
     XCTAssertNil(error);

--- a/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.h
+++ b/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.h
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADKeychainTokenCache.h"
+#import "ADTokenCacheDataSource.h"
+
+@class ADKeyChainHelper;
+@class ADTokenCacheItem;
+@class ADAuthenticationError;
+
+@interface ADLegacyKeychainTokenCache : ADKeychainTokenCache <ADTokenCacheDataSource>
+
+@property (readonly) NSString* __nonnull sharedGroup;
+
+/*!
+     The name of the keychain group to be used by default when creating an ADAuthenticationContext,
+     the default value is com.microsoft.adalcache.
+ */
++ (nullable NSString*)defaultKeychainGroup;
+
+/*!
+     Set the default keychain sharing group to use with ADAL. If set to 'nil' the main bundle's
+     identifier will be used instead. Any keychain sharing group other then the main bundle's identifier
+     will require a keychain sharing group entitlement.
+ 
+     See apple's documentation for keychain groups: such groups require certain
+     entitlements to be set by the applications. Additionally, access to the items in this group
+     is only given to the applications from the same vendor. If this property is not set, the behavior
+     will depend on the values in the entitlements file (if such exists) and may not result in token
+     sharing. The property has no effect if other cache mechanisms are used (non-keychain).
+
+ 
+     NOTE: Once an authentication context has been created with the default keychain
+     group, or +[ADKeychainTokenCache defaultKeychainCache] has been called then
+     this value cannot be changed. Doing so will throw an exception.
+ */
++ (void)setDefaultKeychainGroup:(nullable NSString*)keychainGroup;
+
+/*!
+    @return A singleton instance of the ADKeychainTokenCache for the default keychain group.
+ */
++ (nonnull ADLegacyKeychainTokenCache*)defaultKeychainCache;
+
+/*!
+    @return An instance of ADKeychainTokenCache for the given group, or the defaultKeychainCache
+            singleton if the default keychain group is passed in.
+ */
++ (nonnull ADLegacyKeychainTokenCache*)keychainCacheForGroup:(nullable NSString*)group;
+
+/* Initializes the token cache store with default shared group value.
+ */
+- (nonnull instancetype)init;
+
+/*! Initializes the token cache store.
+ @param sharedGroup Optional. If the application needs to share the cached tokens
+ with other applications from the same vendor, the app will need to specify the 
+ shared group here and add the necessary entitlements to the application.
+ See Apple's keychain services documentation for details. */
+- (nullable instancetype)initWithGroup:(nullable NSString *)sharedGroup;
+
+/*! Return a copy of all items. The array will contain ADTokenCacheItem objects,
+ containing all of the cached information. Returns an empty array, if no items are found.
+ Returns nil in case of error. */
+- (nullable NSArray<ADTokenCacheItem *> *)allItems:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/* Removes a token cache item from the keychain */
+- (BOOL)removeItem:(nonnull ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/* Removes all token cache items for a specific client from the keychain.
+ */
+- (BOOL)removeAllForClientId:(NSString * __nonnull)clientId
+                       error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/* Removes all token cache items for a specific user and a specific clientId from the keychain
+ */
+- (BOOL)removeAllForUserId:(NSString * __nonnull)userId
+                  clientId:(NSString * __nonnull)clientId
+                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+/*
+   Removes all token cache items for a specific user from the keychain with
+   either com.microsoft.adalcache shared group by default or the one provided in setDefaultKeychainGroup method.
+ 
+   This is a destructive action and will remove the SSO state from all apps sharing the same cache!
+   It's indended to be used only as a way to achieve GDPR compliance and make sure all user artifacts are cleaned on user sign out.
+   It's not indended to be used as a way to reset or fix token cache.
+ */
+- (BOOL)wipeAllItemsForUserId:(NSString * __nonnull)userId
+                        error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+// Internal methods
++ (BOOL)checkStatus:(OSStatus)status
+          operation:(nullable NSString *)operation
+      correlationId:(nullable NSUUID *)correlationId
+              error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+- (nullable NSMutableDictionary *)queryDictionaryForKey:(nullable ADTokenCacheKey *)key
+                                                 userId:(nullable NSString *)userId
+                                             additional:(nullable NSDictionary*)additional;
+
+- (nullable NSString*)keychainKeyFromCacheKey:(nullable ADTokenCacheKey *)itemKey;
+
+/*! This method should *only* be called in test code, it should never be called
+ in production code */
+- (void)testRemoveAll:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+- (nullable NSDictionary*)defaultKeychainQuery;
+
+@end

--- a/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.m
+++ b/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.m
@@ -1,0 +1,757 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Security/Security.h>
+#import "ADLegacyKeychainTokenCache.h"
+#import "ADAL_Internal.h"
+#import "ADKeychainUtil.h"
+#import "ADTokenCacheItem.h"
+#import "ADTokenCacheKey.h"
+#import "ADUserInformation.h"
+#import "ADWorkplaceJoinUtil.h"
+#import "ADAuthenticationSettings.h"
+#import "ADTokenCacheItem+Internal.h"
+#import "ADHelpers.h"
+#import "MSIDTelemetryCacheEvent.h"
+#import "MSIDTelemetryEventStrings.h"
+#import "MSIDTelemetry.h"
+#import "MSIDTelemetry+Internal.h"
+
+#define KEYCHAIN_VERSION 1
+#define STRINGIFY(x) #x
+#define TOSTRING(x) STRINGIFY(x)
+#define ONE_DAY_IN_SECONDS (24*60*60)
+
+static NSString* const s_nilKey = @"CC3513A0-0E69-4B4D-97FC-DFB6C91EE132";//A special attribute to write, instead of nil/empty one.
+static NSString* const s_delimiter = @"|";
+
+static NSString* const s_libraryString = @"MSOpenTech.ADAL." TOSTRING(KEYCHAIN_VERSION);
+
+static NSString* const s_wipeLibraryString = @"Microsoft.ADAL.WipeAll." TOSTRING(KEYCHAIN_VERSION);
+
+static NSString* s_defaultKeychainGroup = @"com.microsoft.adalcache";
+static ADLegacyKeychainTokenCache* s_defaultCache = nil;
+
+@implementation ADLegacyKeychainTokenCache
+{
+    NSString* _sharedGroup;
+    NSDictionary* _default;
+}
+
++ (ADLegacyKeychainTokenCache*)defaultKeychainCache
+{
+    static dispatch_once_t s_once;
+    
+    dispatch_once(&s_once, ^{
+        s_defaultCache = [[ADLegacyKeychainTokenCache alloc] init];
+    });
+    
+    
+    return s_defaultCache;
+}
+
++ (ADLegacyKeychainTokenCache*)keychainCacheForGroup:(nullable NSString*)group
+{
+    if ([group isEqualToString:s_defaultKeychainGroup])
+    {
+        return [self defaultKeychainCache];
+    }
+    ADLegacyKeychainTokenCache* cache = [[ADLegacyKeychainTokenCache alloc] initWithGroup:group];
+    return cache;
+}
+
++ (NSString*)defaultKeychainGroup
+{
+    return s_defaultKeychainGroup;
+}
+
++ (void)setDefaultKeychainGroup:(NSString *)keychainGroup
+{
+    if (s_defaultCache)
+    {
+        MSID_LOG_ERROR(nil, @"Failed to set default keychain group, default keychain cache has already been instantiated.");
+        
+        @throw @"Attempting to change the keychain group once AuthenticationContexts have been created or the default keychain cache has been retrieved is invalid. The default keychain group should only be set once for the lifetime of an application.";
+    }
+    
+    MSID_LOG_INFO(nil, @"Setting default keychain group.");
+    MSID_LOG_INFO_PII(nil, @"Setting default keychain group to %@", keychainGroup);
+    
+    if (keychainGroup == s_defaultKeychainGroup)
+    {
+        return;
+    }
+    
+    if (!keychainGroup)
+    {
+        keychainGroup = [[NSBundle mainBundle] bundleIdentifier];
+    }
+    
+    s_defaultKeychainGroup = [keychainGroup copy];
+}
+
+// Shouldn't be called.
+- (id)init
+{
+    return [self initWithGroup:s_defaultKeychainGroup];
+}
+
+- (id)initWithGroup:(NSString *)sharedGroup
+{
+    if (!(self = [super initWithGroup:sharedGroup]))
+    {
+        return nil;
+    }
+    
+    if (!sharedGroup)
+    {
+        sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
+    }
+    
+    NSString* teamId = [ADKeychainUtil keychainTeamId:nil];
+#if !TARGET_OS_SIMULATOR
+    // If we didn't find a team ID and we're on device then the rest of ADAL not only will not work
+    // particularly well, we'll probably induce other issues by continuing.
+    if (!teamId)
+    {
+        return nil;
+    }
+#endif
+    if (teamId)
+    {
+        _sharedGroup = [[NSString alloc] initWithFormat:@"%@.%@", teamId, sharedGroup];
+    }
+    
+    NSMutableDictionary* defaultQuery =
+    [@{
+       (id)kSecClass : (id)kSecClassGenericPassword,
+       (id)kSecAttrGeneric : [s_libraryString dataUsingEncoding:NSUTF8StringEncoding]
+       } mutableCopy];
+
+    // Depending on the environment we may or may not have keychain access groups. Which environments
+    // have keychain access group support also varies over time. They should always work on device,
+    // in Simulator they work when running within an app bundle but not in unit tests, as of Xcode 7.3
+    
+    if (_sharedGroup)
+    {
+        [defaultQuery setObject:_sharedGroup forKey:(id)kSecAttrAccessGroup];
+    }
+    
+    _default = defaultQuery;
+    
+    return self;
+}
+
+-  (NSString*)sharedGroup
+{
+    return _sharedGroup;
+}
+
+
+#pragma mark -
+#pragma mark Token Wipe
+- (NSDictionary *)wipeQuery {
+    static NSDictionary *sWipeQuery;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sWipeQuery = @{
+                       (id)kSecClass                : (id)kSecClassGenericPassword,
+                       (id)kSecAttrGeneric          : [s_wipeLibraryString dataUsingEncoding:NSUTF8StringEncoding],
+                       (id)kSecAttrAccessGroup      : _sharedGroup,
+                       (id)kSecAttrAccount          : @"TokenWipe",
+                       };
+    });
+    return sWipeQuery;
+}
+
+- (BOOL)saveWipeTokenData:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    NSDictionary *wipeInfo = @{ @"bundleId" : [[NSBundle mainBundle] bundleIdentifier],
+                                @"wipeTime" : [NSDate date]
+                                };
+
+    NSData *wipeData = [NSKeyedArchiver archivedDataWithRootObject:wipeInfo];
+
+    OSStatus status = SecItemUpdate((CFDictionaryRef)[self wipeQuery], (CFDictionaryRef)@{ (id)kSecValueData:wipeData  } );
+    if (status == errSecItemNotFound)
+    {
+        NSMutableDictionary *mutableQuery = [[self wipeQuery] mutableCopy];
+        [mutableQuery addEntriesFromDictionary: @{ (id)kSecAttrAccessible : (id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+                                                   (id)kSecValueData : wipeData
+                                                   }];
+         
+        status = SecItemAdd((CFDictionaryRef)mutableQuery, NULL);
+    }
+    
+    if(status != errSecSuccess)
+    {
+        NSString* details = [NSString stringWithFormat:@"Failed to log wipe data with error: %d", (int)status];
+        NSError* nserror = [NSError errorWithDomain:@"Could not log wipe data."
+                                               code:AD_ERROR_UNEXPECTED
+                                           userInfo:nil];
+        if (error)
+        {
+            *error = [ADAuthenticationError errorFromNSError:nserror
+                                                errorDetails:details
+                                               correlationId:nil];
+        }
+        return NO;
+    }
+    
+    return YES;
+}
+
+- (void)logWipeTokenData:(NSUUID *)correlationId
+{
+    NSDictionary *wipeData = [self getWipeTokenData];
+    
+    if (wipeData)
+    {
+        NSString *bundleId = wipeData[@"bundleId"];
+        NSString *wipeTime = [ADHelpers stringFromDate:wipeData[@"wipeTime"]];
+        
+        MSID_LOG_INFO_CORR(correlationId, @"Last wiped by %@ at %@", bundleId, wipeTime);
+        MSID_LOG_INFO_CORR_PII(correlationId, @"Last wiped by %@ at %@", bundleId, wipeTime);
+    }
+    else
+    {
+        MSID_LOG_INFO_CORR(correlationId, @"Failed to get a wipe data or it does not exist");
+        MSID_LOG_INFO_CORR_PII(correlationId, @"Failed to get a wipe data or it does not exist for %@", _sharedGroup);
+    }
+}
+
+#pragma mark -
+#pragma mark Keychain Logging
+
+//Log operations that result in storing or reading cache item:
+- (void)logItem:(ADTokenCacheItem *)item
+        message:(NSString *)additionalMessage
+  correlationId:(NSUUID *)correlationId
+{
+    [item logMessage:additionalMessage level:MSIDLogLevelVerbose correlationId:correlationId];
+}
+
+- (void)logItemRetrievalStatus:(NSArray *)items
+                           key:(ADTokenCacheKey *)key
+                        userId:(NSString *)userId
+                 correlationId:(NSUUID *)correlationId
+{
+    NSString* keyCtxStr = [NSString stringWithFormat:@"(resource <%@> + client <%@> + authority <%@>)", [key resource], [key clientId], [key authority]];
+    if (!items || [items count]<=0)
+    {
+        //if resource is nil, this request is intending to find MRRT
+        MSID_LOG_INFO_CORR(correlationId, @"No items were found for query");
+        MSID_LOG_INFO_CORR_PII(correlationId, @"No items were found for query %@", keyCtxStr);
+    }
+    else
+    {
+        MSID_LOG_INFO_CORR(correlationId, @"Found %lu token(s) for query", (unsigned long)[items count]);
+        MSID_LOG_INFO_CORR_PII(correlationId, @"Found %lu token(s) for query %@ user <%@>", (unsigned long)[items count], keyCtxStr, userId);
+    }
+}
+
+
+- (NSString*)getTokenNameForLog:(ADTokenCacheItem *)item
+{
+    NSString* tokenName = @"unknown token";
+    if (![NSString msidIsStringNilOrBlank:item.accessToken])
+    {
+        if (item.isExpired)
+        {
+            tokenName = @"expired AT";
+        }
+        else
+        {
+            tokenName = @"AT";
+        }
+        
+        if (![NSString msidIsStringNilOrBlank:item.refreshToken])
+        {
+            [tokenName stringByAppendingString:@"+RT"];
+        }
+    }
+    else if ([item.clientId hasPrefix:@"foci-"])
+    {
+        tokenName = @"FRT";
+    }
+    else if (![NSString msidIsStringNilOrBlank:item.refreshToken] && [NSString msidIsStringNilOrBlank:item.resource])
+    {
+        tokenName = @"MRRT";
+    }
+    return tokenName;
+}
+
+
+// Internal method: returns a dictionary with all items that match the criteria.
+// The keys are the keychain fullkey of the items; the values are the
+// keychain attributes as extracted by SecItemCopyMatching. The attributes
+// (represented as dictionaries) can be used to obtain the actual token cache item.
+// May return nil in case of error.
+- (NSArray *)keychainItemsWithKey:(ADTokenCacheKey*)key
+                           userId:(NSString*)userId
+                            error:(ADAuthenticationError* __autoreleasing*)error
+{
+    NSMutableDictionary* query = [self queryDictionaryForKey:key
+                                                  userId:userId
+                                              additional:@{ (id)kSecMatchLimit : (id)kSecMatchLimitAll,
+                                                            (id)kSecReturnData : @YES,
+                                                            (id)kSecReturnAttributes : @YES}];
+    CFTypeRef items = nil;
+    OSStatus status = SecItemCopyMatching((CFDictionaryRef)query, &items);
+    if (status == errSecItemNotFound)
+    {
+        return @[];
+    }
+    else if (status != errSecSuccess)
+    {
+        [ADLegacyKeychainTokenCache checkStatus:status operation:@"retrieve items" correlationId:nil error:error];
+        return nil;
+    }
+    
+    return CFBridgingRelease(items);
+}
+
+
+- (ADTokenCacheItem*)itemFromKeychainAttributes:(NSDictionary*)attrs
+{
+    NSData* data = [attrs objectForKey:(id)kSecValueData];
+    if (!data)
+    {
+        MSID_LOG_WARN(nil, @"Retrieved item with key that did not have generic item data!");
+        return nil;
+    }
+    @try
+    {
+        ADTokenCacheItem* item = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+        if (!item)
+        {
+            MSID_LOG_WARN(nil, @"Unable to decode item from data stored in keychain.");
+            return nil;
+        }
+        if (![item isKindOfClass:[ADTokenCacheItem class]])
+        {
+            MSID_LOG_WARN(nil, @"Unarchived Item was not of expected class.");
+            return nil;
+        }
+        
+        return item;
+    }
+    @catch (NSException *exception)
+    {
+        MSID_LOG_WARN(nil, @"Failed to deserialize data from keychain.");
+        return nil;
+    }
+}
+
+#pragma mark -
+#pragma mark ADTokenCacheAccessor implementation
+
+/*! Return a copy of all items. The array will contain ADTokenCacheItem objects,
+ containing all of the cached information. Returns an empty array, if no items are found.
+ Returns nil in case of error. */
+- (NSArray<ADTokenCacheItem *> *)allItems:(ADAuthenticationError * __autoreleasing *)error
+{
+    return [self getItemsWithKey:nil userId:nil correlationId:nil error:error];
+}
+
+/*!
+    @param  item    The item to be removed.
+    @param  error   (Optional) In the case of an error this will be filled with the
+                    error details.
+ 
+    @return YES if the item was successfully deleted or not in the cache, and the wipe data
+                   is stored successfully.
+ */
+- (BOOL)removeItem:(nonnull ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    RETURN_NO_ON_NIL_ARGUMENT(item);
+    
+    [item logMessage:@"Removing" level:MSIDLogLevelInfo correlationId:nil];
+
+    OSStatus deleteStatus = [self deleteItem:item error:error];
+    
+    //if item does not exist in cache or does not contain a refresh token, deletion is enough and should return.
+    if (deleteStatus != errSecSuccess || [NSString msidIsStringNilOrBlank:item.refreshToken])
+    {
+        return [ADLegacyKeychainTokenCache checkStatus:deleteStatus operation:@"delete" correlationId:nil error:error];
+    }
+
+    return [self saveWipeTokenData:error];
+}
+
+//Interal function: delete an item from keychain;
+- (OSStatus)deleteItem:(nonnull ADTokenCacheItem *)item
+                 error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    RETURN_NO_ON_NIL_ARGUMENT(item);
+    ADTokenCacheKey* key = [item extractKey:error];
+    if (!key)
+    {
+        return NO;
+    }
+    NSMutableDictionary* query = [self queryDictionaryForKey:key
+                                                      userId:item.userInformation.userId
+                                                  additional:nil];
+    return SecItemDelete((CFDictionaryRef)query);
+}
+
+- (BOOL)removeAllForClientId:(NSString * __nonnull)clientId
+                       error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    MSID_LOG_WARN(nil, @"Removing all items for client");
+    MSID_LOG_WARN_PII(nil, @"Removing all items for client %@", clientId);
+    
+    NSArray* items = [self allItems:error];
+    if (!items)
+    {
+        return NO;
+    }
+    
+    for (ADTokenCacheItem * item in items)
+    {
+        if ([clientId isEqualToString:[item clientId]]
+            && ![self removeItem:item error:error])
+        {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+- (BOOL)removeAllForUserId:(NSString * __nonnull)userId
+                  clientId:(NSString * __nonnull)clientId
+                     error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    MSID_LOG_WARN(nil, @"Removing all items for user");
+    MSID_LOG_WARN_PII(nil, @"Removing all items for user + client <%@> userid <%@>", clientId, userId);
+    
+    NSArray* items = [self allItems:nil];
+    if (!items)
+    {
+        return NO;
+    }
+    
+    for (ADTokenCacheItem * item in items)
+    {
+        if ([userId isEqualToString:[[item userInformation] userId]]
+            && [clientId isEqualToString:[item clientId]]
+            && ![self removeItem:item error:error])
+        {
+            return NO;
+        }
+    }
+    return YES;
+}
+
+- (BOOL)wipeAllItemsForUserId:(NSString * __nonnull)userId error:(ADAuthenticationError *__autoreleasing  _Nullable *)error
+{
+    MSID_LOG_WARN(nil, @"Removing all items for user.");
+    MSID_LOG_WARN_PII(nil, @"Removing all items for userId <%@>", userId);
+
+    NSDictionary *query = @{ (id)kSecClass : (id)kSecClassGenericPassword,
+                             (id)kSecAttrAccount: [ADHelpers normalizeUserId:userId].msidBase64UrlEncode,
+                             (id)kSecAttrAccessGroup: _sharedGroup };
+    
+    OSStatus status = SecItemDelete((CFDictionaryRef)query);
+    
+    if ([ADLegacyKeychainTokenCache checkStatus:status operation:@"remove user" correlationId:nil error:error])
+    {
+        return NO;
+    }
+    
+    return [self saveWipeTokenData:error];
+}
+
+#pragma mark -
+#pragma mark Keychain Query Dictionary Utils
+
+//We should not put nil keys in the keychain. The method substitutes nil with a special GUID:
++ (NSString*)getAttributeName:(NSString* )original
+{
+    return ([NSString msidIsStringNilOrBlank:original]) ? s_nilKey : [original msidBase64UrlEncode];
+}
+
+// Given an item key, generates the string key used in the keychain:
+- (NSString*)keychainKeyFromCacheKey:(ADTokenCacheKey *)itemKey
+{
+    //The key contains all of the ADAL cache key elements plus the version of the
+    //library. The latter is required to ensure that SecItemAdd won't break on collisions
+    //with items left over from the previous versions of the library.
+    return [NSString stringWithFormat:@"%@%@%@%@%@%@%@",
+            s_libraryString, s_delimiter,
+            [itemKey.authority msidBase64UrlEncode], s_delimiter,
+            [self.class getAttributeName:itemKey.resource], s_delimiter,
+            [itemKey.clientId msidBase64UrlEncode]
+            ];
+}
+
++ (BOOL)checkStatus:(OSStatus)status
+          operation:(NSString *)operation
+      correlationId:(NSUUID *)correlationId
+              error:(ADAuthenticationError* __autoreleasing *)error
+{
+    if (status == errSecSuccess || status == errSecItemNotFound)
+    {
+        return NO;
+    }
+    
+    ADAuthenticationError* adError = [ADAuthenticationError keychainErrorFromOperation:operation status:status correlationId:correlationId];
+    if (error)
+    {
+        *error = adError;
+    }
+    
+    return YES;
+}
+
+- (NSMutableDictionary*)queryDictionaryForKey:(ADTokenCacheKey *)key
+                                       userId:(NSString *)userId
+                                   additional:(NSDictionary*)additional
+{
+    NSMutableDictionary* query = [NSMutableDictionary dictionaryWithDictionary:_default];
+    if (key)
+    {
+        [query setObject:[self keychainKeyFromCacheKey:key]
+                  forKey:(NSString*)kSecAttrService];
+    }
+    if (userId)
+    {
+        [query setObject:[userId msidBase64UrlEncode]
+                  forKey:(NSString*)kSecAttrAccount];
+    }
+    
+    if (additional)
+    {
+        [query addEntriesFromDictionary:additional];
+    }
+    
+    return query;
+}
+
+- (NSArray<ADTokenCacheItem *> *)getItemsWithKey:(ADTokenCacheKey *)key
+                                          userId:(NSString *)userId
+                                   correlationId:(NSUUID *)correlationId
+                                           error:(ADAuthenticationError * __autoreleasing* )error
+{
+    NSArray* items = [self keychainItemsWithKey:key userId:userId error:error];
+    
+    if (!items || items.count == 0)
+    {
+        [self logWipeTokenData:correlationId];
+    }
+    
+    if (!items)
+    {
+        [self logItemRetrievalStatus:nil key:key userId:userId correlationId:correlationId];
+        return nil;
+    }
+    
+    NSMutableArray* tokenItems = [[NSMutableArray<ADTokenCacheItem *> alloc] initWithCapacity:items.count];
+    for (NSDictionary* attrs in items)
+    {
+        ADTokenCacheItem* item = [self itemFromKeychainAttributes:attrs];
+        if (!item)
+        {
+            continue;
+        }
+        
+        // Delete tombstones generated from previous versions of ADAL
+        if (item.refreshToken != nil && [item.refreshToken isEqualToString:@"<tombstone>"]) {
+            [self deleteItem:item error:nil];
+            continue;
+        }
+
+        [tokenItems addObject:item];
+    }
+    
+    [self logItemRetrievalStatus:tokenItems key:key userId:userId correlationId:correlationId];
+    
+    return tokenItems;
+    
+}
+
+/*!
+    @param key      The key of the item.
+    @param userId   The specific user whose item is needed. May be nil, in which
+                    case the item for the first user in the cache will be returned.
+    @param error    Will be set only in case of ambiguity. E.g. if userId is nil
+                    and we have tokens from multiple users. If the cache item is not
+                    present, the error will not be set.
+ */
+- (ADTokenCacheItem*)getItemWithKey:(ADTokenCacheKey *)key
+                             userId:(NSString *)userId
+                      correlationId:(NSUUID *)correlationId
+                              error:(ADAuthenticationError * __autoreleasing *)error
+{
+    NSArray* items = [self getItemsWithKey:key userId:userId correlationId:correlationId error:error];
+    
+    if (!items || items.count == 0)
+    {
+        return nil;
+    }
+    
+    if (items.count > 1)
+    {
+        ADAuthenticationError* adError =
+        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_CACHE_MULTIPLE_USERS
+                                               protocolCode:nil
+                                               errorDetails:@"The token cache store for this resource contains more than one user. Please set the 'userId' parameter to the one that will be used."
+                                              correlationId:correlationId];
+        if (error)
+        {
+            *error = adError;
+        }
+        
+        return nil;
+    }
+    
+    return items.firstObject;
+}
+
+/*!
+    Ensures the cache contains an item matching the passed in item, adding or updating the
+    item as necessary.
+    
+    @param  item    The item to add to the cache, or update if an item matching the key and
+                    userId already exists in the cache.
+    @param  error   (Optional) In the case of an error this will be filled with the
+                    error details.
+ */
+- (BOOL)addOrUpdateItem:(ADTokenCacheItem *)item
+          correlationId:(nullable NSUUID *)correlationId
+                  error:(ADAuthenticationError * __autoreleasing*)error
+{
+    @synchronized(self)
+    {
+        ADTokenCacheKey* key = [item extractKey:error];
+        if (!key)
+        {
+            return NO;
+        }
+        
+        // In layers above this a nil/blank user ID means we simply don't know who it is (thanks to ADFS)
+        // however for the purposes of adding users we still do need to have an account name, even if it
+        // is just blank.
+        NSString* userId = item.userInformation.userId;
+        if (!userId)
+        {
+            userId = @"";
+        }
+        
+        // If the item wasn't found that means we need to add it.
+        NSMutableDictionary* query = [self queryDictionaryForKey:key
+                                                          userId:userId
+                                                      additional:nil];
+        
+        NSData* itemData = [NSKeyedArchiver archivedDataWithRootObject:item];
+        if (!itemData)
+        {
+            ADAuthenticationError* adError = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_CACHE_BAD_FORMAT protocolCode:nil errorDetails:@"Failed to archive keychain item" correlationId:correlationId];
+            if (error)
+            {
+                *error = adError;
+            }
+            return NO;
+        }
+        
+        NSDictionary* attrToUpdate = @{ (id)kSecValueData : itemData };
+        OSStatus status = SecItemUpdate((CFDictionaryRef)query, (CFDictionaryRef)attrToUpdate);
+        if (status == errSecSuccess)
+        {
+            return YES;
+        }
+        else if (status == errSecItemNotFound)
+        {
+            // If the item wasn't found that means we need to add it instead.
+            
+            [query addEntriesFromDictionary:@{ (id)kSecValueData : itemData,
+                                               (id)kSecAttrAccessible : (id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly}];
+            status = SecItemAdd((CFDictionaryRef)query, NULL);
+            if ([ADLegacyKeychainTokenCache checkStatus:status operation:@"add" correlationId:correlationId error:error])
+            {
+                return NO;
+            }
+        }
+        else if ([ADLegacyKeychainTokenCache checkStatus:status operation:@"update" correlationId:correlationId error:error])
+        {
+            return NO;
+        }
+    }
+    
+    return YES;
+}
+
+- (void)testRemoveAll:(ADAuthenticationError * __autoreleasing *)error
+{
+    MSID_LOG_ERROR(nil, @"******** -testRemoveAll: being called in ADKeychainTokenCache. This method should NEVER be called in production code. ********");
+    @synchronized(self)
+    {
+        NSMutableDictionary* query = [self queryDictionaryForKey:nil userId:nil additional:nil];
+        OSStatus status = SecItemDelete((CFDictionaryRef)query);
+        [ADLegacyKeychainTokenCache checkStatus:status operation:@"remove all" correlationId:nil error:error];
+        
+        query =
+        [@{
+           (id)kSecClass                : (id)kSecClassGenericPassword,
+           (id)kSecAttrGeneric          : [s_wipeLibraryString dataUsingEncoding:NSUTF8StringEncoding],
+           (id)kSecAttrAccessGroup      : _sharedGroup,
+           (id)kSecAttrAccount          : @"TokenWipe"
+           } mutableCopy];
+        
+        status = SecItemDelete((CFDictionaryRef)query);
+        [ADLegacyKeychainTokenCache checkStatus:status operation:@"remove all" correlationId:nil error:error];
+        
+
+    }
+}
+
+- (NSDictionary *)defaultKeychainQuery
+{
+    return _default;
+}
+
+- (NSDictionary *)getWipeTokenData
+{
+    static NSDictionary *sQuery;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        NSMutableDictionary *query = [[self wipeQuery] mutableCopy];
+        [query setObject:@(YES) forKey:(id)kSecReturnData];
+        sQuery = query;
+    });
+    
+    CFTypeRef data = nil;
+    OSStatus status = SecItemCopyMatching((CFDictionaryRef)sQuery, &data);
+    
+    if (status == errSecSuccess && data)
+    {
+        NSDictionary *wipeData = [NSKeyedUnarchiver unarchiveObjectWithData:(__bridge NSData * _Nonnull)(data)];
+        CFRelease(data);
+        return wipeData;
+    }
+    
+    return nil;
+}
+
+@end

--- a/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.h
+++ b/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.h
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+
+#import <Foundation/Foundation.h>
+#import "ADTokenCache.h"
+
+#define CURRENT_WRAPPER_CACHE_VERSION 1.0
+
+@class ADAuthenticationError;
+@class ADTokenCacheItem;
+
+@interface ADLegacyMacTokenCache : ADTokenCache <ADTokenCacheDataSource>
+
+/*! Returns the default cache object using the ADTokenCacheDelegate set in
+    ADAuthenticationSettings */
++ (nonnull ADLegacyMacTokenCache *)defaultCache;
+
+- (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate;
+
+- (nullable NSData *)serialize;
+- (BOOL)deserialize:(nullable NSData*)data
+              error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+- (nullable NSArray<ADTokenCacheItem *> *)allItems:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+- (BOOL)removeItem:(nonnull ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error;
+
+- (BOOL)validateCache:(nullable NSDictionary *)dict
+                error:(ADAuthenticationError * __nullable  __autoreleasing * __nullable)error;
+
+- (nullable id<ADTokenCacheDelegate>)delegate;
+
+@end

--- a/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.m
+++ b/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.m
@@ -1,0 +1,595 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//
+//  This class provides a ADTokenCacheAccessor interface around the provided ADCacheStorage interface.
+//
+//  This class deserializes the token cache from the data blob provided by the developer on a -deserialize
+//  call and validates cache format.
+//
+//  Note, this class is only used on Mac OS X. On iOS the only suppport caching interface is
+//  ADKeychainTokenCache.
+//
+//  The cache itself is a serialized collection of object and dictionaries in the following schema:
+//
+//  root
+//    |- version - a NSString with a number specify the version of the cache
+//    |- tokenCache - an NSDictionary
+//          |- tokens   - a NSDictionary containing all the tokens
+//          |     |- [<user_id> - an NSDictionary, keyed off of an NSString of the userId
+//          |            |- <ADTokenCacheStoreKey> - An ADTokenCacheItem, keyed with an ADTokenCacheStoreKey
+
+#import "ADLegacyMacTokenCache.h"
+#import "ADAuthenticationError.h"
+#import "ADErrorCodes.h"
+#import "ADTokenCacheKey.h"
+#import "ADTokenCacheItem+Internal.h"
+#import "ADUserInformation.h"
+#import "ADTokenCache+Internal.h"
+#import "ADTokenCacheKey.h"
+#import "ADAuthenticationSettings.h"
+
+#include <pthread.h>
+
+#define CHECK_ERROR(_cond, _code, _details) { \
+    if (!(_cond)) { \
+        ADAuthenticationError* _AD_ERROR = [ADAuthenticationError errorFromAuthenticationError:_code protocolCode:nil errorDetails:_details correlationId:nil]; \
+        if (error) { *error = _AD_ERROR; } \
+        return NO; \
+    } \
+}
+
+@implementation ADLegacyMacTokenCache
+
++ (ADLegacyMacTokenCache *)defaultCache
+{
+    static dispatch_once_t once;
+    static ADLegacyMacTokenCache * cache = nil;
+    
+    dispatch_once(&once, ^{
+        cache = [ADLegacyMacTokenCache new];
+    });
+    
+    return cache;
+}
+
+- (id)init
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    pthread_rwlock_init(&_lock, NULL);
+    
+    return self;
+}
+
+- (void)dealloc
+{
+    pthread_rwlock_destroy(&_lock);
+}
+
+- (void)setDelegate:(nullable id<ADTokenCacheDelegate>)delegate
+{
+    if (_delegate == delegate)
+    {
+        return;
+    }
+    
+    int err = pthread_rwlock_wrlock(&_lock);
+    if (err != 0)
+    {
+        MSID_LOG_ERROR(nil, @"pthread_rwlock_wrlock failed in setDelegate");
+        return;
+    }
+    
+    _delegate = delegate;
+    _cache = nil;
+    
+    pthread_rwlock_unlock(&_lock);
+    
+    if (!delegate)
+    {
+        return;
+    }
+    
+    [_delegate willAccessCache:self];
+    
+    [_delegate didAccessCache:self];
+}
+
+- (nullable NSData *)serialize
+{
+    if (!_cache)
+    {
+        return nil;
+    }
+    
+    int err = pthread_rwlock_rdlock(&_lock);
+    if (err != 0)
+    {
+        MSID_LOG_ERROR(nil, @"pthread_rwlock_rdlock failed in serialize");
+        return nil;
+    }
+    NSDictionary* cacheCopy = [_cache mutableCopy];
+    pthread_rwlock_unlock(&_lock);
+    
+    // Using the dictionary @{ key : value } syntax here causes _cache to leak. Yay legacy runtime!
+    NSDictionary* wrapper = [NSDictionary dictionaryWithObjectsAndKeys:cacheCopy, @"tokenCache",
+                             @CURRENT_WRAPPER_CACHE_VERSION, @"version", nil];
+    
+    @try
+    {
+        return [NSKeyedArchiver archivedDataWithRootObject:wrapper];
+    }
+    @catch (id exception)
+    {
+        // This should be exceedingly rare as all of the objects in the cache we placed there.
+        MSID_LOG_ERROR(nil, @"Failed to serialize the cache!");
+        return nil;
+    }
+}
+
+- (id)unarchive:(NSData*)data
+          error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    @try
+    {
+        return [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    }
+    @catch (id expection)
+    {
+        ADAuthenticationError* adError =
+        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_CACHE_BAD_FORMAT
+                                               protocolCode:nil
+                                               errorDetails:@"Failed to unarchive data blob from -deserialize!"
+                                              correlationId:nil];
+        
+        if (error)
+        {
+            *error = adError;
+        }
+        
+        return nil;
+    }
+}
+
+
+- (BOOL)deserialize:(nullable NSData*)data
+              error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    pthread_rwlock_wrlock(&_lock);
+    BOOL ret = [self deserializeImpl:data error:error];
+    pthread_rwlock_unlock(&_lock);
+    return ret;
+}
+
+- (BOOL)deserializeImpl:(nullable NSData*)data
+              error:(ADAuthenticationError * __nullable __autoreleasing * __nullable)error
+{
+    // If they pass in nil on deserialize that means to drop the cache
+    if (!data)
+    {
+        _cache = nil;
+        return YES;
+    }
+    
+    id cache = [self unarchive:data error:error];
+    if (!cache)
+    {
+        return NO;
+    }
+    
+    if (![self validateCache:cache error:error])
+    {
+        return NO;
+    }
+    
+    _cache = [cache objectForKey:@"tokenCache"];
+    return YES;
+}
+
+
+- (BOOL)updateCache:(NSData*)data
+              error:(ADAuthenticationError * __autoreleasing *)error
+{
+    if (!data)
+    {
+        if (_cache)
+        {
+            MSID_LOG_WARN(nil, @"nil data provided to -updateCache, dropping old cache.");
+            _cache = nil;
+        }
+        else
+        {
+            MSID_LOG_INFO(nil, @"No data provided for cache.");
+        }
+        return YES;
+    }
+    
+    // Unarchive the data first
+    NSDictionary* dict = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    CHECK_ERROR(dict, AD_ERROR_CACHE_BAD_FORMAT, @"Unable to unarchive data provided by cache storage!");
+
+    if (![self validateCache:dict error:error])
+    {
+        return NO;
+    }
+    
+    _cache = [dict objectForKey:@"tokenCache"];
+    
+    return YES;
+}
+
+#pragma mark -
+
+- (void)addToItems:(nonnull NSMutableArray *)items
+    fromDictionary:(nonnull NSDictionary *)dictionary
+               key:(nonnull ADTokenCacheKey *)key
+{
+    ADTokenCacheItem* item = [dictionary objectForKey:key];
+    if (item)
+    {
+        item = [item copy];
+        
+        [items addObject:item];
+    }
+}
+
+- (void)addToItems:(nonnull NSMutableArray *)items
+         forUserId:(nonnull NSString *)userId
+            tokens:(nonnull NSDictionary *)tokens
+               key:(ADTokenCacheKey *)key
+{
+    NSDictionary* userTokens = [tokens objectForKey:userId];
+    if (!userTokens)
+    {
+        return;
+    }
+    
+    // Add items matching the key for this user
+    if (key)
+    {
+        [self addToItems:items fromDictionary:userTokens key:key];
+    }
+    else
+    {
+        for (id adkey in userTokens)
+        {
+            [self addToItems:items fromDictionary:userTokens key:adkey];
+        }
+    }
+}
+
+- (NSArray<ADTokenCacheItem *> *)getItemsImplKey:(nullable ADTokenCacheKey *)key
+                                          userId:(nullable NSString *)userId
+{
+    if (!_cache)
+    {
+        return nil;
+    }
+    
+    NSDictionary* tokens = [_cache objectForKey:@"tokens"];
+    if (!tokens)
+    {
+        return nil;
+    }
+    
+    NSMutableArray* items = [NSMutableArray new];
+    
+    if (userId)
+    {
+        // If we have a specified userId then we only look for that one
+        [self addToItems:items forUserId:userId tokens:tokens key:key];
+    }
+    else
+    {
+        // Otherwise we have to traverse all of the users in the cache
+        for (NSString* userId in tokens)
+        {
+            [self addToItems:items forUserId:userId tokens:tokens key:key];
+        }
+    }
+    
+    return items;
+}
+
+
+/*! Clears token cache details for specific keys.
+    @param item The item to remove from the array.
+ */
+- (BOOL)removeItem:(ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __autoreleasing *)error
+{
+    [_delegate willWriteCache:self];
+    int err = pthread_rwlock_wrlock(&_lock);
+    if (err != 0)
+    {
+        MSID_LOG_ERROR(nil, @"pthread_rwlock_wrlock failed in removeItem");
+        return NO;
+    }
+    BOOL result = [self removeImpl:item error:error];
+    pthread_rwlock_unlock(&_lock);
+    [_delegate didWriteCache:self];
+    return result;
+}
+
+- (BOOL)removeImpl:(ADTokenCacheItem *)item
+             error:(ADAuthenticationError * __autoreleasing *)error
+{
+    ADTokenCacheKey* key = [item extractKey:error];
+    if (!key)
+    {
+        return NO;
+    }
+    
+    NSString* userId = item.userInformation.userId;
+    if (!userId)
+    {
+        userId = @"";
+    }
+    
+    NSMutableDictionary* tokens = [_cache objectForKey:@"tokens"];
+    if (!tokens)
+    {
+        return YES;
+    }
+    
+    NSMutableDictionary* userTokens = [tokens objectForKey:userId];
+    if (!userTokens)
+    {
+        return YES;
+    }
+    
+    if (![userTokens objectForKey:key])
+    {
+        return YES;
+    }
+    
+    [userTokens removeObjectForKey:key];
+    
+    // Check to see if we need to remove the overall dict
+    if (!userTokens.count)
+    {
+        [tokens removeObjectForKey:userId];
+    }
+    
+    return YES;
+}
+
+/*! Return a copy of all items. The array will contain ADTokenCacheItem objects,
+ containing all of the cached information. Returns an empty array, if no items are found.
+ Returns nil in case of error. */
+- (NSArray<ADTokenCacheItem *> *)allItems:(ADAuthenticationError * __autoreleasing *)error
+{
+    return [self getItemsWithKey:nil userId:nil correlationId:nil error:error];
+}
+
+- (id<ADTokenCacheDelegate>)delegate
+{
+    return _delegate;
+}
+
+- (BOOL)validateCache:(NSDictionary*)dict
+                error:(ADAuthenticationError * __autoreleasing *)error
+{
+    CHECK_ERROR([dict isKindOfClass:[NSDictionary class]], AD_ERROR_CACHE_BAD_FORMAT, @"Root level object of cache is not a NSDictionary!");
+    
+    NSString* version = [dict objectForKey:@"version"];
+    CHECK_ERROR(version, AD_ERROR_CACHE_BAD_FORMAT, @"Missing version number from cache.");
+    CHECK_ERROR([version floatValue] <= CURRENT_WRAPPER_CACHE_VERSION, AD_ERROR_CACHE_VERSION_MISMATCH, @"Cache is a future unsupported version.");
+    
+    NSDictionary* cache = [dict objectForKey:@"tokenCache"];
+    CHECK_ERROR(cache, AD_ERROR_CACHE_BAD_FORMAT, @"Missing token cache from data.");
+    CHECK_ERROR([cache isKindOfClass:[NSMutableDictionary class]], AD_ERROR_CACHE_BAD_FORMAT, @"Cache is not a dictionary!");
+    
+    NSDictionary* tokens = [cache objectForKey:@"tokens"];
+    
+    if (tokens)
+    {
+        CHECK_ERROR([tokens isKindOfClass:[NSMutableDictionary class]], AD_ERROR_CACHE_BAD_FORMAT, @"tokens must be a mutable dictionary.");
+        for (id userId in tokens)
+        {
+            // On the second level we're expecting NSDictionaries keyed off of the user ids (an NSString*)
+            CHECK_ERROR([userId isKindOfClass:[NSString class]], AD_ERROR_CACHE_BAD_FORMAT, @"User ID key is not of the expected class type");
+            id userDict = [tokens objectForKey:userId];
+            CHECK_ERROR([userDict isKindOfClass:[NSMutableDictionary class]], AD_ERROR_CACHE_BAD_FORMAT, @"User ID should have mutable dictionaries in the cache");
+            
+            for (id adkey in userDict)
+            {
+                // On the first level we're expecting NSDictionaries keyed off of ADTokenCacheStoreKey
+                CHECK_ERROR([adkey isKindOfClass:[ADTokenCacheKey class]], AD_ERROR_CACHE_BAD_FORMAT, @"Key is not of the expected class type");
+                id token = [userDict objectForKey:adkey];
+                CHECK_ERROR([token isKindOfClass:[ADTokenCacheItem class]], AD_ERROR_CACHE_BAD_FORMAT, @"Token is not of the expected class type!");
+            }
+        }
+    }
+    
+    return YES;
+}
+
+#pragma mark -
+#pragma mark ADTokenCacheAccessor Protocol Implementation
+
+/*! May return nil, if no cache item corresponds to the requested key
+ @param key The key of the item.
+ @param userId The specific user whose item is needed. May be nil, in which
+ case the item for the first user in the cache will be returned.
+ @param error Will be set only in case of ambiguity. E.g. if userId is nil
+ and we have tokens from multiple users. If the cache item is not present,
+ the error will not be set. */
+- (ADTokenCacheItem *)getItemWithKey:(ADTokenCacheKey *)key
+                              userId:(NSString *)userId
+                       correlationId:(NSUUID *)correlationId
+                               error:(ADAuthenticationError * __autoreleasing *)error
+{
+    NSArray<ADTokenCacheItem *> * items = [self getItemsWithKey:key userId:userId correlationId:correlationId error:error];
+    
+    if (items.count == 0)
+    {
+        return nil;
+    }
+    
+    for (ADTokenCacheItem* item in items)
+    {
+        [item logMessage:@"Found"
+                   level:MSIDLogLevelWarning
+           correlationId:correlationId];
+    }
+    
+    if (items.count == 1)
+    {
+        return items.firstObject;
+    }
+
+    
+    ADAuthenticationError* adError =
+    [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_CACHE_MULTIPLE_USERS
+                                           protocolCode:nil
+                                           errorDetails:@"The token cache store for this resource contains more than one user. Please set the 'userId' parameter to the one that will be used."
+                                          correlationId:correlationId];
+    if (error)
+    {
+        *error = adError;
+    }
+    
+    return nil;
+
+}
+
+/*! Extracts the key from the item and uses it to set the cache details. If another item with the
+ same key exists, it will be overriden by the new one. 'getItemWithKey' method can be used to determine
+ if an item already exists for the same key.
+ @param error in case of an error, if this parameter is not nil, it will be filled with
+ the error details. */
+- (BOOL)addOrUpdateItem:(ADTokenCacheItem *)item
+          correlationId:(NSUUID *)correlationId
+                  error:(ADAuthenticationError * __autoreleasing *)error
+{
+    [_delegate willWriteCache:self];
+    int err = pthread_rwlock_wrlock(&_lock);
+    if (err != 0)
+    {
+        MSID_LOG_ERROR_CORR(correlationId, @"pthread_rwlock_wrlock failed in addOrUpdateItem");
+        return NO;
+    }
+    BOOL result = [self addOrUpdateImpl:item correlationId:correlationId error:error];
+    pthread_rwlock_unlock(&_lock);
+    [_delegate didWriteCache:self];
+    
+    return result;
+}
+
+- (BOOL)addOrUpdateImpl:(ADTokenCacheItem *)item
+          correlationId:(NSUUID *)correlationId
+                  error:(ADAuthenticationError * __autoreleasing *)error
+{
+    if (!item)
+    {
+        ADAuthenticationError* adError = [ADAuthenticationError errorFromArgument:item argumentName:@"item" correlationId:correlationId];
+        if (error)
+        {
+            *error = adError;
+        }
+        return NO;
+    }
+    
+    // Copy the item to make sure it doesn't change under us.
+    item = [item copy];
+    
+    ADTokenCacheKey* key = [item extractKey:error];
+    if (!key)
+    {
+        return NO;
+    }
+    
+    NSMutableDictionary* tokens = nil;
+    
+    if (!_cache)
+    {
+        // If we don't have a cache that means we need to create one.
+        _cache = [NSMutableDictionary new];
+        tokens = [NSMutableDictionary new];
+        [_cache setObject:tokens forKey:@"tokens"];
+    }
+    else
+    {
+        tokens = [_cache objectForKey:@"tokens"];
+    }
+    
+    // Grab the userId first
+    id userId = item.userInformation.userId;
+    if (!userId)
+    {
+        // If we don't have one (ADFS case) then use an empty string
+        userId = @"";
+    }
+    
+    // Grab the token dictionary for this user id.
+    NSMutableDictionary* userDict = [tokens objectForKey:userId];
+    if (!userDict)
+    {
+        userDict = [NSMutableDictionary new];
+        [tokens setObject:userDict forKey:userId];
+    }
+    
+    [userDict setObject:item forKey:key];
+    return YES;
+}
+
+- (NSArray<ADTokenCacheItem *> *)getItemsWithKey:(nullable ADTokenCacheKey *)key
+                                          userId:(nullable NSString *)userId
+                                   correlationId:(nullable NSUUID *)correlationId
+                                           error:(ADAuthenticationError *__autoreleasing *)error
+{
+    (void)error;
+    (void)correlationId;
+    
+    [_delegate willAccessCache:self];
+    int err = pthread_rwlock_rdlock(&_lock);
+    if (err != 0)
+    {
+        MSID_LOG_ERROR_CORR(correlationId, @"pthread_rwlock_rdlock failed in getItemsWithKey");
+        return nil;
+    }
+    NSArray<ADTokenCacheItem *> * result = [self getItemsImplKey:key userId:userId];
+    pthread_rwlock_unlock(&_lock);
+    
+    [_delegate didAccessCache:self];
+    
+    return result;
+}
+
+- (nullable NSDictionary *)getWipeTokenData
+{
+    // Wiping token data is not yet supported on macOS
+    return nil;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"ADTokenCache: %@", _cache];
+}
+
+@end

--- a/ADAL/tests/integration/mac/ADTokenCacheToMSIDMacTokenCacheTests.m
+++ b/ADAL/tests/integration/mac/ADTokenCacheToMSIDMacTokenCacheTests.m
@@ -25,8 +25,7 @@
 #import "XCTestCase+TestHelperMethods.h"
 #import "ADTokenCacheItem.h"
 #import "MSIDMacTokenCache.h"
-#import "ADTokenCache.h"
-#import "ADTokenCache+Internal.h"
+#import "ADLegacyMacTokenCache.h"
 #import "MSIDTokenCacheKey.h"
 #import "MSIDLegacyTokenCacheKey.h"
 #import "ADUserInformation.h"
@@ -52,7 +51,7 @@
 
 - (void)testMSIDMacTokenCacheGetItemFromADALBlob_whenBlobContainsItem_shouldReturnThatItem
 {
-    ADTokenCache *adTokenCache = [ADTokenCache new];
+    ADLegacyMacTokenCache *adTokenCache = [ADLegacyMacTokenCache new];
     NSDate *date = [NSDate new];
     NSDictionary *additionalServerInfo = @{@"key1": @"value1"};
     NSData *sessionKey = [@"test" dataUsingEncoding:NSUTF8StringEncoding];
@@ -78,7 +77,7 @@
                                      resource:TEST_RESOURCE
                                  legacyUserId:TEST_USER_ID];
 
-    // Read from blob created by ADTokenCache.
+    // Read from blob created by ADLegacyMacTokenCache.
     NSData *data = [adTokenCache serialize];
     result = [msidMacTokenCache deserialize:data error:&error];
     XCTAssertNil(error);
@@ -111,7 +110,7 @@
     XCTAssertTrue(result);
 
     ADTokenCacheKey *key = [ADTokenCacheKey keyWithAuthority:TEST_AUTHORITY resource:TEST_RESOURCE clientId:TEST_CLIENT_ID error:nil];
-    ADTokenCache *adTokenCache = [ADTokenCache new];
+    ADLegacyMacTokenCache *adTokenCache = [ADLegacyMacTokenCache new];
 
     // Read from blob created by MSIDMacTokenCache.
     NSData *data = [msidMacTokenCache serialize];


### PR DESCRIPTION
Because both ADTokenCache and ADKeychainTokenCache are public components and they'll be modified to use MSID cache components, we need to have unmodified legacy components for integration testing purposes. 

ADLegacyTokenCache and ADLegacyKeychainTokenCache files are copy from original with class name changes.