### PR TITLE
Add new API to skip access token in cache

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -350,6 +350,22 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:@"8" completionBlock:completionBlock];
 }
 
+- (void)acquireTokenSilentWithResource:(NSString*)resource
+                              clientId:(NSString*)clientId
+                           redirectUri:(NSURL*)redirectUri
+                                userId:(NSString*)userId
+                          forceRefresh:(BOOL)forceRefresh
+                       completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    API_ENTRY;
+    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
+    
+    [request setUserId:userId];
+    [request setSilent:YES];
+    [request setForceRefresh:forceRefresh];
+    [request acquireToken:@"9" completionBlock:completionBlock];
+}
+
 - (void)acquireTokenWithResource:(NSString*)resource
                         clientId:(NSString*)clientId
                      redirectUri:(NSURL*)redirectUri

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -36,6 +36,7 @@
     ADUserIdentifier *_identifier;
     ADTokenCacheAccessor *_tokenCache;
     BOOL _extendedLifetime;
+    BOOL _forceRefresh;
     NSUUID *_correlationId;
     NSString *_telemetryRequestId;
 }
@@ -48,6 +49,7 @@
 @property (retain, nonatomic) ADUserIdentifier* identifier;
 @property (retain, nonatomic) ADTokenCacheAccessor* tokenCache;
 @property BOOL extendedLifetime;
+@property BOOL forceRefresh;
 @property (retain, nonatomic) NSUUID* correlationId;
 @property (retain, nonatomic) NSString* telemetryRequestId;
 

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -34,6 +34,7 @@
 @synthesize identifier = _identifier;
 @synthesize tokenCache = _tokenCache;
 @synthesize extendedLifetime = _extendedLifetime;
+@synthesize forceRefresh = _forceRefresh;
 @synthesize correlationId = _correlationId;
 @synthesize telemetryRequestId = _telemetryRequestId;
 
@@ -80,6 +81,7 @@
     parameters->_tokenCache = _tokenCache;
     parameters->_correlationId = [_correlationId copyWithZone:zone];
     parameters->_extendedLifetime = _extendedLifetime;
+    parameters->_forceRefresh = _forceRefresh;
     parameters->_telemetryRequestId = [_telemetryRequestId copyWithZone:zone];
     
     return parameters;

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -436,6 +436,26 @@ typedef enum
                                 userId:(NSString*)userId
                        completionBlock:(ADAuthenticationCallback)completionBlock;
 
+/*! Follows the OAuth2 protocol (RFC 6749). The function will first look at the cache and automatically check for token
+ expiration. If forceRefresh flag is passed in as YES, access token in cache will be skipped.
+ If no suitable access token is found in the cache or forceRefresh flag is YES, but refresh token is available,
+ the function will use the refresh token automatically. This method will not show UI for the user to reauthorize resource usage.
+ If reauthorization is needed, the method will return an error with code AD_ERROR_USER_INPUT_NEEDED.
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param userId The user to be prepopulated in the credentials form. Additionally, if token is found in the cache,
+ it may not be used if it belongs to different token. This parameter can be nil.
+ @param forceRefresh The flag to skip existing access token in cache.
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+- (void)acquireTokenSilentWithResource:(NSString *)resource
+                              clientId:(NSString *)clientId
+                           redirectUri:(NSURL *)redirectUri
+                                userId:(NSString *)userId
+                          forceRefresh:(BOOL)forceRefresh
+                       completionBlock:(ADAuthenticationCallback)completionBlock;
+
 /*! Follows the OAuth2 protocol (RFC 6749). The function will use the refresh token provided to get access token.
  This method will not show UI for the user to reauthorize resource usage.
  If the call fails, error will be included in the result.

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -301,7 +301,7 @@
     }
     
     // If we have a good (non-expired) access token then return it right away
-    if (item.accessToken && !item.isExpired)
+    if (item.accessToken && !item.isExpired && !_requestParams.forceRefresh)
     {
         [ADLogger logToken:item.accessToken
                  tokenType:@"AT"
@@ -317,7 +317,7 @@
     }
     
     // If the access token is good in terms of extended lifetime then store it for later use
-    if (item.accessToken && item.isExtendedLifetimeValid)
+    if (item.accessToken && item.isExtendedLifetimeValid && !_requestParams.forceRefresh)
     {
         _extendedLifetimeAccessTokenItem = item;
     }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -104,6 +104,7 @@
 - (void)setPromptBehavior:(ADPromptBehavior)promptBehavior;
 - (void)setSilent:(BOOL)silent;
 - (void)setSkipCache:(BOOL)skipCache;
+- (void)setForceRefresh:(BOOL)forceRefresh;
 - (void)setCorrelationId:(NSUUID*)correlationId;
 - (NSUUID*)correlationId;
 - (NSString*)telemetryRequestId;

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -189,6 +189,12 @@ static dispatch_semaphore_t s_interactionLock = nil;
     _skipCache = skipCache;
 }
 
+- (void)setForceRefresh:(BOOL)forceRefresh
+{
+    CHECK_REQUEST_STARTED;
+    [_requestParams setForceRefresh:forceRefresh];
+}
+
 - (void)setCorrelationId:(NSUUID*)correlationId
 {
     CHECK_REQUEST_STARTED;


### PR DESCRIPTION
The following API has been added to `ADAuthenticationContext`:

```
- (void)acquireTokenSilentWithResource:(NSString*)resource
                              clientId:(NSString *)clientId
                           redirectUri:(NSURL *)redirectUri
                                userId:(NSString *)userId
                          forceRefresh:(BOOL)forceRefresh
                       completionBlock:(ADAuthenticationCallback)completionBlock;
```


