### PR TITLE
Updated to teamID hint fix and log instead of failing when broker response caching fails

### DIFF
--- a/ADAL/resources/ios/Framework/Info.plist
+++ b/ADAL/resources/ios/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.5</string>
+	<string>2.7.6</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -27,7 +27,7 @@
 // through build script. Don't change its format unless changing build script as well.)
 #define ADAL_VER_HIGH       2
 #define ADAL_VER_LOW        7
-#define ADAL_VER_PATCH      5
+#define ADAL_VER_PATCH      6
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -316,7 +316,8 @@ NSString* kAdalResumeDictionaryKey = @"adal-broker-resume-dictionary";
         
         if (!saveResult)
         {
-            return [ADAuthenticationResult resultFromMSIDError:msidError];
+            MSID_LOG_ERROR(nil, @"Failed to save tokens in cache, error code %ld, error domain %@, description %@", (long)msidError.code, msidError.domain, msidError.description);
+            MSID_LOG_ERROR_PII(nil, @"Failed to save tokens in cache, error %@", msidError);
         }
         
         NSString *userId = [[[result tokenCacheItem] userInformation] userId];

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,9 @@
+Version 2.7.6 (12.01.2018)
+-----------
+* Changed teamIDHint to avoid conflicts with other SDKs
+* Improved userID handling for Intune app protection scenarios 
+* Don't fail acquireToken when saving broker response tokens failed
+
 Version 2.7.5 (11.02.2018)
 -----------
 * Don't fail acquireToken when saving to cache fails (#1338)


### PR DESCRIPTION
Follow up to this [fix](https://github.com/AzureAD/azure-activedirectory-library-for-objc/pull/1338), we should also apply the same logic for brokered scenarios. Additionally, updated identitycore for the [teamID change](https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/300)