### PR TITLE
Telemetry fix

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -105,6 +105,8 @@
 		603389271D595A920024A9BF /* ADRequestParameters.m in Sources */ = {isa = PBXBuildFile; fileRef = 60D2F4001D531F16008725D9 /* ADRequestParameters.m */; };
 		603389281D595AA70024A9BF /* ADTelemetryAPIEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 6010EDE51D47B21600B62072 /* ADTelemetryAPIEvent.m */; };
 		6033892C1D595AD50024A9BF /* ADTelemetryBrokerEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 6010EDF91D47B2F300B62072 /* ADTelemetryBrokerEvent.m */; };
+		6035CD8F208003FE00369E69 /* ADAcquireTokenTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8E208003FE00369E69 /* ADAcquireTokenTelemetryTests.m */; };
+		6035CD90208003FE00369E69 /* ADAcquireTokenTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6035CD8E208003FE00369E69 /* ADAcquireTokenTelemetryTests.m */; };
 		603841A01DF9248F00D30F3D /* ADTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6038419F1DF9248F00D30F3D /* ADTelemetryTestDispatcher.m */; };
 		603841A11DF9248F00D30F3D /* ADTelemetryTestDispatcher.m in Sources */ = {isa = PBXBuildFile; fileRef = 6038419F1DF9248F00D30F3D /* ADTelemetryTestDispatcher.m */; };
 		6085CBF01DF764EB004BBF2A /* ADTelemetry.h in Copy Files */ = {isa = PBXBuildFile; fileRef = 6004019F1D340B760020EAAB /* ADTelemetry.h */; };
@@ -264,7 +266,6 @@
 		B24D25E92059F67D00025B8B /* ADResponseCacheHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B24D25E72059F67D00025B8B /* ADResponseCacheHandler.h */; };
 		B24D25EA2059F67D00025B8B /* ADResponseCacheHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B24D25E82059F67D00025B8B /* ADResponseCacheHandler.m */; };
 		B24D25EB2059F67D00025B8B /* ADResponseCacheHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B24D25E82059F67D00025B8B /* ADResponseCacheHandler.m */; };
-		B23FC03E1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B23FC03D1F0DA8F5008262F2 /* ADAcquireTokenPkeyAuthTests.m */; };
 		B24D25F9205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B24D25F8205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m */; };
 		B24D25FA205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B24D25F8205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m */; };
 		B267CA1B1EE0E9FF00C0B5A8 /* ADNegotiateHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */; };
@@ -758,6 +759,7 @@
 		601329A9206B237C00E70844 /* ADTokenCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADTokenCacheTests.m; sourceTree = "<group>"; };
 		601BEE2F1C6D9CCE004AA8C1 /* ADTestAuthenticationViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTestAuthenticationViewController.h; sourceTree = "<group>"; };
 		601BEE301C6DAA86004AA8C1 /* ADTestAuthenticationViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTestAuthenticationViewController.m; sourceTree = "<group>"; };
+		6035CD8E208003FE00369E69 /* ADAcquireTokenTelemetryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADAcquireTokenTelemetryTests.m; sourceTree = "<group>"; };
 		6038419E1DF9246D00D30F3D /* ADTelemetryTestDispatcher.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADTelemetryTestDispatcher.h; sourceTree = "<group>"; };
 		6038419F1DF9248F00D30F3D /* ADTelemetryTestDispatcher.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADTelemetryTestDispatcher.m; sourceTree = "<group>"; };
 		60967E191D76B62B00863853 /* tools */ = {isa = PBXFileReference; lastKnownFileType = folder; path = tools; sourceTree = SOURCE_ROOT; };
@@ -1791,6 +1793,7 @@
 				B20DC5DB1F0D97DD00957806 /* ios */,
 				23CF5E202040ED3500D348AF /* ADTokenCacheItemIntegrationWithMSIDTokensTests.m */,
 				B24D25F8205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m */,
+				6035CD8E208003FE00369E69 /* ADAcquireTokenTelemetryTests.m */,
 			);
 			path = integration;
 			sourceTree = "<group>";
@@ -2884,7 +2887,6 @@
 				236BF3FF205B38EB006E3897 /* ADAcquireTokenPkeyAuthTests.m in Sources */,
 				D67D3D3C1F38502900660F32 /* ADTestCase.m in Sources */,
 				B24D25F9205EFBC200025B8B /* ADAuthenticationErrorConverterIntegrationTests.m in Sources */,
-				B20DC60F1F0D99A300957806 /* ADAcquireTokenTests.m in Sources */,
 				D62256521F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
 				B2822A2F2055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */,
 				04930F7D1FEC8C0F00FC4DCD /* MSIDAadAuthorityCache+TestUtil.m in Sources */,
@@ -2907,6 +2909,7 @@
 				D67D3D471F422C3200660F32 /* ADFSAuthorityValidationIntegrationTests.m in Sources */,
 				B20DC59A1F0D96A100957806 /* ADTestAuthenticationViewController.m in Sources */,
 				B2822A342055DBF900390B6E /* ADLegacyKeychainTokenCache.m in Sources */,
+				6035CD8F208003FE00369E69 /* ADAcquireTokenTelemetryTests.m in Sources */,
 				B20D8FF51F60A3490021DA25 /* ADTelemetryIntegrationTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -2932,6 +2935,7 @@
 				D6D4D49B1F2FCD8600CC1859 /* ADTestURLResponse.m in Sources */,
 				D62256541F4C9EE8003D5DF4 /* ADTestAuthorityValidationResponse.m in Sources */,
 				23F4935420605EF500BDD7D5 /* AADAuthorityValidationIntegrationTests.m in Sources */,
+				6035CD90208003FE00369E69 /* ADAcquireTokenTelemetryTests.m in Sources */,
 				B2908C0E1FCA4E5900AFE98E /* ADTelemetryIntegrationTests.m in Sources */,
 				B2822A302055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */,
 				B20DC5C81F0D96A700957806 /* ADTestAuthenticationViewController.m in Sources */,

--- a/ADAL/src/telemetry/ADAggregatedDispatcher.m
+++ b/ADAL/src/telemetry/ADAggregatedDispatcher.m
@@ -63,7 +63,7 @@ static NSDictionary *s_eventPropertiesDictionary;
         [self addPropertiesToDictionary:aggregatedEvent event:event];
     }
     
-    [_dispatcher dispatchEvent:aggregatedEvent];
+    [self dispatchEvent:aggregatedEvent];
 }
 
 - (void)receive:(NSString *)requestId
@@ -100,7 +100,7 @@ static NSDictionary *s_eventPropertiesDictionary;
     {
         ADTelemetryCollectionBehavior collectionBehavior = [ADTelemetryCollectionRules getTelemetryCollectionRule:propertyName];
         
-        NSString* propertyKey = TELEMETRY_KEY(propertyName);
+        NSString* propertyKey = propertyName;
         
         if (collectionBehavior == CollectAndUpdate)
         {

--- a/ADAL/src/telemetry/ADDefaultDispatcher.h
+++ b/ADAL/src/telemetry/ADDefaultDispatcher.h
@@ -33,4 +33,6 @@
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDispatcher:(id<ADDispatcher>)dispatcher;
 
+- (void)dispatchEvent:(NSDictionary<NSString*, NSString*> *)event;
+
 @end

--- a/ADAL/src/telemetry/ADDefaultDispatcher.m
+++ b/ADAL/src/telemetry/ADDefaultDispatcher.m
@@ -25,6 +25,7 @@
 #import "MSIDTelemetryEventInterface.h"
 #import "ADDefaultDispatcher.h"
 #import "MSIDTelemetryEventInterface.h"
+#import "MSIDTelemetryEventStrings.h"
 
 @implementation ADDefaultDispatcher
 
@@ -62,8 +63,25 @@
     
     if (properties)
     {
-        [_dispatcher dispatchEvent:properties];
+        [self dispatchEvent:properties];
     }
+}
+
+- (void)dispatchEvent:(NSDictionary<NSString*, NSString*> *)event;
+{
+    [_dispatcher dispatchEvent:[self appendPrefixForEvent:event]];
+}
+
+- (NSDictionary *)appendPrefixForEvent:(NSDictionary *)event
+{
+    NSMutableDictionary *eventWithPrefix = [NSMutableDictionary new];
+    
+    for (NSString *propertyName in [event allKeys])
+    {
+        [eventWithPrefix setValue:event[propertyName] forKey:TELEMETRY_KEY(propertyName)];
+    }
+    
+    return eventWithPrefix;
 }
 
 @end

--- a/ADAL/src/telemetry/ADTelemetry.m
+++ b/ADAL/src/telemetry/ADTelemetry.m
@@ -80,4 +80,14 @@
     [[MSIDTelemetry sharedInstance] removeAllDispatchers];
 }
 
+- (BOOL)piiEnabled
+{
+    return [[MSIDTelemetry sharedInstance] piiEnabled];
+}
+
+- (void)setPiiEnabled:(BOOL)piiEnabled
+{
+    [[MSIDTelemetry sharedInstance] setPiiEnabled:piiEnabled];
+}
+
 @end

--- a/ADAL/tests/integration/ADAcquireTokenTelemetryTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTelemetryTests.m
@@ -1,0 +1,404 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <XCTest/XCTest.h>
+#import "XCTestCase+TestHelperMethods.h"
+#import "ADTestURLSession.h"
+#import "ADTestURLResponse.h"
+#import "ADTelemetryTestDispatcher.h"
+#import "ADAuthorityValidation.h"
+#import "MSIDSharedTokenCache.h"
+#import "MSIDLegacyTokenCacheAccessor.h"
+#import "ADAuthenticationContext+TestUtil.h"
+#import "MSIDDeviceId.h"
+#import "ADTokenCacheKey.h"
+#import "NSString+MSIDExtensions.h"
+#import "MSIDTelemetryEventStrings.h"
+
+#if TARGET_OS_IPHONE
+#import "MSIDKeychainTokenCache+MSIDTestsUtil.h"
+#import "MSIDKeychainTokenCache.h"
+#import "ADLegacyKeychainTokenCache.h"
+#else
+#import "ADTokenCache+Internal.h"
+#endif
+
+@interface ADAcquireTokenTelemetryTests : ADTestCase
+
+@property (nonatomic) MSIDSharedTokenCache *tokenCache;
+@property (nonatomic) id<ADTokenCacheDataSource> cacheDataSource;
+@property (nonatomic) NSMutableArray *receivedEvents;
+
+@end
+
+@implementation ADAcquireTokenTelemetryTests
+
+- (void)setUp
+{
+    [super setUp];
+    
+    _receivedEvents = [NSMutableArray array];
+    [self resetCache];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+    
+    [[ADTelemetry sharedInstance] removeAllDispatchers];
+    [ADTelemetry sharedInstance].piiEnabled = NO;
+}
+
+- (void)resetCache
+{
+#if TARGET_OS_IPHONE
+    [MSIDKeychainTokenCache reset];
+    
+    self.cacheDataSource = ADLegacyKeychainTokenCache.defaultKeychainCache;
+    
+    MSIDLegacyTokenCacheAccessor *legacyTokenCacheAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:MSIDKeychainTokenCache.defaultKeychainCache];
+    
+    self.tokenCache = [[MSIDSharedTokenCache alloc] initWithPrimaryCacheAccessor:legacyTokenCacheAccessor otherCacheAccessors:nil];
+#else
+    ADTokenCache *adTokenCache = [ADTokenCache new];
+    self.cacheDataSource = adTokenCache;
+    
+    MSIDLegacyTokenCacheAccessor *legacyTokenCacheAccessor = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:adTokenCache.macTokenCache];
+    
+    self.tokenCache = [[MSIDSharedTokenCache alloc] initWithPrimaryCacheAccessor:legacyTokenCacheAccessor otherCacheAccessors:nil];
+#endif
+}
+
+- (void)setupForAcquireTokenWithNetworkResponse
+{
+    // A simple FRT case, the only RT available is the FRT so that would should be the one used
+    ADAuthenticationError *error = nil;
+    XCTAssertTrue([self.cacheDataSource addOrUpdateItem:[self adCreateFRTCacheItem] correlationId:nil error:&error]);
+    XCTAssertNil(error);
+    
+    ADTestURLResponse *response = [self adResponseRefreshToken:@"family refresh token"
+                                                     authority:TEST_AUTHORITY
+                                                      resource:TEST_RESOURCE
+                                                      clientId:TEST_CLIENT_ID
+                                                requestHeaders:nil
+                                                 correlationId:TEST_CORRELATION_ID
+                                               newRefreshToken:@"new family refresh token"
+                                                newAccessToken:TEST_ACCESS_TOKEN
+                                              additionalFields:@{ ADAL_CLIENT_FAMILY_ID : @"1"}
+                                               responseHeaders:@{@"x-ms-clitelem" : @"1,0,0,2550.0643,I"}];
+    
+    [ADTestURLSession addResponse:response];
+    [[ADAuthorityValidation sharedInstance] addInvalidAuthority:TEST_AUTHORITY];
+}
+
+- (void)setupForAcquireTokenWithoutNetworkResponse
+{
+    // Add a token item to return in the cache
+    ADAuthenticationError *error = nil;
+    ADTokenCacheItem *item = [self adCreateCacheItem];
+    [self.cacheDataSource addOrUpdateItem:item correlationId:nil error:&error];
+}
+
+- (void)setupADTelemetryDispatcherWithAggregationRequired:(BOOL)aggregationRequired
+{
+    ADTelemetryTestDispatcher *dispatcher = [ADTelemetryTestDispatcher new];
+    
+    // the dispatcher will store the telemetry events it receives
+    [dispatcher setTestCallback:^(NSDictionary *event)
+     {
+         [_receivedEvents addObject:event];
+     }];
+    
+    // register the dispatcher
+    [[ADTelemetry sharedInstance] addDispatcher:dispatcher aggregationRequired:aggregationRequired];
+}
+
+- (ADAuthenticationContext *)getTestAuthenticationContext
+{
+    ADAuthenticationContext *context = [[ADAuthenticationContext alloc] initWithAuthority:TEST_AUTHORITY
+                                                                        validateAuthority:NO
+                                                                                    error:nil];
+    context.tokenCache = self.tokenCache;
+    NSAssert(context, @"If this is failing for whatever reason you should probably fix it before trying to run tests.");
+    [context setCorrelationId:TEST_CORRELATION_ID];
+    
+    return context;
+}
+
+- (void)testAcquireTokenTelemetry_whenPiiEnabledAndAggregrationOn_shouldReturnOneEventWithPii
+{
+    [self setupForAcquireTokenWithNetworkResponse];
+    [self setupADTelemetryDispatcherWithAggregationRequired:YES];
+    [ADTelemetry sharedInstance].piiEnabled = YES;
+    
+    ADAuthenticationContext *context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // verify telemetry output
+    // there should be 1 telemetry events recorded as aggregation flag is ON
+    XCTAssertEqual([_receivedEvents count], 1);
+    
+    // the following properties are expected in an aggregrated event
+    NSDictionary *event = [_receivedEvents firstObject];
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ID)], @"8");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_REQUEST_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CORRELATION_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_ver"]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_sku"]]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_TYPE)], @"aad");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EXTENDED_EXPIRES_ON_SETTING)], @"no");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_PROMPT_BEHAVIOR)], @"AD_PROMPT_AUTO");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESULT_STATUS)], @"succeeded");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESPONSE_TIME)]]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CACHE_EVENT_COUNT)], @"7");
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RT_STATUS)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_MRRT_STATUS)], @"tried");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_FRT_STATUS)], @"tried");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_HTTP_EVENT_COUNT)], @"1");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ERROR_CODE)], @"AD_ERROR_SUCCEEDED");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_OAUTH_ERROR_CODE)], @"");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_SUCCESSFUL)], @"yes");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_HTTP_RESPONSE_CODE)], @"400");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_VALIDATION_STATUS)], @"no");
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SERVER_ERROR_CODE)]);
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RT_AGE)], @"2550.0643");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SPE_INFO)], @"I");
+    // expect unhashed Oii
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_NAME)], [MSIDDeviceId applicationName]);//Oii
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_TENANT_ID)], @"6fd1f5cd-a94c-4335-889b-6c598e6d8048");//Oii
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CLIENT_ID)], TEST_CLIENT_ID);//Oii
+#if TARGET_OS_IPHONE
+    // application_version is only available in unit test framework with host app
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_VERSION)], [MSIDDeviceId applicationVersion]);//Oii
+#endif
+    // expect hashed Pii
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_DEVICE_ID)], [[MSIDDeviceId deviceTelemetryId] msidComputeSHA256]);//Pii
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID)], [TEST_USER_ID msidComputeSHA256]);//Pii
+}
+
+- (void)testAcquireTokenTelemetry_whenPiiDisabledAndAggregrationOn_shouldReturnOneEventWithoutPii
+{
+    [self setupForAcquireTokenWithNetworkResponse];
+    [self setupADTelemetryDispatcherWithAggregationRequired:YES];
+    [ADTelemetry sharedInstance].piiEnabled = NO;
+    
+    ADAuthenticationContext *context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // verify telemetry output
+    // there should be 1 telemetry events recorded as aggregation flag is ON
+    XCTAssertEqual([_receivedEvents count], 1);
+    
+    // the following properties are expected in an aggregrated event
+    NSDictionary *event = [_receivedEvents firstObject];
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ID)], @"8");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_REQUEST_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CORRELATION_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_ver"]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_sku"]]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_TYPE)], @"aad");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EXTENDED_EXPIRES_ON_SETTING)], @"no");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_PROMPT_BEHAVIOR)], @"AD_PROMPT_AUTO");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESULT_STATUS)], @"succeeded");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESPONSE_TIME)]]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CACHE_EVENT_COUNT)], @"7");
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RT_STATUS)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_MRRT_STATUS)], @"tried");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_FRT_STATUS)], @"tried");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_HTTP_EVENT_COUNT)], @"1");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ERROR_CODE)], @"AD_ERROR_SUCCEEDED");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_OAUTH_ERROR_CODE)], @"");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_SUCCESSFUL)], @"yes");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_HTTP_RESPONSE_CODE)], @"400");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_VALIDATION_STATUS)], @"no");
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SERVER_ERROR_CODE)]);
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SERVER_SUBERROR_CODE)]);
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RT_AGE)], @"2550.0643");
+    XCTAssertEqualObjects([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_SPE_INFO)], @"I");
+    // do not expect Oii
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_NAME)]);//Oii
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_TENANT_ID)]);//Oii
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CLIENT_ID)]);//Oii
+#if TARGET_OS_IPHONE
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_VERSION)]);//Oii
+#endif
+    // do not expect Pii
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_DEVICE_ID)]);//Pii
+    XCTAssertNil([event objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID)]);//Pii
+}
+
+- (void)testAcquireTokenTelemetry_whenPiiEnabledAndAggregrationOff_shouldReturnEventsWithPii
+{
+    [self setupForAcquireTokenWithNetworkResponse];
+    [self setupADTelemetryDispatcherWithAggregationRequired:NO];
+    [ADTelemetry sharedInstance].piiEnabled = YES;
+    
+    ADAuthenticationContext *context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // verify telemetry output
+    // there should be multiple telemetry events as aggregation flag is NO
+    XCTAssertTrue([_receivedEvents count] > 1);
+    
+    // take the API event as a sample and verify the output
+    NSDictionary *apiEvent = nil;
+    for (NSDictionary *event in _receivedEvents)
+    {
+        if ([MSID_TELEMETRY_EVENT_API_EVENT isEqualToString:[event objectForKey:(TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME))]])
+        {
+            apiEvent = event;
+        }
+    }
+    XCTAssertNotNil(apiEvent);
+    
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME)], MSID_TELEMETRY_EVENT_API_EVENT);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ID)], @"8");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_REQUEST_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CORRELATION_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:@"Microsoft.ADAL.x_client_ver"]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:@"Microsoft.ADAL.x_client_sku"]]);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_TYPE)], @"aad");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EXTENDED_EXPIRES_ON_SETTING)], @"no");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_PROMPT_BEHAVIOR)], @"AD_PROMPT_AUTO");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESULT_STATUS)], @"succeeded");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESPONSE_TIME)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_START_TIME)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_END_TIME)]]);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ERROR_CODE)], @"AD_ERROR_SUCCEEDED");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_SUCCESSFUL)], @"yes");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_EXTENED_LIFE_TIME_TOKEN)], @"no");
+    // expect unhashed Oii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY)], TEST_AUTHORITY);//Oii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_NAME)], [MSIDDeviceId applicationName]);//Oii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_TENANT_ID)], @"6fd1f5cd-a94c-4335-889b-6c598e6d8048");//Oii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CLIENT_ID)], TEST_CLIENT_ID);//Oii
+#if TARGET_OS_IPHONE
+    // application_version is only available in unit test framework with host app
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_VERSION)], [MSIDDeviceId applicationVersion]);//Oii
+#endif
+    // expect hashed Pii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_DEVICE_ID)], [[MSIDDeviceId deviceTelemetryId] msidComputeSHA256]);//Pii
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID)], [TEST_USER_ID msidComputeSHA256]);//Pii
+}
+
+- (void)testAcquireTokenTelemetry_whenPiiDisabledAndAggregrationOff_shouldReturnEventsWithoutPii
+{
+    [self setupForAcquireTokenWithNetworkResponse];
+    [self setupADTelemetryDispatcherWithAggregationRequired:NO];
+    [ADTelemetry sharedInstance].piiEnabled = NO;
+    
+    ADAuthenticationContext *context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // verify telemetry output
+    // there should be multiple telemetry events as aggregation flag is NO
+    XCTAssertTrue([_receivedEvents count] > 1);
+    
+    // take the API event as a sample and verify the output
+    NSDictionary *apiEvent = nil;
+    for (NSDictionary *event in _receivedEvents)
+    {
+        if ([MSID_TELEMETRY_EVENT_API_EVENT isEqualToString:[event objectForKey:(TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME))]])
+        {
+            apiEvent = event;
+        }
+    }
+    XCTAssertNotNil(apiEvent);
+    
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EVENT_NAME)], MSID_TELEMETRY_EVENT_API_EVENT);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ID)], @"8");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_REQUEST_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CORRELATION_ID)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:@"Microsoft.ADAL.x_client_ver"]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:@"Microsoft.ADAL.x_client_sku"]]);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_AUTHORITY_TYPE)], @"aad");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_EXTENDED_EXPIRES_ON_SETTING)], @"no");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_PROMPT_BEHAVIOR)], @"AD_PROMPT_AUTO");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESULT_STATUS)], @"succeeded");
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_RESPONSE_TIME)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_START_TIME)]]);
+    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_END_TIME)]]);
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_API_ERROR_CODE)], @"AD_ERROR_SUCCEEDED");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_SUCCESSFUL)], @"yes");
+    XCTAssertEqualObjects([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_IS_EXTENED_LIFE_TIME_TOKEN)], @"no");
+    // do not expect Oii
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_NAME)]);//Oii
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_TENANT_ID)]);//Oii
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_CLIENT_ID)]);//Oii
+#if TARGET_OS_IPHONE
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_APPLICATION_VERSION)]);//Oii
+#endif
+    // do not expect Pii
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_DEVICE_ID)]);//Pii
+    XCTAssertNil([apiEvent objectForKey:TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID)]);//Pii
+}
+
+@end
+

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -428,7 +428,7 @@ const int sAsyncContextTimeout = 10;
 
 - (void)testFailsWithNilUserIdAndMultipleCachedUsers
 {
-    [ADTelemetry sharedInstance].piiEnabled = YES;
+    [ADTelemetry sharedInstance].piiEnabled = NO;
 
     // prepare and register telemetry dispatcher
     ADTelemetryTestDispatcher* dispatcher = [ADTelemetryTestDispatcher new];
@@ -484,7 +484,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.application_name"]]);
     XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_ver"]]);
     XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.x_client_sku"]]);
-    XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.client_id"]]);
+    XCTAssertTrue([NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.client_id"]]);
     XCTAssertTrue(![NSString msidIsStringNilOrBlank:[event objectForKey:@"Microsoft.ADAL.device_id"]]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.authority_type"] isEqualToString:@"aad"]);
     XCTAssertTrue([[event objectForKey:@"Microsoft.ADAL.extended_expires_on_setting"] isEqualToString:@"no"]);

--- a/ADAL/tests/integration/ADTelemetryIntegrationTests.m
+++ b/ADAL/tests/integration/ADTelemetryIntegrationTests.m
@@ -551,7 +551,7 @@
     
     NSDictionary *dictionary = [_receivedEvents firstObject];
     XCTAssertNotNil(dictionary);
-    XCTAssertNil([dictionary objectForKey:MSID_TELEMETRY_KEY_USER_ID]);
+    XCTAssertNil([dictionary objectForKey:(TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID))]);
 }
 
 - (void)test_telemetryPiiRules_whenPiiEnabledYesAggregationNo_shouldHashPiiFields
@@ -588,7 +588,7 @@
     
     NSDictionary *dictionary = [_receivedEvents firstObject];
     XCTAssertNotNil(dictionary);
-    XCTAssertNil([dictionary objectForKey:MSID_TELEMETRY_KEY_USER_ID]);
+    XCTAssertNil([dictionary objectForKey:(TELEMETRY_KEY(MSID_TELEMETRY_KEY_USER_ID))]);
 }
 
 - (void)test_telemetryPiiRules_whenPiiEnabledYesAggregationYes_shouldHashPiiFields

--- a/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.m
+++ b/ADAL/tests/integration/legacytest/ADLegacyMacTokenCache.m
@@ -158,7 +158,7 @@
     {
         return [NSKeyedUnarchiver unarchiveObjectWithData:data];
     }
-    @catch (id expection)
+    @catch (id exception)
     {
         ADAuthenticationError* adError =
         [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_CACHE_BAD_FORMAT

--- a/ADAL/tests/unit/ADTelemetryAPIEventTests.m
+++ b/ADAL/tests/unit/ADTelemetryAPIEventTests.m
@@ -55,7 +55,7 @@
     ADAssertStringEquals([event propertyWithName:MSID_TELEMETRY_KEY_USER_ID], [@"eric_cartman@contoso.com" msidComputeSHA256]);
 }
 
-- (void)testSetUserInformation_whenTenantIdProvided_shouldHashTenantId
+- (void)testSetUserInformation_whenTenantIdProvided_shouldNotHashTenantIdAsItIsOii
 {
     NSUUID *correlationId = [NSUUID UUID];
     ADTelemetryAPIEvent *event = [[ADTelemetryAPIEvent alloc] initWithName:@"testEvent1"
@@ -65,7 +65,7 @@
     
     [event setUserInformation:userInfo];
     
-    ADAssertStringEquals([event propertyWithName:MSID_TELEMETRY_KEY_TENANT_ID], [@"6fd1f5cd-a94c-4335-889b-6c598e6d8048" msidComputeSHA256]);
+    ADAssertStringEquals([event propertyWithName:MSID_TELEMETRY_KEY_TENANT_ID], @"6fd1f5cd-a94c-4335-889b-6c598e6d8048");
 }
 
 - (void)testSetUserId_whenUserIdValid_shouldHashUserId


### PR DESCRIPTION
As part of the telemetry fix (common core PR is [here](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/119)), the following changes are made for ADAL:

- Since there is no clear clue on when to use TELEMETRY_KEY() to add prefix and when not to use, it could be error-prone and cause confusion. Now we simply not use prefix in common core at all. Only we finally dispatch the events in ADAL/MSAL to developers, we add the prefix.

- Setting `PiiEnabled` of `ADTelemetry` should change the `PiiEnabled` flag in `MSIDTelemetry`. Otherwise the flag won't work. Now issue has been fixed.

- Removed the ad-hoc telemetry testing code in `ADAcquireTokenTests.m`. Added `ADAcquireTokenTelemetryTests.m` to do the integration testing for acquireToken call. Test cases for different scenario have been added.
