### PR TITLE
ID token factory now also checks upn and unique_name claim to determine version

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -5055,7 +5055,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4EAF1FC370BF00CD70C5 /* adal__testapp__mac.xcconfig */;
 			buildSettings = {
-				GCC_OPTIMIZATION_LEVEL = 0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 			};
 			name = Debug;

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -5055,6 +5055,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4EAF1FC370BF00CD70C5 /* adal__testapp__mac.xcconfig */;
 			buildSettings = {
+				GCC_OPTIMIZATION_LEVEL = 0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 			};
 			name = Debug;

--- a/ADAL/automation/tests/interactive/ADALOnPremLoginTests.m
+++ b/ADAL/automation/tests/interactive/ADALOnPremLoginTests.m
@@ -188,6 +188,7 @@
     config = [self.testConfiguration configWithAdditionalConfiguration:silentParams];
     [self acquireTokenSilent:config];
     [self assertAccessTokenNotNil];
+    XCTAssertEqualObjects([[self resultDictionary][@"displayable_id"] lowercaseString], self.primaryAccount.account.lowercaseString);
     [self closeResultView];
 }
 
@@ -211,6 +212,7 @@
     [self acquireToken:config];
     [self enterADFSPassword];
     [self assertAccessTokenNotNil];
+    XCTAssertEqualObjects([[self resultDictionary][@"displayable_id"] lowercaseString], self.primaryAccount.account.lowercaseString);
     [self closeResultView];
 
     // Now do silent #296725
@@ -232,6 +234,7 @@
     // Now do access token refresh
     [self acquireTokenSilent:config];
     [self assertAccessTokenNotNil];
+    XCTAssertEqualObjects([[self resultDictionary][@"displayable_id"] lowercaseString], self.primaryAccount.account.lowercaseString);
     [self closeResultView];
 
     // Now do silent #296725 without providing user ID
@@ -245,6 +248,7 @@
     config = [self.testConfiguration configWithAdditionalConfiguration:silentParams];
     [self acquireTokenSilent:config];
     [self assertAccessTokenNotNil];
+    XCTAssertEqualObjects([[self resultDictionary][@"displayable_id"] lowercaseString], self.primaryAccount.account.lowercaseString);
     [self closeResultView];
 }
 

--- a/ADAL/xcconfig/adal__debug.xcconfig
+++ b/ADAL/xcconfig/adal__debug.xcconfig
@@ -3,3 +3,4 @@
 //
 
 #include "../IdentityCore/IdentityCore/xcconfig/identitycore__debug.xcconfig"
+GCC_OPTIMIZATION_LEVEL = 0;


### PR DESCRIPTION
See common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/314