### PR TITLE
Add the option to remove all users for a client in cache view

### DIFF
--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppCacheViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppCacheViewController.m
@@ -100,7 +100,7 @@
     [self loadCache];
 }
 
-- (void)deleteAllAtPath:(NSIndexPath*)indexPath
+- (void)deleteAllForUserIdClientIdAtPath:(NSIndexPath*)indexPath
 {
     ADTestAppCacheRowItem* rowItem = [self cacheItemForPath:indexPath];
     if (!rowItem.clientId)
@@ -113,6 +113,21 @@
     
     ADKeychainTokenCache* cache = [ADKeychainTokenCache new];
     [cache removeAllForUserId:userId clientId:rowItem.title error:nil];
+    
+    [self loadCache];
+}
+
+- (void)deleteAllForClientIdAtPath:(NSIndexPath*)indexPath
+{
+    ADTestAppCacheRowItem* rowItem = [self cacheItemForPath:indexPath];
+    if (!rowItem.clientId)
+    {
+        NSLog(@"Trying to delete all from a non-client-id item?");
+        return;
+    }
+    
+    ADKeychainTokenCache* cache = [ADKeychainTokenCache new];
+    [cache removeAllForClientId:rowItem.title error:nil];
     
     [self loadCache];
 }
@@ -175,17 +190,26 @@
     [expireTokenAction setBackgroundColor:[UIColor orangeColor]];
     
     
-    UITableViewRowAction* deleteAllAction =
+    UITableViewRowAction* deleteAllForUserIdClientIdAction =
     [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
-                                       title:@"Delete All"
+                                       title:@"Delete this user for this Client"
                                      handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
     {
-        [self deleteAllAtPath:indexPath];
+        [self deleteAllForUserIdClientIdAtPath:indexPath];
     }];
+    [deleteAllForUserIdClientIdAction setBackgroundColor:[UIColor orangeColor]];
+    
+    UITableViewRowAction* deleteAllForClientIdAction =
+    [UITableViewRowAction rowActionWithStyle:UITableViewRowActionStyleDestructive
+                                       title:@"Delete all users for this Client!"
+                                     handler:^(UITableViewRowAction * _Nonnull action, NSIndexPath * _Nonnull indexPath)
+     {
+         [self deleteAllForClientIdAtPath:indexPath];
+     }];
     
     _tokenRowActions = @[ deleteTokenAction, expireTokenAction ];
     _mrrtRowActions = @[ deleteTokenAction, invalidateAction ];
-    _clientIdRowActions = @[ deleteAllAction ];
+    _clientIdRowActions = @[ deleteAllForClientIdAction, deleteAllForUserIdClientIdAction ];
     
     [[NSNotificationCenter defaultCenter] addObserverForName:ADTestAppCacheChangeNotification
                                                       object:nil


### PR DESCRIPTION
For the test app, the option to remove all users for a client is added in cache view, 
such that we can test `[ADKeychainTokenCache removeAllForClientId:error:]`.