### PR TITLE
Update encoding

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest.m
@@ -162,7 +162,7 @@ static dispatch_semaphore_t s_interactionLock = nil;
         return NO;
     }
 
-    NSData *decodedData = [_claims.msidWWWFormURLDecode dataUsingEncoding:NSUTF8StringEncoding];
+    NSData *decodedData = [_claims.msidURLDecode dataUsingEncoding:NSUTF8StringEncoding];
     NSError *jsonError = nil;
     NSDictionary *decodedDictionary = [NSDictionary msidDictionaryFromJsonData:decodedData error:&jsonError];
 

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -132,7 +132,7 @@ static ADAuthenticationResult *s_result = nil;
     
     if (![NSString msidIsStringNilOrBlank:claims])
     {
-        webviewConfig.claims = [claims msidWWWFormURLDecode];
+        webviewConfig.claims = [claims msidURLDecode];
     }
 
 #if TARGET_OS_IPHONE

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -126,7 +126,7 @@ static ADAuthenticationResult *s_result = nil;
     webviewConfig.loginHint = requestParams.identifier.userId;
     webviewConfig.promptBehavior = [ADAuthenticationContext getPromptParameter:promptBehavior];
     
-    webviewConfig.extraQueryParameters = [self.class dictionaryFromQueryString:requestParams.extraQueryParameters];
+    webviewConfig.extraQueryParameters = [NSDictionary msidDictionaryFromURLEncodedString:requestParams.extraQueryParameters];
 
     NSString *claims = [MSIDClientCapabilitiesUtil msidClaimsParameterFromCapabilities:requestParams.clientCapabilities developerClaims:requestParams.decodedClaims];
     
@@ -146,46 +146,6 @@ static ADAuthenticationResult *s_result = nil;
                                                                 context:requestParams
                                                       completionHandler:completionHandler];
 }
-
-//TODO: Replace with MSID utility
-+ (NSDictionary *)dictionaryFromQueryString:(NSString *)string
-{
-    if ([NSString msidIsStringNilOrBlank:string])
-    {
-        return nil;
-    }
-    
-    NSArray *queries = [string componentsSeparatedByString:@"&"];
-    NSMutableDictionary *queryDict = [NSMutableDictionary new];
-    
-    for (NSString *query in queries)
-    {
-        NSArray *queryElements = [query componentsSeparatedByString:@"="];
-        if (queryElements.count > 2)
-        {
-            MSID_LOG_WARN(nil, @"Query parameter must be a form key=value: %@", query);
-            continue;
-        }
-        
-        NSString *key = [queryElements[0] msidTrimmedString];
-        if ([NSString msidIsStringNilOrBlank:key])
-        {
-            MSID_LOG_WARN(nil, @"Query parameter must have a key");
-            continue;
-        }
-        
-        NSString *value = @"";
-        if (queryElements.count == 2)
-        {
-            value = [queryElements[1] msidTrimmedString];
-        }
-        
-        [queryDict setValue:value forKey:key];
-    }
-    
-    return queryDict;
-}
-
 
 #if TARGET_OS_IPHONE
 + (void)setInterruptedBrokerResult:(ADAuthenticationResult *)result

--- a/ADAL/src/validation/ADAuthorityValidationRequest.m
+++ b/ADAL/src/validation/ADAuthorityValidationRequest.m
@@ -66,7 +66,7 @@ static NSString* const s_kAuthorizationEndPointKey = @"authorization_endpoint";
                                    s_kAuthorizationEndPointKey: authorizationEndpoint};
     
     NSString *endpoint = [NSString stringWithFormat:@"https://%@/%@?%@",
-                          trustedHost, MSID_OAUTH2_INSTANCE_DISCOVERY_SUFFIX, [NSString msidWWWFormURLEncodedStringFromDictionary:request_data]];
+                          trustedHost, MSID_OAUTH2_INSTANCE_DISCOVERY_SUFFIX, [NSString msidURLEncodedStringFromDictionary:request_data]];
     
     return [NSURL URLWithString:endpoint];
 }


### PR DESCRIPTION
For broker request, continue to use url form encoding for backward compat.
Otherwise, use url encoding for extra query params and others.