### PR TITLE
Return unexpected for expected, but non mapped error code.

### DIFF
--- a/ADAL/src/ADAuthenticationErrorMap.m
+++ b/ADAL/src/ADAuthenticationErrorMap.m
@@ -135,13 +135,15 @@ static NSDictionary *s_userInfoKeyMapping;
     NSString *adDomain = [self adErrorDomainFromMsidError:msidError];
     if (!adDomain) return msidError.code;
  
+    // No mapping available for keychain error domain, return code as is.
     if ([adDomain isEqualToString:ADKeychainErrorDomain]) return msidError.code;
     
+    // Other errors should be mapped.
     NSNumber *mappedErrorCode = s_errorCodeMapping[adDomain][@(msidError.code)];
     if (!mappedErrorCode)
     {
         MSID_LOG_WARN(nil, @"ADAuthenticationErrorMap - could not find the error code mapping entry for domain (%@) + error code (%ld).", adDomain, (long)msidError.code);
-        return msidError.code;
+        return AD_ERROR_UNEXPECTED;
     }
     
     return [mappedErrorCode integerValue];

--- a/ADAL/src/cache/ADMSIDDataSourceWrapper.m
+++ b/ADAL/src/cache/ADMSIDDataSourceWrapper.m
@@ -82,7 +82,7 @@
 {
     NSError *cacheError = nil;
     
-    BOOL result = [self.dataSource removeItemsWithKey:[item tokenCacheKey] context:nil error:&cacheError];
+    BOOL result = [self.dataSource removeItemsWithTokenKey:[item tokenCacheKey] context:nil error:&cacheError];
     
     if (cacheError && error)
     {

--- a/ADAL/tests/unit/ADAuthenticationErrorConverterTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorConverterTests.m
@@ -46,7 +46,7 @@
     XCTAssertNil(adalError);
 }
 
- - (void)testErrorConversion_whenOnlyErrorDomainIsMapped_shouldKeepErrorCode {
+- (void)testErrorConversion_whenErrorDomainIsNotMapped_shouldKeepErrorCode {
     NSInteger errorCode = -9999;
     NSString *errorDescription = @"a fake error description.";
     NSString *oauthError = @"a fake oauth error message.";
@@ -65,13 +65,70 @@
     ADAuthenticationError *adalError = [ADAuthenticationErrorConverter ADAuthenticationErrorFromMSIDError:msidError];
     
     XCTAssertNotNil(adalError);
-    XCTAssertEqualObjects(adalError.domain, ADAuthenticationErrorDomain);
+    XCTAssertEqualObjects(adalError.domain, @"Unmapped Domain");
     XCTAssertEqual(adalError.code, errorCode);
     XCTAssertEqualObjects(adalError.errorDetails, errorDescription);
     XCTAssertEqualObjects(adalError.protocolCode, oauthError);
     XCTAssertEqualObjects(adalError.userInfo[NSUnderlyingErrorKey], underlyingError);
     XCTAssertEqualObjects(adalError.userInfo[ADHTTPHeadersKey], httpHeaders);
 }
+
+- (void)testErrorConversion_whenErrorDomainIsKeychain_shouldKeepErrorCode {
+    NSInteger errorCode = -9999;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSError *underlyingError = [NSError errorWithDomain:NSOSStatusErrorDomain code:errSecItemNotFound userInfo:nil];
+    NSUUID *correlationId = [NSUUID UUID];
+    NSDictionary *httpHeaders = @{@"fake header key" : @"fake header value"};
+    
+    NSError *msidError = MSIDCreateError(MSIDKeychainErrorDomain,
+                                         errorCode,
+                                         errorDescription,
+                                         oauthError,
+                                         nil,
+                                         underlyingError,
+                                         correlationId,
+                                         @{MSIDHTTPHeadersKey : httpHeaders});
+    ADAuthenticationError *adalError = [ADAuthenticationErrorConverter ADAuthenticationErrorFromMSIDError:msidError];
+    
+    XCTAssertNotNil(adalError);
+    XCTAssertEqualObjects(adalError.domain, ADKeychainErrorDomain);
+    XCTAssertEqual(adalError.code, errorCode);
+    XCTAssertEqualObjects(adalError.errorDetails, errorDescription);
+    XCTAssertEqualObjects(adalError.protocolCode, oauthError);
+    XCTAssertEqualObjects(adalError.userInfo[NSUnderlyingErrorKey], underlyingError);
+    XCTAssertEqualObjects(adalError.userInfo[ADHTTPHeadersKey], httpHeaders);
+
+}
+
+- (void)testErrorConversion_whenErrorDomainIsMappedAndNoErrorCode_shouldADALUnexpectedError {
+    NSInteger errorCode = -9999;
+    NSString *errorDescription = @"a fake error description.";
+    NSString *oauthError = @"a fake oauth error message.";
+    NSError *underlyingError = [NSError errorWithDomain:NSOSStatusErrorDomain code:errSecItemNotFound userInfo:nil];
+    NSUUID *correlationId = [NSUUID UUID];
+    NSDictionary *httpHeaders = @{@"fake header key" : @"fake header value"};
+    
+    NSError *msidError = MSIDCreateError(MSIDErrorDomain,
+                                         errorCode,
+                                         errorDescription,
+                                         oauthError,
+                                         nil,
+                                         underlyingError,
+                                         correlationId,
+                                         @{MSIDHTTPHeadersKey : httpHeaders});
+    ADAuthenticationError *adalError = [ADAuthenticationErrorConverter ADAuthenticationErrorFromMSIDError:msidError];
+    
+    XCTAssertNotNil(adalError);
+    XCTAssertEqualObjects(adalError.domain, ADAuthenticationErrorDomain);
+    XCTAssertEqual(adalError.code, AD_ERROR_UNEXPECTED);
+    XCTAssertEqualObjects(adalError.errorDetails, errorDescription);
+    XCTAssertEqualObjects(adalError.protocolCode, oauthError);
+    XCTAssertEqualObjects(adalError.userInfo[NSUnderlyingErrorKey], underlyingError);
+    XCTAssertEqualObjects(adalError.userInfo[ADHTTPHeadersKey], httpHeaders);
+}
+
+
 
 - (void)testErrorConversion_whenBothErrorDomainAndCodeAreMapped_shouldMapBoth {
     NSString *domain = MSIDErrorDomain;

--- a/ADAL/tests/unit/ADAuthenticationErrorMapTests.m
+++ b/ADAL/tests/unit/ADAuthenticationErrorMapTests.m
@@ -72,7 +72,7 @@
 {
     NSError *msidError = MSIDCreateError(MSIDErrorDomain, 99999, nil, nil, nil, nil, nil, nil);
     NSInteger code = [ADAuthenticationErrorMap adErrorCodeFromMsidError:msidError];
-    NSInteger expectedErrorCode = 99999;
+    NSInteger expectedErrorCode = AD_ERROR_UNEXPECTED;
     XCTAssertEqual(code, expectedErrorCode);
 }
 


### PR DESCRIPTION
Except keychain domain where code is not mapped.