### PR TITLE
Changed default teamID hint and added more logging for the teamID retrieval

### DIFF
--- a/ADAL.podspec
+++ b/ADAL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "ADAL"
   s.module_name  = "ADAL"
-  s.version      = "2.6.6"
+  s.version      = "2.6.7"
   s.summary      = "The ADAL SDK for iOS gives you the ability to add Azure Identity authentication to your application"
 
   s.description  = <<-DESC

--- a/ADAL/resources/ios/Framework/Info.plist
+++ b/ADAL/resources/ios/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.6.6</string>
+	<string>2.6.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -27,7 +27,7 @@
 // through build script. Don't change its format unless changing build script as well.)
 #define ADAL_VER_HIGH       2
 #define ADAL_VER_LOW        6
-#define ADAL_VER_PATCH      6
+#define ADAL_VER_PATCH      7
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/ADAL/src/cache/ios/ADKeychainTokenCache.m
+++ b/ADAL/src/cache/ios/ADKeychainTokenCache.m
@@ -128,13 +128,20 @@ static ADKeychainTokenCache* s_defaultCache = nil;
     {
         sharedGroup = [[NSBundle mainBundle] bundleIdentifier];
     }
+
+    ADAuthenticationError *teamIdError = nil;
     
-    NSString* teamId = [ADKeychainUtil keychainTeamId:nil];
+    NSString* teamId = [ADKeychainUtil keychainTeamId:&teamIdError];
 #if !TARGET_OS_SIMULATOR
     // If we didn't find a team ID and we're on device then the rest of ADAL not only will not work
     // particularly well, we'll probably induce other issues by continuing.
     if (!teamId)
     {
+        if (teamIdError)
+        {
+            AD_LOG_ERROR(nil, @"Encountered an error when retrieving teamID. Error protocol code %@, error details %@, error %@", teamIdError.protocolCode, teamIdError.errorDetails, teamIdError);
+        }
+
         return nil;
     }
 #endif

--- a/ADAL/src/utils/ios/ADKeychainUtil.m
+++ b/ADAL/src/utils/ios/ADKeychainUtil.m
@@ -59,7 +59,7 @@
 
     if (readStatus == errSecInteractionNotAllowed)
     {
-        AD_LOG_ERROR(nil, @"Encountered an error when reading teamIDHint in keychain. Keychain status %ld", (long)status);
+        AD_LOG_ERROR(nil, @"Encountered an error when reading teamIDHint in keychain. Keychain status %ld", (long)readStatus);
 
         OSStatus deleteStatus = SecItemDelete((__bridge CFDictionaryRef)query);
 

--- a/ADAL/src/utils/ios/ADKeychainUtil.m
+++ b/ADAL/src/utils/ios/ADKeychainUtil.m
@@ -50,17 +50,18 @@
 + (NSString*)retrieveTeamIDFromKeychain:(ADAuthenticationError * __autoreleasing *)error
 {
     NSDictionary *query = @{ (id)kSecClass : (id)kSecClassGenericPassword,
-                             (id)kSecAttrAccount : @"teamIDHint",
+                             (id)kSecAttrAccount : @"SDK.ObjC.teamIDHint",
                              (id)kSecAttrService : @"",
                              (id)kSecReturnAttributes : @YES };
     CFDictionaryRef result = nil;
     
-    OSStatus status = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
+    OSStatus readStatus = SecItemCopyMatching((__bridge CFDictionaryRef)query, (CFTypeRef *)&result);
 
-    if (status == errSecInteractionNotAllowed)
+    if (readStatus == errSecInteractionNotAllowed)
     {
+        AD_LOG_ERROR(nil, @"Encountered an error when reading teamIDHint in keychain. Keychain status %ld", (long)status);
+
         OSStatus deleteStatus = SecItemDelete((__bridge CFDictionaryRef)query);
-        AD_LOG_WARN(nil, @"Deleted existing teamID");
 
         if (deleteStatus != errSecSuccess)
         {
@@ -74,9 +75,11 @@
             return nil;
         }
     }
+
+    OSStatus status = readStatus;
     
-    if (status == errSecItemNotFound
-        || status == errSecInteractionNotAllowed)
+    if (readStatus == errSecItemNotFound
+        || readStatus == errSecInteractionNotAllowed)
     {
         NSMutableDictionary* addQuery = [query mutableCopy];
         [addQuery setObject:(id)kSecAttrAccessibleAlways forKey:(id)kSecAttrAccessible];
@@ -85,6 +88,8 @@
 
     if (status != errSecSuccess)
     {
+        AD_LOG_ERROR(nil, @"Encountered an error when reading teamIDHint in keychain. Keychain status %ld, read status %ld", (long)status, (long)readStatus);
+
         ADAuthenticationError* adError = [ADAuthenticationError keychainErrorFromOperation:@"team ID" status:status correlationId:nil];
         if (error)
         {

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,8 @@
+Version 2.6.7 (12.01.2018)
+------------
+* Changed teamIDHint to avoid conflicts with other SDKs
+* Improved userID handling for Intune app protection scenarios 
+
 Version 2.6.6 (09.10.2018)
 ------------
 * Added support to send claims to the token endpoint (#1272)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,6 @@
-Version 2.6.7 (12.01.2018)
+Version 2.6.7 (11.29.2018)
 ------------
 * Changed teamIDHint to avoid conflicts with other SDKs
-* Improved userID handling for Intune app protection scenarios 
 
 Version 2.6.6 (09.10.2018)
 ------------


### PR DESCRIPTION
* Previously applied [fix](https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/1328) doesn't seem to always work when Intune MAM SDK is also involved. If the offending teamID entry is written into com.microsoft.adalcache or com.microsoft.intune.mam keychain groups, Intune MAM SDK would block from deleting them under certain circumstances. 
* Changing default teamID to not conflict with the problematic one should resolve the issue.
* Also added more error logs around keychain teamID retrieval to allow better investigation of similar issues in the future. 