### PR TITLE
Minor improvements for previously flaky tests

### DIFF
--- a/ADAL/automation/ADAutoMainViewController.m
+++ b/ADAL/automation/ADAutoMainViewController.m
@@ -464,7 +464,9 @@
                                   redirectUri:[NSURL URLWithString:parameters[@"redirect_uri"]]
                               completionBlock:^(ADAuthenticationResult *result) {
 
-                                  [self displayAuthenticationResult:result logs:weakSelf.resultLogs];
+                                  dispatch_async(dispatch_get_main_queue(), ^{
+                                      [weakSelf displayAuthenticationResult:result logs:weakSelf.resultLogs];
+                                  });
                               }];
 
     };

--- a/ADAL/automation/tests/ADALBaseUITest.h
+++ b/ADAL/automation/tests/ADALBaseUITest.h
@@ -51,6 +51,7 @@
 - (void)clearCache;
 - (void)clearKeychain;
 - (void)clearCookies;
+- (void)blackForestWaitForNextButton:(XCUIApplication *)application;
 - (void)aadEnterEmail:(NSString *)email;
 - (void)aadEnterEmail;
 - (void)aadEnterEmailInApp:(XCUIApplication *)app;

--- a/ADAL/automation/tests/ADALBaseUITest.m
+++ b/ADAL/automation/tests/ADALBaseUITest.m
@@ -182,6 +182,28 @@ static MSIDTestAccountsProvider *s_accountsProvider;
 
 #pragma mark - Actions
 
+/*
+ There seems to be some flakiness around sovereign user with login hint provided,
+ where ESTS sometimes shows the username page with next button and sometimes redirects to the password page correctly. This portion of code waits for the "Next" button for 10 seconds if it appears.
+ */
+- (void)blackForestWaitForNextButton:(XCUIApplication *)application
+{
+    XCUIElement *emailTextField = application.textFields[@"Enter your email, phone, or Skype."];
+
+    for (int i = 0; i < 10; i++)
+    {
+        if (emailTextField.exists)
+        {
+            [application.buttons[@"Next"] msidTap];
+            break;
+        }
+        else
+        {
+            sleep(1);
+        }
+    }
+}
+
 - (void)aadEnterEmail:(NSString *)email inApp:(XCUIApplication *)app
 {
     XCUIElement *emailTextField = app.textFields[@"Enter your email, phone, or Skype."];

--- a/ADAL/automation/tests/interactive/ADALAADLoginTests.m
+++ b/ADAL/automation/tests/interactive/ADALAADLoginTests.m
@@ -512,8 +512,8 @@
     XCUIElement *getTheAppButton = safari.staticTexts[@"GET THE APP"];
     [self waitForElement:getTheAppButton];
 #else
-    XCUIElement *enterPassword = safari.staticTexts[@"Enter password"];
-    [self waitForElement:enterPassword];
+    XCUIElement *safariWindow = safari.windows.firstMatch;
+    [self waitForElement:safariWindow];
 #endif
     
     [self.testApp activate];

--- a/ADAL/automation/tests/interactive/ADALSovereignBlackForestLoginTests.m
+++ b/ADAL/automation/tests/interactive/ADALSovereignBlackForestLoginTests.m
@@ -63,10 +63,7 @@
     
     [self acquireToken:config];
 
-    XCUIElement *emailTextField = self.testApp.textFields[@"Enter your email, phone, or Skype."];
-    [self waitForElement:emailTextField];
-    [self.testApp.buttons[@"Next"] msidTap];
-
+    [self blackForestWaitForNextButton:self.testApp];
     [self blackforestComEnterPassword];
     
     [self assertAccessTokenNotNil];

--- a/ADAL/automation/tests/multiapp/ADALiOSBrokerInvocationTests.m
+++ b/ADAL/automation/tests/multiapp/ADALiOSBrokerInvocationTests.m
@@ -83,10 +83,7 @@ static BOOL brokerAppInstalled = NO;
     [self acquireToken:config];
 
     XCUIApplication *brokerApp = [self brokerApp];
-
-    __auto_type nextButton = brokerApp.buttons[@"Next"];
-    [self waitForElement:nextButton];
-    [nextButton tap];
+    [self blackForestWaitForNextButton:brokerApp];
 
     XCUIElement *passwordTextField = brokerApp.secureTextFields[@"Password"];
     [self waitForElement:passwordTextField];


### PR DESCRIPTION
Fixed a couple of test issues found while running tests (none of these change any code in ADAL itself):
* Update result on the main thread in the automation test app for acquireTokenByRefreshToken
* Handle ESTS flakiness for sovereign accounts when login hint is provided
* Check for browser window appearance and not password field for company portal install prompt test on macOS