### PR TITLE
Add openid scope for acquireTokenWithRefreshToken API

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -413,6 +413,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
     CHECK_STRING_ARG_BLOCK(refreshToken);
     [request setRefreshToken:refreshToken];
+    [request setScope:OAUTH2_SCOPE_OPENID_VALUE];
     [request setSilent:YES];
     
     [request acquireToken:@"136" completionBlock:completionBlock];

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -2163,13 +2163,23 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil(error);
     
     // the request should be using refresh token from developer
-    [ADTestURLSession addResponse:[self adResponseRefreshToken:@"refresh token from developer"
+    ADTestURLResponse *response = [self adResponseRefreshToken:@"refresh token from developer"
                                                      authority:TEST_AUTHORITY
                                                       resource:TEST_RESOURCE
                                                       clientId:TEST_CLIENT_ID
                                                  correlationId:TEST_CORRELATION_ID
                                                newRefreshToken:@"refresh token from server"
-                                                newAccessToken:@"access token from server"]];
+                                                newAccessToken:@"access token from server"];
+    
+    // explicitly set scope=open as the required field in request body
+    [response setUrlFormEncodedBody:@{ OAUTH2_GRANT_TYPE : @"refresh_token",
+                                       OAUTH2_REFRESH_TOKEN : @"refresh token from developer",
+                                       OAUTH2_RESOURCE : TEST_RESOURCE,
+                                       OAUTH2_CLIENT_ID : TEST_CLIENT_ID,
+                                       OAUTH2_SCOPE : OAUTH2_SCOPE_OPENID_VALUE
+                                       }];
+    
+    [ADTestURLSession addResponse:response];
     
     [context acquireTokenWithRefreshToken:@"refresh token from developer"
                                  resource:TEST_RESOURCE
@@ -2199,13 +2209,23 @@ const int sAsyncContextTimeout = 10;
     XCTestExpectation* expectation = [self expectationWithDescription:@"acquireTokenWithRefreshToken"];
     
     // the request should be using refresh token from developer
-    [ADTestURLSession addResponse:[self adResponseRefreshToken:@"refresh token from developer"
+    ADTestURLResponse *response = [self adResponseRefreshToken:@"refresh token from developer"
                                                      authority:TEST_AUTHORITY
                                                       resource:TEST_RESOURCE
                                                       clientId:TEST_CLIENT_ID
                                                  correlationId:TEST_CORRELATION_ID
                                                newRefreshToken:@"refresh token from server"
-                                                newAccessToken:@"access token from server"]];
+                                                newAccessToken:@"access token from server"];
+    
+    // explicitly set scope=open as the required field in request body
+    [response setUrlFormEncodedBody:@{ OAUTH2_GRANT_TYPE : @"refresh_token",
+                                       OAUTH2_REFRESH_TOKEN : @"refresh token from developer",
+                                       OAUTH2_RESOURCE : TEST_RESOURCE,
+                                       OAUTH2_CLIENT_ID : TEST_CLIENT_ID,
+                                       OAUTH2_SCOPE : OAUTH2_SCOPE_OPENID_VALUE
+                                       }];
+    
+    [ADTestURLSession addResponse:response];
     
     [context acquireTokenWithRefreshToken:@"refresh token from developer"
                                  resource:TEST_RESOURCE
@@ -2257,12 +2277,22 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil(error);
     
     // Network Response to reject developer's refresh token
-    [ADTestURLSession addResponse:[self adResponseBadRefreshToken:@"refresh token from developer"
+    ADTestURLResponse *response = [self adResponseBadRefreshToken:@"refresh token from developer"
                                                         authority:TEST_AUTHORITY
                                                          resource:TEST_RESOURCE
                                                          clientId:TEST_CLIENT_ID
                                                        oauthError:@"invalid_grant"
-                                                    correlationId:TEST_CORRELATION_ID]];
+                                                    correlationId:TEST_CORRELATION_ID];
+    
+    // explicitly set scope=open as the required field in request body
+    [response setUrlFormEncodedBody:@{ OAUTH2_GRANT_TYPE : @"refresh_token",
+                                       OAUTH2_REFRESH_TOKEN : @"refresh token from developer",
+                                       OAUTH2_RESOURCE : TEST_RESOURCE,
+                                       OAUTH2_CLIENT_ID : TEST_CLIENT_ID,
+                                       OAUTH2_SCOPE : OAUTH2_SCOPE_OPENID_VALUE
+                                       }];
+    
+    [ADTestURLSession addResponse:response];
     
     [context acquireTokenWithRefreshToken:@"refresh token from developer"
                                  resource:TEST_RESOURCE


### PR DESCRIPTION
`scope=openid` is now passed to server for `[ADAuthenticationContext acquireTokenWithRefreshToken:...]` API.

Unit tests are also changed accordingly as `scope=openid` is now expected in the network request.