### PR TITLE
Midella/make intune mam resource more resilient

### DIFF
--- a/ADAL/src/ADEnrollmentGateway.m
+++ b/ADAL/src/ADEnrollmentGateway.m
@@ -244,6 +244,12 @@ static NSString *s_intuneResourceJSON = nil;
             return resources[host];
     }
 
+    if ([(NSDictionary *)resources count])
+    {
+        // if there are Intune Resources available at this point, just return the first
+        return [[resources allValues] objectAtIndex:0];
+    }
+
     return nil;
 }
 

--- a/ADAL/tests/unit/ios/ADEnrollmentGatewayTests.m
+++ b/ADAL/tests/unit/ios/ADEnrollmentGatewayTests.m
@@ -356,10 +356,11 @@
 
 }
 
-- (void)testintuneMAMResource_whenResourceDoesNotForHost_shouldFailWithoutError
+- (void)testintuneMAMResource_whenResourceDoesNotExistForAuthority_shouldReturnTheFirstResource
 {
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:@"{\"login.microsoftonline.com\":\"https://www.microsoft.com/intune\"}"];
     ADAuthenticationError *error = nil;
-    XCTAssertNil([ADEnrollmentGateway intuneMAMResource:[NSURL URLWithString:@"https://login.notMicrosoft.com"] error:&error]);
+    XCTAssert([@"https://www.microsoft.com/intune" isEqualToString:[ADEnrollmentGateway intuneMAMResource:[NSURL URLWithString:@"https://login.notMicrosoft.com"] error:&error]]);
     XCTAssertNil(error);
 }
 


### PR DESCRIPTION
If there is an Intune Resource available but we could match an authority, just return the first available resource. Intune currently only uses one resource for everything, but might not have access to all authority values possible when this is set.