### PR TITLE
Fixed ADAggregatedDispatcher warning

### DIFF
--- a/ADAL/src/telemetry/ADAggregatedDispatcher.m
+++ b/ADAL/src/telemetry/ADAggregatedDispatcher.m
@@ -37,13 +37,6 @@
 
 static NSDictionary *s_eventPropertiesDictionary;
 
-- (id)init
-{
-    //Ensure that the appropriate init function is called. This will cause the runtime to throw.
-    [super doesNotRecognizeSelector:_cmd];
-    return nil;
-}
-
 - (id)initWithDispatcher:(id<ADDispatcher>)dispatcher
 {
     self = [super initWithDispatcher:dispatcher];


### PR DESCRIPTION
init is marked as unavailable in header file, so xcodebuild complains that we're implementing an unavailable method. 