### PR TITLE
Disable CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF

### DIFF
--- a/ADAL.podspec
+++ b/ADAL.podspec
@@ -21,6 +21,7 @@ Pod::Spec.new do |s|
     :git => "https://github.com/AzureAD/azure-activedirectory-library-for-objc.git", 
     :tag => s.version.to_s
   }
+  s.pod_target_xcconfig = { 'CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF' => 'NO' }
   
   s.default_subspecs ='app-lib'
   


### PR DESCRIPTION
Change podspec to disable CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF explicitly, making it consistent with the xcode project settings.

I notice there are still two more warnings when consuming ADAL as pod:
`- WARN  | [ADAL/app-lib,ADAL/extension] xcodebuild:  /Users/jasoncoolmax/Desktop/work/adal/ADAL/src/ui/ios/ADAuthenticationViewController.m:122:1: warning: Implementing deprecated method [-Wdeprecated-implementations]`
`- WARN  | [ADAL/app-lib,ADAL/extension] xcodebuild:  /Users/jasoncoolmax/Desktop/work/adal/ADAL/src/ui/ios/ADAuthenticationViewController.m:129:1: warning: Implementing deprecated method [-Wdeprecated-implementations]`

Do we want to address them?