### PR TITLE
Set both encoded and unencoded claims in setter

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -379,7 +379,11 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 
     [request setUserId:userId];
     [request setSilent:YES];
-    [request setClaims:claims];
+    ADAuthenticationError *claimsError;
+    if(![request setClaims:claims error:&claimsError])
+    {
+        completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
+    }
     [request acquireToken:@"10" completionBlock:completionBlock];
 }
 
@@ -432,7 +436,12 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request setPromptBehavior:promptBehavior];
     [request setUserIdentifier:userId];
     [request setExtraQueryParameters:queryParams];
-    [request setClaims:claims];
+    ADAuthenticationError *claimsError;
+    if(![request setClaims:claims error:&claimsError])
+    {
+        completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
+    }
+        
     [request acquireToken:@"133" completionBlock:completionBlock];
 }
 

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -438,7 +438,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request setUserIdentifier:userId];
     [request setExtraQueryParameters:queryParams];
     ADAuthenticationError *claimsError;
-    if(![request setClaims:claims error:&claimsError])
+    if (![request setClaims:claims error:&claimsError])
     {
         completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
         return;

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -380,7 +380,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request setUserId:userId];
     [request setSilent:YES];
     ADAuthenticationError *claimsError;
-    if(![request setClaims:claims error:&claimsError])
+    if (![request setClaims:claims error:&claimsError])
     {
         completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
         return;

--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -383,6 +383,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     if(![request setClaims:claims error:&claimsError])
     {
         completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
+        return;
     }
     [request acquireToken:@"10" completionBlock:completionBlock];
 }
@@ -440,6 +441,7 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     if(![request setClaims:claims error:&claimsError])
     {
         completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
+        return;
     }
         
     [request acquireToken:@"133" completionBlock:completionBlock];

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -212,45 +212,9 @@
         }
         return NO;
     }
-    
-    // Make sure claims is properly encoded
-    NSString* claimsParams = _claims;
-    NSURL* url = [NSURL URLWithString:[NSMutableString stringWithFormat:@"%@?claims=%@", _context.authority, claimsParams]];
-    if (!url)
-    {
-        if (error)
-        {
-            *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_DEVELOPER_INVALID_ARGUMENT
-                                                            protocolCode:nil
-                                                            errorDetails:@"claims is not properly encoded. Please make sure it is URL encoded."
-                                                           correlationId:_requestParams.correlationId];
-        }
-        return NO;
-    }
-
-    NSData *jsonData = [_claims.adUrlFormDecode dataUsingEncoding:NSUTF8StringEncoding];
-
-    NSError *jsonError = nil;
-
-    NSDictionary *decodedDictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&jsonError];
-
-    if (!decodedDictionary)
-    {
-        if (error)
-        {
-            *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_DEVELOPER_INVALID_ARGUMENT
-                                                            protocolCode:nil
-                                                            errorDetails:@"claims is not proper JSON. Please make sure it is correct JSON claims parameter."
-                                                           correlationId:_requestParams.correlationId];
-        }
-        return NO;
-    }
 
     // Always skip access token cache if claims parameter is not nil/empty
     [_requestParams setForceRefresh:YES];
-
-    // Set decoded claims
-    _requestParams.decodedClaims = decodedDictionary;
 
     return YES;
 }

--- a/ADAL/src/request/ADAuthenticationRequest.h
+++ b/ADAL/src/request/ADAuthenticationRequest.h
@@ -98,7 +98,7 @@
 // These can only be set before the request gets sent out.
 - (void)setScope:(NSString*)scope;
 - (void)setExtraQueryParameters:(NSString*)queryParams;
-- (void)setClaims:(NSString *)claims;
+- (BOOL)setClaims:(NSString *)claims error:(ADAuthenticationError **)error;
 - (void)setUserIdentifier:(ADUserIdentifier*)identifier;
 - (void)setUserId:(NSString*)userId;
 - (void)setPromptBehavior:(ADPromptBehavior)promptBehavior;

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -145,15 +145,62 @@ static dispatch_semaphore_t s_interactionLock = nil;
     _queryParams = [queryParams copy];
 }
 
-- (void)setClaims:(NSString *)claims
+- (BOOL)setClaims:(NSString *)claims error:(ADAuthenticationError **)error
 {
-    CHECK_REQUEST_STARTED;
+    if (_requestStarted) {
+        AD_LOG_WARN(nil, @"call to %s after the request started. call has no effect.", __PRETTY_FUNCTION__);
+        return YES;
+    }
+    
     if (_claims == claims)
     {
-        return;
+        return YES;
     }
-
+    
     _claims = [claims.adTrimmedString copy];
+    
+    if ([NSString adIsStringNilOrBlank:_claims])
+    {
+        return YES;
+    }
+    
+    // Make sure claims is properly encoded
+    NSString* claimsParams = _claims;
+    NSURL* url = [NSURL URLWithString:[NSMutableString stringWithFormat:@"%@?claims=%@", _context.authority, claimsParams]];
+    if (!url)
+    {
+        if (error)
+        {
+            *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_DEVELOPER_INVALID_ARGUMENT
+                                                            protocolCode:nil
+                                                            errorDetails:@"claims is not properly encoded. Please make sure it is URL encoded."
+                                                           correlationId:_requestParams.correlationId];
+        }
+        return NO;
+    }
+    
+    NSData *jsonData = [_claims.adUrlFormDecode dataUsingEncoding:NSUTF8StringEncoding];
+    
+    NSError *jsonError = nil;
+    
+    NSDictionary *decodedDictionary = [NSJSONSerialization JSONObjectWithData:jsonData options:0 error:&jsonError];
+    
+    if (!decodedDictionary)
+    {
+        if (error)
+        {
+            *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_DEVELOPER_INVALID_ARGUMENT
+                                                            protocolCode:nil
+                                                            errorDetails:@"claims is not proper JSON. Please make sure it is correct JSON claims parameter."
+                                                           correlationId:_requestParams.correlationId];
+        }
+        return NO;
+    }
+    
+    // Set decoded claims
+    _requestParams.decodedClaims = decodedDictionary;
+    
+    return YES;
 }
 
 - (void)setUserIdentifier:(ADUserIdentifier *)identifier


### PR DESCRIPTION
Such that we don't need to rely on function `checkClaims` later in the flow to set the unencoded claims parameter. 