### PR TITLE
Fix return value of removeItem

### DIFF
--- a/ADAL/src/cache/ios/ADKeychainTokenCache+Internal.h
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache+Internal.h
@@ -28,6 +28,7 @@
 
 @interface ADKeychainTokenCache (Internal) <ADTokenCacheDataSource>
 
+// Return NO if there is an error in status
 + (BOOL)checkStatus:(OSStatus)status
           operation:(NSString *)operation
       correlationId:(NSUUID *)correlationId

--- a/ADAL/src/cache/ios/ADKeychainTokenCache+Internal.h
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache+Internal.h
@@ -28,7 +28,7 @@
 
 @interface ADKeychainTokenCache (Internal) <ADTokenCacheDataSource>
 
-// Return NO if there is an error in status
+// Return YES if there is an error in status
 + (BOOL)checkStatus:(OSStatus)status
           operation:(NSString *)operation
       correlationId:(NSUUID *)correlationId

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -395,7 +395,7 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     //if item does not exist in cache or does not contain a refresh token, deletion is enough and should return.
     if (deleteStatus != errSecSuccess || [NSString adIsStringNilOrBlank:item.refreshToken])
     {
-        return [ADKeychainTokenCache checkStatus:deleteStatus operation:@"delete" correlationId:nil error:error];
+        return ![ADKeychainTokenCache checkStatus:deleteStatus operation:@"delete" correlationId:nil error:error];
     }
 
     return [self saveWipeTokenData:error];

--- a/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
@@ -193,12 +193,12 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     
     //remove item1.
     //Since item1 does not contain refresh token, it should be deleted from cache.
-    [mStore removeItem:item1 error:&error];
+    XCTAssertTrue([mStore removeItem:item1 error:&error]);
     ADAssertNoError;
     XCTAssertEqual([self count], 1);
     
     //remove item2.
-    [mStore removeItem:item2 error:&error];
+    XCTAssertTrue([mStore removeItem:item2 error:&error]);
     ADAssertNoError;
     XCTAssertEqual([self count], 0);
 }
@@ -211,10 +211,10 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     XCTAssertNotNil([mStore allItems:&error]);
     ADAssertNoError;
     
-    //add three items with the same client ID and one with a different client ID
-    ADTokenCacheItem* item1 = [self adCreateCacheItem:@"eric@contoso.com"];
+    //add some items (ATs and RTs) with the same client ID and one with a different client ID
+    ADTokenCacheItem* item1 = [self adCreateATCacheItem:TEST_RESOURCE userId:@"eric@contoso.com"];
     [mStore addOrUpdateItem:item1 correlationId:nil error:&error];
-    ADTokenCacheItem* item2 = [self adCreateCacheItem:@"stan@contoso.com"];
+    ADTokenCacheItem* item2 = [self adCreateMRRTCacheItem:@"stan@contoso.com"];
     [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
     ADTokenCacheItem* item3 = [self adCreateCacheItem:@"jack@contoso.com"];
     [mStore addOrUpdateItem:item3 correlationId:nil error:&error];
@@ -240,20 +240,22 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     XCTAssertNotNil([mStore allItems:&error]);
     ADAssertNoError;
     
-    //add two items with the same client ID and same user ID but differnet resource
+    //add three (ATs and RTs) items with the same client ID and same user ID but differnet resource
     ADTokenCacheItem* item1 = [self adCreateCacheItem:@"eric@contoso.com"];
     [item1 setResource:@"resource 1"];
     [mStore addOrUpdateItem:item1 correlationId:nil error:&error];
     ADTokenCacheItem* item2 = [self adCreateCacheItem:@"eric@contoso.com"];
     [item2 setResource:@"resource 2"];
     [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
-    //add another two more items
-    ADTokenCacheItem* item3 = [self adCreateCacheItem:@"jack@contoso.com"];
+    ADTokenCacheItem* item3 = [self adCreateATCacheItem:@"resource 3" userId:@"eric@contoso.com"];
     [mStore addOrUpdateItem:item3 correlationId:nil error:&error];
-    ADTokenCacheItem* item4 = [self adCreateCacheItem:@"rose@contoso.com"];
+    //add another two more items
+    ADTokenCacheItem* item4 = [self adCreateCacheItem:@"jack@contoso.com"];
     [mStore addOrUpdateItem:item4 correlationId:nil error:&error];
+    ADTokenCacheItem* item5 = [self adCreateCacheItem:@"rose@contoso.com"];
+    [mStore addOrUpdateItem:item5 correlationId:nil error:&error];
     ADAssertNoError;
-    XCTAssertEqual([self count], 4);
+    XCTAssertEqual([self count], 5);
     
     //remove items with user ID as @"eric@contoso.com" and client ID as TEST_CLIENT_ID
     [mStore removeAllForUserId:@"eric@contoso.com" clientId:TEST_CLIENT_ID error:&error];
@@ -261,8 +263,8 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     XCTAssertEqual([self count], 2);
 
     //only item3 and item4 are left in cache 
-    [self verifyCacheContainsItem:item3];
     [self verifyCacheContainsItem:item4];
+    [self verifyCacheContainsItem:item5];
 }
 
 - (BOOL)wipeTokenDataExist

--- a/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
+++ b/ADAL/tests/unit/ios/ADKeychainTokenCacheTests.m
@@ -240,7 +240,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     XCTAssertNotNil([mStore allItems:&error]);
     ADAssertNoError;
     
-    //add three (ATs and RTs) items with the same client ID and same user ID but differnet resource
+    //add three items (ATs and RTs) with the same client ID and same user ID but differnet resource
     ADTokenCacheItem* item1 = [self adCreateCacheItem:@"eric@contoso.com"];
     [item1 setResource:@"resource 1"];
     [mStore addOrUpdateItem:item1 correlationId:nil error:&error];
@@ -249,6 +249,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     [mStore addOrUpdateItem:item2 correlationId:nil error:&error];
     ADTokenCacheItem* item3 = [self adCreateATCacheItem:@"resource 3" userId:@"eric@contoso.com"];
     [mStore addOrUpdateItem:item3 correlationId:nil error:&error];
+    
     //add another two more items
     ADTokenCacheItem* item4 = [self adCreateCacheItem:@"jack@contoso.com"];
     [mStore addOrUpdateItem:item4 correlationId:nil error:&error];
@@ -262,7 +263,7 @@ NSString* const sFileNameEmpty = @"Invalid or empty file name";
     ADAssertNoError;
     XCTAssertEqual([self count], 2);
 
-    //only item3 and item4 are left in cache 
+    //only item4 and item5 are left in cache
     [self verifyCacheContainsItem:item4];
     [self verifyCacheContainsItem:item5];
 }


### PR DESCRIPTION
`[ADKeychainTokenCache removeItem:...]` may return an incorrect BOOL value when the token being deleted is an access token.

Unit tests have also been modified as they should have caught the bug.