### PR TITLE
Set log level to nothing for all tests except logger tests

### DIFF
--- a/ADAL/resources/mac/Info.plist
+++ b/ADAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.6</string>
+	<string>2.7.7</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -40,14 +40,12 @@
 - (void)setUp
 {
     [super setUp];
-    [ADLogger setNSLogging:YES];
 }
 
 
 - (void)tearDown
 {
     XCTAssertTrue([ADTestURLSession noResponsesLeft]);
-    [ADLogger setNSLogging:NO];
     [ADTestURLSession clearResponses];
     [[ADClientMetrics getInstance] clearMetrics];
     [ADAuthorityValidation clearAadCache];

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -29,6 +29,7 @@
 #import "ADTestCase.h"
 #import "ADClientMetrics.h"
 #import "ADAuthorityValidation+TestUtil.h"
+#import "ADLogger.h"
 
 #if TARGET_OS_IPHONE
 #import "ADApplicationTestUtil.h"
@@ -39,12 +40,14 @@
 - (void)setUp
 {
     [super setUp];
+    [ADLogger setNSLogging:YES];
 }
 
 
 - (void)tearDown
 {
     XCTAssertTrue([ADTestURLSession noResponsesLeft]);
+    [ADLogger setNSLogging:NO];
     [ADTestURLSession clearResponses];
     [[ADClientMetrics getInstance] clearMetrics];
     [ADAuthorityValidation clearAadCache];

--- a/ADAL/tests/ADTestCase.m
+++ b/ADAL/tests/ADTestCase.m
@@ -40,8 +40,8 @@
 - (void)setUp
 {
     [super setUp];
+    [ADLogger setLevel:ADAL_LOG_LEVEL_NO_LOG];
 }
-
 
 - (void)tearDown
 {

--- a/ADAL/tests/unit/ADLoggerTests.m
+++ b/ADAL/tests/unit/ADLoggerTests.m
@@ -217,8 +217,8 @@
     
     [ADLogger setLoggerCallback:^(ADAL_LOG_LEVEL logLevel, NSString *message, BOOL containsPii)
      {
-         NSLog(@"Logger Message: %@", message);
          XCTAssertNotNil(message);
+         XCTAssertEqualObjects(message, @"message");
          XCTAssertEqual(logLevel, ADAL_LOG_LEVEL_ERROR);
          XCTAssertFalse(containsPii);
          

--- a/ADAL/tests/unit/ADLoggerTests.m
+++ b/ADAL/tests/unit/ADLoggerTests.m
@@ -216,6 +216,7 @@
     
     [ADLogger setLoggerCallback:^(ADAL_LOG_LEVEL logLevel, NSString *message, BOOL containsPii)
      {
+         NSLog(@"Logger Message: %@", message);
          XCTAssertNotNil(message);
          XCTAssertEqual(logLevel, ADAL_LOG_LEVEL_ERROR);
          XCTAssertFalse(containsPii);

--- a/ADAL/tests/unit/ADLoggerTests.m
+++ b/ADAL/tests/unit/ADLoggerTests.m
@@ -38,6 +38,7 @@
     
     self.enableNSLogging = [ADLogger getNSLogging];
     [ADLogger setNSLogging:YES];
+    [ADLogger setLevel:ADAL_LOG_LEVEL_ERROR];
 }
 
 - (void)tearDown

--- a/ADAL/tests/unit/ADLoggerTests.m
+++ b/ADAL/tests/unit/ADLoggerTests.m
@@ -218,7 +218,7 @@
     [ADLogger setLoggerCallback:^(ADAL_LOG_LEVEL logLevel, NSString *message, BOOL containsPii)
      {
          XCTAssertNotNil(message);
-         XCTAssertEqualObjects(message, @"message");
+         XCTAssertTrue([message containsString:@"message"]);
          XCTAssertEqual(logLevel, ADAL_LOG_LEVEL_ERROR);
          XCTAssertFalse(containsPii);
          


### PR DESCRIPTION
Seems like because all other tests are logging very rapidly,  this slows down tests and ADLoggerTests might get delayed messages. This PR disables logging for all tests that don't need it. Also, updates ADAL framework version number.