### PR TITLE
Surface system error when accessing token endpoint

### DIFF
--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -482,6 +482,12 @@
                  [self requestTokenByCode:code
                           completionBlock:^(MSIDTokenResponse *response, ADAuthenticationError *error)
                   {
+                      if (error)
+                      {
+                          completionBlock([ADAuthenticationResult resultFromError:error correlationId:_requestParams.correlationId]);
+                          return;
+                      }
+                      
                       ADAuthenticationResult *result = [ADResponseCacheHandler processAndCacheResponse:response
                                                                                       fromRefreshToken:nil
                                                                                                  cache:self.tokenCache

--- a/ADAL/tests/ADTestAuthenticationViewController.h
+++ b/ADAL/tests/ADTestAuthenticationViewController.h
@@ -58,5 +58,6 @@ typedef void (^OnLoadBlock)(NSURLRequest *urlRequest, id<ADWebAuthDelegate> dele
 + (void)addDelegateCallWebAuthDidCompleteWithURL:(NSURL *)endURL;
 + (void)addDelegateCallWebAuthDidFailWithError:(NSError *)error;
 + (void)clearDelegateCalls;
++ (void)reset;
 
 @end

--- a/ADAL/tests/ADTestAuthenticationViewController.m
+++ b/ADAL/tests/ADTestAuthenticationViewController.m
@@ -250,4 +250,10 @@ static OnLoadBlock s_onLoadBlock = nil;
     [s_delegateCalls removeAllObjects];
 }
 
++ (void)reset
+{
+    s_onLoadBlock = nil;
+    [self clearDelegateCalls];
+}
+
 @end


### PR DESCRIPTION
Also fix unit tests which might interfere with each other, which makes it difficult to debug.