### PR TITLE
Don't mask protection_policies_required on silent calls

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -298,18 +298,29 @@
 
     if (_silent && !_allowSilent)
     {
+        
         //The cache lookup and refresh token attempt have been unsuccessful,
         //so credentials are needed to get an access token, but the developer, requested
-        //no UI to be shown:
-        NSDictionary* underlyingError = _underlyingError ? @{NSUnderlyingErrorKey:_underlyingError} : nil;
-        ADAuthenticationError* error =
-        [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
-                                               protocolCode:nil
-                                               errorDetails:ADCredentialsNeeded
-                                                   userInfo:underlyingError
-                                              correlationId:correlationId];
+        //no UI to be shown.
+        // If the underlying error is AD_ERROR_SERVER_PROTECTION_POLICY_REQUIRED,
+        // Intune MAM remediation is needed and we should pass that instead.
+        ADAuthenticationResult* result;
+        if (AD_ERROR_SERVER_PROTECTION_POLICY_REQUIRED == _underlyingError.code)
+        {
+            result = [ADAuthenticationResult resultFromError:_underlyingError correlationId:correlationId];
+        }
+        else
+        {
+            NSDictionary* underlyingError = _underlyingError ? @{NSUnderlyingErrorKey:_underlyingError} : nil;
+            ADAuthenticationError* error =
+            [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_SERVER_USER_INPUT_NEEDED
+                                                   protocolCode:nil
+                                                   errorDetails:ADCredentialsNeeded
+                                                       userInfo:underlyingError
+                                                  correlationId:correlationId];
+            result = [ADAuthenticationResult resultFromError:error correlationId:correlationId];
+        }
         
-        ADAuthenticationResult* result = [ADAuthenticationResult resultFromError:error correlationId:correlationId];
         completionBlock(result);
         return;
     }


### PR DESCRIPTION
If error is protection_policies_required, don't mask it with user_input_needed