### PR TITLE
Integrate MAM SDK with ADAL Test App

### DIFF
--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -205,6 +205,17 @@
     UIView* clearButtonsView = [self createThreeItemLayoutView:clearCookies item2:clearCache item3:wipeUpn];
     [layout addCenteredView:clearButtonsView key:@"clearButtons"];
     
+    UIButton* mamRegister = [UIButton buttonWithType:UIButtonTypeSystem];
+    [mamRegister setTitle:@"MAM Register" forState:UIControlStateNormal];
+    [mamRegister addTarget:self action:@selector(mamRegister:) forControlEvents:UIControlEventTouchUpInside];
+    
+    UIButton* mamUnregister = [UIButton buttonWithType:UIButtonTypeSystem];
+    [mamUnregister setTitle:@"MAM Unregister" forState:UIControlStateNormal];
+    [mamUnregister addTarget:self action:@selector(mamUnregister:) forControlEvents:UIControlEventTouchUpInside];
+    
+    UIView* mamButtonsView = [self createTwoItemLayoutView:mamRegister item2:mamUnregister];
+    [layout addCenteredView:mamButtonsView key:@"mamButtons"];
+    
     _resultView = [[UITextView alloc] init];
     _resultView.layer.borderWidth = 1.0f;
     _resultView.layer.borderColor = [UIColor colorWithRed:0.9f green:0.9f blue:0.9f alpha:1.0f].CGColor;
@@ -726,6 +737,14 @@
     
     _resultView.text = [NSString stringWithFormat:@"Wiped cache for %@.", userId];
     
+}
+
+- (IBAction)mamRegister:(id)sender
+{
+}
+
+- (IBAction)mamUnregister:(id)sender
+{
 }
 
 - (IBAction)changeProfile:(id)sender

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -28,12 +28,12 @@
 #import "ADTestAppProfileViewController.h"
 #import "ADTestAppClaimsPickerController.h"
 
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
 #import <IntuneMAMWalledGarden/IntuneMAM.h>
 #endif
 
 @interface ADTestAppAcquireTokenViewController () <UITextFieldDelegate
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
 , IntuneMAMComplianceDelegate
 #endif
 >
@@ -80,7 +80,7 @@
     [self setTabBarItem:tabBarItem];
     
     [self setEdgesForExtendedLayout:UIRectEdgeTop];
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
     [[IntuneMAMComplianceManager instance] setDelegate:self];
 #endif
     
@@ -757,7 +757,7 @@
 
 - (IBAction)mamRegister:(id)sender
 {
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])
     {
         _resultView.text = [NSString stringWithFormat:@"Please specify user id before clicking register!"];
@@ -775,7 +775,7 @@
 
 - (IBAction)mamUnregister:(id)sender
 {
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])
     {
         _resultView.text = [NSString stringWithFormat:@"Please specify user id before clicking unregister!"];
@@ -788,7 +788,7 @@
 #endif
 }
 
-#if MAM_SDK_TESTING
+#if AD_MAM_SDK_TESTING
 - (void)identity:(NSString*)identity hasComplianceStatus:(IntuneMAMComplianceStatus)status withErrorString:(NSString *)error
 {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -28,15 +28,16 @@
 #import "ADTestAppProfileViewController.h"
 #import "ADTestAppClaimsPickerController.h"
 
-#if AD_MAM_SDK_TESTING
+#ifdef AD_MAM_SDK_TESTING
 #import <IntuneMAMWalledGarden/IntuneMAM.h>
 #endif
 
-@interface ADTestAppAcquireTokenViewController () <UITextFieldDelegate
-#if AD_MAM_SDK_TESTING
-, IntuneMAMComplianceDelegate, IntuneMAMEnrollmentDelegate
+@interface ADTestAppAcquireTokenViewController ()
+#ifdef AD_MAM_SDK_TESTING
+<UITextFieldDelegate, IntuneMAMComplianceDelegate, IntuneMAMEnrollmentDelegate>
+#else
+<UITextFieldDelegate>
 #endif
->
 
 @property (nonatomic) ADTestAppClaimsPickerController *claimsPickerController;
 
@@ -80,7 +81,7 @@
     [self setTabBarItem:tabBarItem];
     
     [self setEdgesForExtendedLayout:UIRectEdgeTop];
-#if AD_MAM_SDK_TESTING
+#ifdef AD_MAM_SDK_TESTING
     [[IntuneMAMComplianceManager instance] setDelegate:self];
     [[IntuneMAMEnrollmentManager instance] setDelegate:self];
 #endif
@@ -758,7 +759,7 @@
 
 - (IBAction)mamEnroll:(id)sender
 {
-#if AD_MAM_SDK_TESTING
+#ifdef AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])
     {
         _resultView.text = [NSString stringWithFormat:@"Please specify user id before clicking register!"];
@@ -776,7 +777,7 @@
 
 - (IBAction)mamUnenroll:(id)sender
 {
-#if AD_MAM_SDK_TESTING
+#ifdef AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])
     {
         _resultView.text = [NSString stringWithFormat:@"Please specify user id before clicking unregister!"];
@@ -791,7 +792,7 @@
 #endif
 }
 
-#if AD_MAM_SDK_TESTING
+#ifdef AD_MAM_SDK_TESTING
 - (void)identity:(NSString*)identity hasComplianceStatus:(IntuneMAMComplianceStatus)status withErrorString:(NSString *)error
 {
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -217,15 +217,15 @@
     UIView* clearButtonsView = [self createThreeItemLayoutView:clearCookies item2:clearCache item3:wipeUpn];
     [layout addCenteredView:clearButtonsView key:@"clearButtons"];
     
-    UIButton* mamRegister = [UIButton buttonWithType:UIButtonTypeSystem];
-    [mamRegister setTitle:@"MAM Register" forState:UIControlStateNormal];
-    [mamRegister addTarget:self action:@selector(mamRegister:) forControlEvents:UIControlEventTouchUpInside];
+    UIButton* mamEnroll = [UIButton buttonWithType:UIButtonTypeSystem];
+    [mamEnroll setTitle:@"MAM Enroll" forState:UIControlStateNormal];
+    [mamEnroll addTarget:self action:@selector(mamEnroll:) forControlEvents:UIControlEventTouchUpInside];
     
-    UIButton* mamUnregister = [UIButton buttonWithType:UIButtonTypeSystem];
-    [mamUnregister setTitle:@"MAM Unregister" forState:UIControlStateNormal];
-    [mamUnregister addTarget:self action:@selector(mamUnregister:) forControlEvents:UIControlEventTouchUpInside];
+    UIButton* mamUnenroll = [UIButton buttonWithType:UIButtonTypeSystem];
+    [mamUnenroll setTitle:@"MAM Unenroll" forState:UIControlStateNormal];
+    [mamUnenroll addTarget:self action:@selector(mamUnenroll:) forControlEvents:UIControlEventTouchUpInside];
     
-    UIView* mamButtonsView = [self createTwoItemLayoutView:mamRegister item2:mamUnregister];
+    UIView* mamButtonsView = [self createTwoItemLayoutView:mamEnroll item2:mamUnenroll];
     [layout addCenteredView:mamButtonsView key:@"mamButtons"];
     
     _resultView = [[UITextView alloc] init];
@@ -756,7 +756,7 @@
     [self.navigationController pushViewController:[ADTestAppProfileViewController sharedProfileViewController] animated:YES];
 }
 
-- (IBAction)mamRegister:(id)sender
+- (IBAction)mamEnroll:(id)sender
 {
 #if AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])
@@ -774,7 +774,7 @@
 #endif
 }
 
-- (IBAction)mamUnregister:(id)sender
+- (IBAction)mamUnenroll:(id)sender
 {
 #if AD_MAM_SDK_TESTING
     if ([NSString adIsStringNilOrBlank:self.identifier.userId])

--- a/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/ADTestAppAcquireTokenViewController.m
@@ -34,7 +34,7 @@
 
 @interface ADTestAppAcquireTokenViewController () <UITextFieldDelegate
 #if AD_MAM_SDK_TESTING
-, IntuneMAMComplianceDelegate
+, IntuneMAMComplianceDelegate, IntuneMAMEnrollmentDelegate
 #endif
 >
 
@@ -82,6 +82,7 @@
     [self setEdgesForExtendedLayout:UIRectEdgeTop];
 #if AD_MAM_SDK_TESTING
     [[IntuneMAMComplianceManager instance] setDelegate:self];
+    [[IntuneMAMEnrollmentManager instance] setDelegate:self];
 #endif
     
     return self;
@@ -781,10 +782,12 @@
         _resultView.text = [NSString stringWithFormat:@"Please specify user id before clicking unregister!"];
         return;
     }
+
+    _resultView.text = [NSString stringWithFormat:@"Sending Unenroll request to MAM SDK..."];
     
-    [[IntuneMAMEnrollmentManager instance] deRegisterAndUnenrollAccount:self.identifier.userId withWipe:YES];
-    
-    _resultView.text = [NSString stringWithFormat:@"Unregister request sent to MAM SDK."];
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+        [[IntuneMAMEnrollmentManager instance] deRegisterAndUnenrollAccount:self.identifier.userId withWipe:YES];
+    });
 #endif
 }
 
@@ -793,6 +796,13 @@
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         _resultView.text = [NSString stringWithFormat:@"MAM Enrollment for %@ with status: %lu, error: %@", identity, (unsigned long)status, error];
+    });
+}
+
+- (void)unenrollRequestWithStatus:(IntuneMAMEnrollmentStatus *_Nonnull)status
+{
+    dispatch_async(dispatch_get_main_queue(), ^{
+        _resultView.text = [NSString stringWithFormat:@"Unenrollment status for %@: success: %@, status code: %lu, errorString: %@, error: %@", status.identity, status.didSucceed ? @"YES":@"NO", (unsigned long)status.statusCode, status.errorString, status.error];
     });
 }
 #endif

--- a/Samples/MyTestiOSApp/MyTestiOSApp/MyTestiOSApp.entitlements
+++ b/Samples/MyTestiOSApp/MyTestiOSApp/MyTestiOSApp.entitlements
@@ -7,6 +7,7 @@
 		<string>$(AppIdentifierPrefix)com.MSOpenTech.MyTestiOSApp</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.workplacejoin</string>
 		<string>$(AppIdentifierPrefix)com.microsoft.adalcache</string>
+		<string>$(AppIdentifierPrefix)com.microsoft.intune.mam</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
To serve the purpose of testing True MAM scenario.

The MAM SDK is not included yet. We will explore a better solution to include large file to the repo.

For now, testing will require:
1. move the MAM SDK framework to the test app build target as embedded binary;
2. define the preprocessor macro AD_MAM_SDK_TESTING to activate the MAM SDK related code