### PR TITLE
Don't fail acquireToken when saving to cache fails

### DIFF
--- a/ADAL/src/cache/ADResponseCacheHandler.m
+++ b/ADAL/src/cache/ADResponseCacheHandler.m
@@ -65,7 +65,8 @@
     
     if (!result)
     {
-        return [ADAuthenticationResult resultFromMSIDError:msidError correlationId:requestParams.correlationId];
+        MSID_LOG_ERROR(nil, @"Failed to save tokens in cache, error code %ld, error domain %@, description %@", (long)msidError.code, msidError.domain, msidError.description);
+        MSID_LOG_ERROR_PII(nil, @"Failed to save tokens in cache, error %@", msidError);
     }
     
     MSIDLegacySingleResourceToken *resultToken = [factory legacyTokenFromResponse:response configuration:requestParams.msidConfig];

--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -171,7 +171,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
     {
         if (error)
         {
-            MSID_LOG_WARN(_requestParams, @"JSON desiarliazation error %ld", jsonError.code);
+            MSID_LOG_WARN(_requestParams, @"JSON desiarliazation error %ld", (long)jsonError.code);
             MSID_LOG_WARN_PII(_requestParams, @"JSON desiarliazation error %@ for claims %@", jsonError, claims);
 
             *error = [ADAuthenticationError errorFromAuthenticationError:AD_ERROR_DEVELOPER_INVALID_ARGUMENT


### PR DESCRIPTION
This is previous 2.6.x behavior...
Reverting it in 2.7.x to avoid conflicts with Intune SDK...