### PR TITLE
Backport client certificate double cert fix into 2.7.4

### DIFF
--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -189,22 +189,11 @@
         CFRetain(identity);
         MSID_LOG_INFO(protocol.context, @"Using user selected certificate");
     }
-    
-    SecCertificateRef cert = NULL;
-    OSStatus status = SecIdentityCopyCertificate(identity, &cert);
-    if (status != errSecSuccess)
-    {
-        CFRelease(identity);
-        MSID_LOG_ERROR(protocol.context, @"Failed to copy certificate from identity.");
-        
-        completionHandler(NSURLSessionAuthChallengeCancelAuthenticationChallenge, nil);
-        return YES;
-    }
+
     
     MSID_LOG_INFO(protocol.context, @"Responding to cert auth challenge with certicate");
-    NSURLCredential *credential = [[NSURLCredential alloc] initWithIdentity:identity certificates:@[(__bridge id)cert] persistence:NSURLCredentialPersistenceNone];
+    NSURLCredential *credential = [[NSURLCredential alloc] initWithIdentity:identity certificates:nil persistence:NSURLCredentialPersistenceNone];
     completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
-    CFRelease(cert);
     CFRelease(identity);
     return YES;
 }

--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -192,6 +192,10 @@
 
     
     MSID_LOG_INFO(protocol.context, @"Responding to cert auth challenge with certicate");
+    
+    /*
+     The `certificates` parameter accepts an array of /intermediate/ certificates leading from the leaf to the root.  It must not include the leaf certificate because the system gets that from the digital identity.  It should not include a root certificate because, when the server does trust evaluation on the leaf, it already has a copy of the relevant root. Therefore, we are sending "nil" to the certificates array.
+     */
     NSURLCredential *credential = [[NSURLCredential alloc] initWithIdentity:identity certificates:nil persistence:NSURLCredentialPersistenceNone];
     completionHandler(NSURLSessionAuthChallengeUseCredential, credential);
     CFRelease(identity);


### PR DESCRIPTION
Backporting this [fix](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/233) into 2.7.4 as it's impacting multiple customers. 