### PR TITLE
AD Default web request timeout expected to be 30 seconds

### DIFF
--- a/ADAL/src/ADAuthenticationSettings.m
+++ b/ADAL/src/ADAuthenticationSettings.m
@@ -44,7 +44,7 @@
     if (self)
     {
         //Initialize the defaults here:
-        self.requestTimeOut = 300;//in seconds.
+        self.requestTimeOut = 30;//in seconds.
         self.expirationBuffer = 300;//in seconds, ensures catching of clock differences between the server and the device
 #if TARGET_OS_IPHONE
         


### PR DESCRIPTION
...according to comment on ADWebRequest.m line 94.

Actual timeout experienced to be 5 minutes when attempting to validate authority in 100% packet loss setting. Network setting configured by Apple's Network Link Conditioner.

Asking to modify the requestTimeout default from 300 seconds to 30 seconds.