### PR TITLE
Fixed broker token replay for sovereign clouds and first time auth

### DIFF
--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -143,9 +143,11 @@
     }
 
     request_data[MSID_OAUTH2_SCOPE] = _requestParams.openidScopesString;
-    
+
+    NSString *authority = _requestParams.cloudAuthority ? _requestParams.cloudAuthority : _requestParams.authority;
+
     ADWebAuthRequest* webReq =
-    [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:[[_requestParams authority] stringByAppendingString:MSID_OAUTH2_TOKEN_SUFFIX]]
+    [[ADWebAuthRequest alloc] initWithURL:[NSURL URLWithString:[authority stringByAppendingString:MSID_OAUTH2_TOKEN_SUFFIX]]
                                   context:_requestParams];
     [webReq setRequestDictionary:request_data];
     

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -251,6 +251,110 @@
     XCTAssertEqualObjects([tokenCache getFRTItem:cacheAuthority].userInformation.tenantId, correctTid);
 }
 
+- (void)testBroker_whenTenantSpecified_andSovereignCloudRequest_shouldGetNewATForCorrectAuthority
+{
+    NSString *authority = @"https://login.microsoftonline.com/contoso.net";
+    NSString *cacheAuthority = @"https://login.microsoftonline2.de/contoso.net";
+    NSString *brokerKey = @"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U";
+    NSString *redirectUri = @"x-msauth-unittest://com.microsoft.unittesthost";
+    NSString *brokerRT = @"i-am-a-refresh-token";
+    NSString *brokerAT = @"i-am-a-access-token";
+    NSString *updatedRT = @"updated-refresh-token";
+    NSString *updatedAT = @"updated-access-token";
+    NSString *correctTid = @"4b93453c-1131-4828-9715-a2e83336f2f2";
+
+    [ADBrokerKeyHelper setSymmetricKey:brokerKey];
+
+    // Parameters for launching broker
+    [ADApplicationTestUtil onOpenURL:^BOOL(NSURL *url, NSDictionary<NSString *,id> *options) {
+        (void)options;
+
+        NSDictionary *expectedParams =
+        @{
+          @"authority" : authority,
+          @"resource" : TEST_RESOURCE,
+          @"username_type" : @"",
+          @"max_protocol_ver" : @"2",
+          @"broker_key" : brokerKey,
+          @"client_version" : ADAL_VERSION_NSSTRING,
+          @"force" : @"NO",
+          @"redirect_uri" : redirectUri,
+          @"username" : @"",
+          @"client_id" : TEST_CLIENT_ID,
+          @"correlation_id" : TEST_CORRELATION_ID,
+          @"skip_cache" : @"NO",
+          @"extra_qp" : @"",
+          @"claims" : @"",
+          };
+
+        NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidURLFormEncode]];
+        NSURL *expectedURL = [NSURL URLWithString:expectedUrlString];
+        XCTAssertTrue([expectedURL matchesURL:url]);
+
+        // Broker response back to client
+        NSDictionary *responseParams =
+        @{
+          @"authority" : @"https://login.microsoftonline.de/contoso.net",
+          @"resource" : TEST_RESOURCE,
+          @"client_id" : TEST_CLIENT_ID,
+          @"id_token" : [[self adCreateUserInformation:TEST_USER_ID] rawIdToken],
+          @"access_token" : brokerAT,
+          @"refresh_token" : brokerRT,
+          @"foci" : @"1",
+          @"expires_in" : @"3600"
+          };
+
+        [ADAuthenticationContext handleBrokerResponse:[ADBrokerIntegrationTests createV2BrokerResponse:responseParams redirectUri:redirectUri]];
+        return YES;
+    }];
+
+    NSArray *metadata = @[ @{ @"preferred_network" : @"login.microsoftonline.de",
+                              @"preferred_cache" : @"login.microsoftonline2.de",
+                              @"aliases" : @[ @"login.microsoftonline2.de", @"login.microsoftonline.de"] } ];
+    ADTestURLResponse *validationResponse =
+    [ADTestAuthorityValidationResponse validAuthority:authority
+                                          trustedHost:@"login.microsoftonline.com"
+                                         withMetadata:metadata];
+
+    ADRefreshResponseBuilder *builder = [ADRefreshResponseBuilder new];
+    builder.oldRefreshToken = brokerRT;
+    builder.authority = @"https://login.microsoftonline.de/contoso.net";
+    builder.requestBody[@"scope"] = @"openid";
+    builder.updatedRefreshToken = updatedRT;
+    builder.updatedAccessToken = updatedAT;
+    builder.responseBody[@"foci"] = @"1";
+    builder.updatedIdToken = [self adCreateUserInformation:TEST_USER_ID tenantId:correctTid homeUserId:nil].rawIdToken;
+    ADTestURLResponse *tokenResponse = builder.response;
+    [ADTestURLSession addResponses:@[validationResponse, tokenResponse]];
+
+    ADAuthenticationContext *context = [self getBrokerTestContext:authority];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token callback"];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:[NSURL URLWithString:redirectUri]
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+
+         XCTAssertEqualObjects(result.tokenCacheItem.accessToken, updatedAT);
+         XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, updatedRT);
+         XCTAssertEqualObjects(result.authority, @"https://login.microsoftonline.de/contoso.net");
+
+         [expectation fulfill];
+     }];
+
+    [self waitForExpectations:@[expectation] timeout:1.0];
+
+    ADLegacyKeychainTokenCache *tokenCache = ADLegacyKeychainTokenCache.defaultKeychainCache;
+
+    XCTAssertEqualObjects([tokenCache getAT:cacheAuthority], updatedAT);
+    XCTAssertEqualObjects([tokenCache getMRRT:cacheAuthority], updatedRT);
+    XCTAssertEqualObjects([tokenCache getMRRTItem:cacheAuthority].userInformation.tenantId, correctTid);
+    XCTAssertEqualObjects([tokenCache getFRT:cacheAuthority], updatedRT);
+    XCTAssertEqualObjects([tokenCache getFRTItem:cacheAuthority].userInformation.tenantId, correctTid);
+}
+
 - (void)testBroker_whenTenantSpecifiedWithRequestUsingScope_shouldGetNewAT
 {
     // This test is near identical to testBroker_whenTenantSpecified_shouldGetNewAT except the


### PR DESCRIPTION
Fixes 2 issues in the access token replay logic (logic introduced in 2.6.0 to fix guest user scenarios):
* First response after broker install returned nil access token
* Token replay didn't work for sovereign clouds