### PR TITLE
Backported macOS crash fix for 10.11 CBA flows

### DIFF
--- a/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
+++ b/ADAL/src/workplacejoin/mac/ADClientCertAuthHandler.m
@@ -260,7 +260,6 @@
     }
     
     SecIdentityRef identity = _panel.identity;
-    _panel = nil;
     return identity;
 }
 


### PR DESCRIPTION
See description of the issue here: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/244