### PR TITLE
Add a overload function to acquire token by refresh token and user id

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -466,6 +466,24 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:@"136" completionBlock:completionBlock];
 }
 
+- (void)acquireTokenWithRefreshToken:(NSString *)refreshToken
+                            resource:(NSString *)resource
+                            clientId:(NSString *)clientId
+                         redirectUri:(NSURL *)redirectUri
+                      userIdentifier:(ADUserIdentifier *)userId
+                     completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    API_ENTRY;
+    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
+    CHECK_STRING_ARG_BLOCK(refreshToken);
+    [request setRefreshToken:refreshToken];
+    [request setUserIdentifier:userId];
+    [request setScopesString:MSID_OAUTH2_SCOPE_OPENID_VALUE];
+    [request setSilent:YES];
+    
+    [request acquireToken:@"137" completionBlock:completionBlock];
+}
+
 #pragma mark - Private
 
 #if TARGET_OS_IPHONE

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -470,14 +470,14 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
                             resource:(NSString *)resource
                             clientId:(NSString *)clientId
                          redirectUri:(NSURL *)redirectUri
-                      userIdentifier:(ADUserIdentifier *)userId
+                              userId:(NSString *)userId
                      completionBlock:(ADAuthenticationCallback)completionBlock
 {
     API_ENTRY;
     REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
     CHECK_STRING_ARG_BLOCK(refreshToken);
     [request setRefreshToken:refreshToken];
-    [request setUserIdentifier:userId];
+    [request setUserId:userId];
     [request setScopesString:MSID_OAUTH2_SCOPE_OPENID_VALUE];
     [request setSilent:YES];
     

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -458,14 +458,14 @@ typedef enum
  @param resource The resource whose token is needed.
  @param clientId The client identifier
  @param redirectUri The redirect URI according to OAuth2 protocol
- @param userId An ADUserIdentifier object describing the user being authenticated
+ @param userId The user matching the refresh token provided. If there is a mismatch, error will be returned
  @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
  */
 - (void)acquireTokenWithRefreshToken:(NSString *)refreshToken
                             resource:(NSString *)resource
                             clientId:(NSString *)clientId
                          redirectUri:(NSURL *)redirectUri
-                      userIdentifier:(ADUserIdentifier *)userId
+                              userId:(NSString *)userId
                      completionBlock:(ADAuthenticationCallback)completionBlock;
 
 @end

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -451,6 +451,23 @@ typedef enum
                          redirectUri:(NSURL *)redirectUri
                      completionBlock:(ADAuthenticationCallback)completionBlock;
 
+/*! Follows the OAuth2 protocol (RFC 6749). The function will use the refresh token provided to get access token.
+ This method will not show UI for the user to reauthorize resource usage.
+ If the call fails, error will be included in the result.
+ @param refreshToken The refresh token provided in order to get acces token.
+ @param resource The resource whose token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param userId An ADUserIdentifier object describing the user being authenticated
+ @param completionBlock The block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+- (void)acquireTokenWithRefreshToken:(NSString *)refreshToken
+                            resource:(NSString *)resource
+                            clientId:(NSString *)clientId
+                         redirectUri:(NSURL *)redirectUri
+                      userIdentifier:(ADUserIdentifier *)userId
+                     completionBlock:(ADAuthenticationCallback)completionBlock;
+
 @end
 
 

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -40,6 +40,7 @@
 #import "MSIDAccessToken.h"
 #import "ADUserInformation.h"
 #import "ADResponseCacheHandler.h"
+#import "MSIDLegacyRefreshToken.h"
 
 @implementation ADAuthenticationRequest (AcquireToken)
 
@@ -533,8 +534,16 @@
 {
     ADAcquireTokenSilentHandler *request = [ADAcquireTokenSilentHandler requestWithParams:_requestParams
                                                                                tokenCache:self.tokenCache];
+    
+    // Construct a refresh token object to wrap up the refresh token provided by developer
+    MSIDLegacyRefreshToken *refreshTokenItem = [[MSIDLegacyRefreshToken alloc] init];
+    refreshTokenItem.refreshToken = _refreshToken;
+    refreshTokenItem.legacyUserId = _requestParams.identifier.userId;
+    refreshTokenItem.authority = [NSURL URLWithString:_requestParams.authority];
+    refreshTokenItem.clientId  = _requestParams.clientId;
+    
     [request acquireTokenByRefreshToken:_refreshToken
-                              cacheItem:nil
+                              cacheItem:refreshTokenItem
                        useOpenidConnect:YES
                         completionBlock:^(ADAuthenticationResult *result)
      {


### PR DESCRIPTION
Added the following overload function to accept user id for `acquireTokenWithRefreshToken`. Such a function is needed if the resource is True MAM CA protected.

- (void)acquireTokenWithRefreshToken:(NSString *)refreshToken
                            resource:(NSString *)resource
                            clientId:(NSString *)clientId
                         redirectUri:(NSURL *)redirectUri
                      userIdentifier:(ADUserIdentifier *)userId
                     completionBlock:(ADAuthenticationCallback)completionBlock;
