### PR TITLE
Changed teamID hint to avoid conflicts with .NET team

### DIFF
--- a/ADAL/src/utils/ios/ADKeychainUtil.m
+++ b/ADAL/src/utils/ios/ADKeychainUtil.m
@@ -50,7 +50,7 @@
 + (NSString*)retrieveTeamIDFromKeychain:(ADAuthenticationError * __autoreleasing *)error
 {
     NSDictionary *query = @{ (id)kSecClass : (id)kSecClassGenericPassword,
-                             (id)kSecAttrAccount : @"teamIDHint",
+                             (id)kSecAttrAccount : @"ADAL.ObjC.teamIDHint",
                              (id)kSecAttrService : @"",
                              (id)kSecReturnAttributes : @YES };
     CFDictionaryRef result = nil;
@@ -63,7 +63,7 @@
         [addQuery setObject:(id)kSecAttrAccessibleAlways forKey:(id)kSecAttrAccessible];
         status = SecItemAdd((__bridge CFDictionaryRef)addQuery, (CFTypeRef *)&result);
     }
-    
+
     if (status != errSecSuccess)
     {
         ADAuthenticationError* adError = [ADAuthenticationError keychainErrorFromOperation:@"team ID" status:status correlationId:nil];


### PR DESCRIPTION
.NET ADAL shipped with default accessibility for "teamID" hint, which means it's not accessible when device is locked. ADAL Obj-C cannot read the existing "teamID" while device is locked and it's causing issues to some apps. 

Changing the teamID account will mean we create a new entry in the keychain, and we'll set it to kSecAttrAccessibleAlways to ensure it can be read while device is locked. 