### PR TITLE
True MAM CA cache fix

### DIFF
--- a/ADAL.podspec
+++ b/ADAL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "ADAL"
   s.module_name  = "ADAL"
-  s.version      = "2.7.12"
+  s.version      = "2.7.13"
   s.summary      = "The ADAL SDK for iOS gives you the ability to add Azure Identity authentication to your application"
 
   s.description  = <<-DESC

--- a/ADAL.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/ADAL.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
+<dict/>
 </plist>

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -5054,7 +5054,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.office.outlook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.adal.2.1.0.TestApp;
 			};
 			name = Debug;
 		};
@@ -5064,7 +5064,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
-				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.office.outlook;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.adal.2.1.0.TestApp;
 			};
 			name = Release;
 		};

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -4258,6 +4258,7 @@
 				CODE_SIGN_IDENTITY = "";
 				DEVELOPMENT_TEAM = "";
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -4267,6 +4268,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				DEVELOPMENT_TEAM = "";
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};
@@ -4289,6 +4291,7 @@
 			baseConfigurationReference = D6CF4EB91FC370C100CD70C5 /* adal__unittest__mac.xcconfig */;
 			buildSettings = {
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -4296,6 +4299,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4EB91FC370C100CD70C5 /* adal__unittest__mac.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};
@@ -4583,6 +4587,7 @@
 			baseConfigurationReference = D6CF4EA91FC370BF00CD70C5 /* adal__integrationtest__mac.xcconfig */;
 			buildSettings = {
 				GCC_OPTIMIZATION_LEVEL = 0;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Debug;
 		};
@@ -4590,6 +4595,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = D6CF4EA91FC370BF00CD70C5 /* adal__integrationtest__mac.xcconfig */;
 			buildSettings = {
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 			};
 			name = Release;
 		};

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -1160,6 +1160,7 @@
 		B258487B20747998007FAD22 /* KeyVaultClient.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeyVaultClient.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B258488020747A54007FAD22 /* KeyVault.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = KeyVault.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B258488220747B01007FAD22 /* KeyVaultClient.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = KeyVaultClient.xcodeproj; path = ../KeyVaultClient/KeyVaultClient.xcodeproj; sourceTree = "<group>"; };
+		B26207E022C872DA00F867D9 /* ADEnrollmentGateway+UnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADEnrollmentGateway+UnitTests.h"; sourceTree = "<group>"; };
 		B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADNegotiateHandler.h; sourceTree = "<group>"; };
 		B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADNegotiateHandler.m; sourceTree = "<group>"; };
 		B2822A2C2055D67200390B6E /* ADLegacyMacTokenCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADLegacyMacTokenCache.h; sourceTree = "<group>"; };
@@ -2235,6 +2236,7 @@
 		B20DC5D51F0D97C600957806 /* ios */ = {
 			isa = PBXGroup;
 			children = (
+				B26207E022C872DA00F867D9 /* ADEnrollmentGateway+UnitTests.h */,
 				A521AB7020EED85C0005735B /* ADEnrollmentGatewayTests.m */,
 				234F3CE51F35159500DE4AA4 /* ADAuthenticationContextTests.m */,
 				B20DC5D61F0D97C600957806 /* ADAL_iOS_UTs-Info.plist */,

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -5054,6 +5054,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.office.outlook;
 			};
 			name = Debug;
 		};
@@ -5063,6 +5064,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				ENABLE_BITCODE = NO;
+				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.office.outlook;
 			};
 			name = Release;
 		};

--- a/ADAL/resources/ios/Framework/Info.plist
+++ b/ADAL/resources/ios/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.12</string>
+	<string>2.7.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/resources/mac/Info.plist
+++ b/ADAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.11</string>
+	<string>2.7.12</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/resources/mac/Info.plist
+++ b/ADAL/resources/mac/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.7.12</string>
+	<string>2.7.13</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -27,7 +27,7 @@
 // through build script. Don't change its format unless changing build script as well.)
 #define ADAL_VER_HIGH       2
 #define ADAL_VER_LOW        7
-#define ADAL_VER_PATCH      12
+#define ADAL_VER_PATCH      13
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -70,4 +70,10 @@
      telemetryRequestId:(NSString *)telemetryRequestId
            logComponent:(NSString *)logComponent;
 
+- (BOOL)isCapableForMAMCA;
++ (NSString *)applicationIdentifierWithAuthority:(NSString *)authority;
+
+- (NSString *)enrollmentIDForHomeAccountID:(NSString *)homeAccountId
+                              legacyUserID:(NSString *)legacyUserID;
+
 @end

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -28,6 +28,14 @@
 #import "NSString+MSIDExtensions.h"
 #import "MSIDAuthorityFactory.h"
 #import "MSIDConstants.h"
+#import "ADEnrollmentGateway.h"
+#import "MSIDADFSAuthority.h"
+
+@interface ADRequestParameters()
+
+@property (nonatomic) MSIDConfiguration *mamCAConfiguration;
+
+@end
 
 @implementation ADRequestParameters
 
@@ -176,7 +184,66 @@
                                                                     clientId:self.clientId
                                                                       target:self.resource];
     
+    if ([self isCapableForMAMCA])
+    {
+        config.applicationIdentifier = [[NSBundle mainBundle] bundleIdentifier];
+        config.enrollmentId = [self enrollmentIDForHomeAccountID:self.account.homeAccountId
+                                                    legacyUserID:self.account.legacyAccountId];
+    }
+    
     return config;
+}
+
+#pragma mark - Enrollment ID
+
+- (BOOL)isCapableForMAMCA
+{
+    NSString *authority = self.cloudAuthority ? self.cloudAuthority : self.authority;
+    return [self.class isCapableForMAMCA:authority];
+}
+
++ (BOOL)isCapableForMAMCA:(NSString *)authority
+{
+#if TARGET_OS_IPHONE
+    __auto_type adfsAuthority = [[MSIDADFSAuthority alloc] initWithURL:[NSURL URLWithString:authority] context:nil error:nil];
+    
+    BOOL isADFSInstance = adfsAuthority != nil;
+    
+    if (!isADFSInstance)
+    {
+        return ![NSString msidIsStringNilOrBlank:[ADEnrollmentGateway allIntuneMAMResourcesJSON]];
+    }
+    
+    return NO;
+#else
+    return NO;
+#endif
+}
+
++ (NSString *)applicationIdentifierWithAuthority:(NSString *)authority
+{
+    return [self isCapableForMAMCA:authority] ? [[NSBundle mainBundle] bundleIdentifier] : nil;
+}
+
+- (NSString *)enrollmentIDForHomeAccountID:(NSString *)homeAccountId
+                              legacyUserID:(NSString *)legacyUserID
+{
+    if (![self isCapableForMAMCA])
+    {
+        return nil;
+    }
+    
+    ADAuthenticationError *error = nil;
+    NSString *enrollId = [ADEnrollmentGateway enrollmentIDForHomeAccountId:homeAccountId
+                                                                    userID:legacyUserID
+                                                                     error:&error];
+    
+    if (error)
+    {
+        MSID_LOG_ERROR_PII(self, @"Error looking up enrollment ID %@", error);
+    }
+    
+    return enrollId;
 }
 
 @end

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -31,12 +31,6 @@
 #import "ADEnrollmentGateway.h"
 #import "MSIDADFSAuthority.h"
 
-@interface ADRequestParameters()
-
-@property (nonatomic) MSIDConfiguration *mamCAConfiguration;
-
-@end
-
 @implementation ADRequestParameters
 
 @synthesize authority = _authority;

--- a/ADAL/src/cache/ADResponseCacheHandler.h
+++ b/ADAL/src/cache/ADResponseCacheHandler.h
@@ -35,6 +35,7 @@
                                    fromRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)refreshToken
                                               cache:(MSIDLegacyTokenCacheAccessor *)cache
                                              params:(ADRequestParameters *)requestParams
+                                      configuration:(MSIDConfiguration *)configuration
                                        verifyUserId:(BOOL)verifyUserId;
 
 @end

--- a/ADAL/src/cache/ADResponseCacheHandler.m
+++ b/ADAL/src/cache/ADResponseCacheHandler.m
@@ -39,6 +39,7 @@
                                    fromRefreshToken:(MSIDBaseToken<MSIDRefreshableToken> *)refreshToken
                                               cache:(MSIDLegacyTokenCacheAccessor *)cache
                                              params:(ADRequestParameters *)requestParams
+                                      configuration:(MSIDConfiguration *)configuration
                                        verifyUserId:(BOOL)verifyUserId
 {
     NSError *msidError = nil;
@@ -59,7 +60,7 @@
                           params:requestParams];
     }
     
-    result = [cache saveTokensWithConfiguration:requestParams.msidConfig
+    result = [cache saveTokensWithConfiguration:configuration
                                        response:response
                                         context:requestParams
                                           error:&msidError];
@@ -70,7 +71,7 @@
         MSID_LOG_ERROR_PII(nil, @"Failed to save tokens in cache, error %@", msidError);
     }
     
-    MSIDLegacySingleResourceToken *resultToken = [factory legacyTokenFromResponse:response configuration:requestParams.msidConfig];
+    MSIDLegacySingleResourceToken *resultToken = [factory legacyTokenFromResponse:response configuration:configuration];
     
     ADTokenCacheItem *adTokenCacheItem = [[ADTokenCacheItem alloc] initWithLegacySingleResourceToken:resultToken];
     

--- a/ADAL/src/cache/ADTokenCacheItem+MSIDTokens.m
+++ b/ADAL/src/cache/ADTokenCacheItem+MSIDTokens.m
@@ -53,6 +53,8 @@
         _accessToken = accessToken.accessToken;
         _resource = accessToken.resource;
         _expiresOn = accessToken.expiresOn;
+        _enrollmentId = accessToken.enrollmentId;
+        _applicationIdentifier = accessToken.applicationIdentifier;
     }
     
     [self calculateHash];
@@ -148,6 +150,8 @@
                                                                              clientId:self.clientId
                                                                              resource:self.resource
                                                                          legacyUserId:self.userInformation.userId];
+    
+    key.applicationIdentifier = self.applicationIdentifier;
     return key;
 }
 
@@ -170,6 +174,8 @@
     cacheItem.homeAccountId = self.userInformation.homeAccountId;
     cacheItem.credentialType = [MSIDCredentialTypeHelpers credentialTypeWithRefreshToken:self.refreshToken accessToken:self.accessToken];
     cacheItem.additionalInfo = self.additionalServer;
+    cacheItem.enrollmentId = self.enrollmentId;
+    cacheItem.applicationIdentifier = self.applicationIdentifier;
     return cacheItem;
 }
 

--- a/ADAL/src/cache/ADTokenCacheItem.m
+++ b/ADAL/src/cache/ADTokenCacheItem.m
@@ -53,7 +53,7 @@
 
 - (void)calculateHash
 {
-    _hash = [[NSString stringWithFormat:@"%@%@%@%@", _resource, _authority, _clientId, _userInformation.userId] hash];
+    _hash = [[NSString stringWithFormat:@"%@%@%@%@%@", _resource, _authority, _clientId, _userInformation.userId, _applicationIdentifier] hash];
 }
 
 //Multi-resource refresh tokens are stored separately, as they apply to all resources. As such,
@@ -93,12 +93,14 @@
         return [ADTokenCacheKey keyWithAuthority:_storageAuthority
                                         resource:_resource
                                         clientId:_clientId
+                                   appIdentifier:_applicationIdentifier
                                            error:error];
     }
     
     return [ADTokenCacheKey keyWithAuthority:_authority
                                     resource:_resource
                                     clientId:_clientId
+                               appIdentifier:_applicationIdentifier
                                        error:error];
 }
 
@@ -139,6 +141,8 @@
     [aCoder encodeObject:_expiresOn forKey:@"expiresOn"];
     [aCoder encodeObject:_userInformation forKey:@"userInformation"];
     [aCoder encodeObject:_additionalServer forKey:@"additionalServer"];
+    [aCoder encodeObject:_enrollmentId forKey:@"enrollmentId"];
+    [aCoder encodeObject:_applicationIdentifier forKey:@"applicationIdentifier"];
 }
 
 //Deserializer:
@@ -162,6 +166,8 @@
     _expiresOn = [aDecoder decodeObjectOfClass:[NSDate class] forKey:@"expiresOn"];
     _userInformation = [aDecoder decodeObjectOfClass:[ADUserInformation class] forKey:@"userInformation"];
     _additionalServer = [aDecoder decodeObjectOfClass:[NSDictionary class] forKey:@"additionalServer"];
+    _enrollmentId = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"enrollmentId"];
+    _applicationIdentifier = [aDecoder decodeObjectOfClass:[NSString class] forKey:@"applicationIdentifier"];
     
     [self calculateHash];
     
@@ -200,6 +206,8 @@
     result &= [self.userInformation isEqual:rhs.userInformation]  || (self.userInformation == rhs.userInformation);
     result &= [self.sessionKey isEqualToData:rhs.sessionKey] || (self.sessionKey == rhs.sessionKey);
     result &= [self.additionalServer isEqualToDictionary:rhs.additionalServer] || (self.additionalServer == rhs.additionalServer);
+    result &= [self.enrollmentId isEqualToString:rhs.enrollmentId] || (self.enrollmentId == rhs.enrollmentId);
+    result &= [self.applicationIdentifier isEqualToString:rhs.applicationIdentifier] || (self.applicationIdentifier == rhs.applicationIdentifier);
 
     return result;
 }

--- a/ADAL/src/cache/ADTokenCacheKey.h
+++ b/ADAL/src/cache/ADTokenCacheKey.h
@@ -36,8 +36,6 @@
     NSString* _clientId;
 }
 
-
-
 /*! Creates a key
  @param authority Required. The authentication authority used.
  @param resource Optional. The resource used for the token. Multi-resource refresh token items can be extracted by specifying nil.

--- a/ADAL/src/cache/ADTokenCacheKey.h
+++ b/ADAL/src/cache/ADTokenCacheKey.h
@@ -36,6 +36,8 @@
     NSString* _clientId;
 }
 
+
+
 /*! Creates a key
  @param authority Required. The authentication authority used.
  @param resource Optional. The resource used for the token. Multi-resource refresh token items can be extracted by specifying nil.
@@ -46,6 +48,13 @@
                              clientId:(NSString *)clientId
                                 error:(ADAuthenticationError * __autoreleasing *)error;
 
+/*! Creates a key with optional application identifier */
++ (ADTokenCacheKey *)keyWithAuthority:(NSString *)authority
+                             resource:(NSString *)resource
+                             clientId:(NSString *)clientId
+                        appIdentifier:(NSString *)appIdentifier
+                                error:(ADAuthenticationError * __autoreleasing *)error;
+
 /*! The authority that issues access tokens */
 @property (readonly) NSString* authority;
 
@@ -54,6 +63,9 @@
 
 /*! The application client identifier */
 @property (readonly) NSString* clientId;
+
+/*! Application identifier */
+@property (readonly) NSString *applicationIdentifier;
 
 - (ADTokenCacheKey *)mrrtKey;
 

--- a/ADAL/src/cache/ADTokenCacheKey.m
+++ b/ADAL/src/cache/ADTokenCacheKey.m
@@ -27,6 +27,12 @@
 #import "ADHelpers.h"
 #import "ADTokenCacheKey.h"
 
+@interface ADTokenCacheKey()
+
+@property (readwrite) NSString *applicationIdentifier;
+
+@end
+
 @implementation ADTokenCacheKey
 
 @synthesize authority = _authority;
@@ -57,9 +63,22 @@
     return self;
 }
 
++ (ADTokenCacheKey *)keyWithAuthority:(NSString *)authority
+                             resource:(NSString *)resource
+                             clientId:(NSString *)clientId
+                                error:(ADAuthenticationError * __autoreleasing *)error
+{
+    return [ADTokenCacheKey keyWithAuthority:authority
+                                    resource:resource
+                                    clientId:clientId
+                               appIdentifier:nil
+                                       error:error];
+}
+
 + (id)keyWithAuthority:(NSString *)authority
               resource:(NSString *)resource
               clientId:(NSString *)clientId
+         appIdentifier:(NSString *)appIdentifier
                  error:(ADAuthenticationError * __autoreleasing *)error
 {
     API_ENTRY;
@@ -73,6 +92,7 @@
     RETURN_NIL_ON_NIL_EMPTY_ARGUMENT(clientId);
     
     ADTokenCacheKey* key = [[ADTokenCacheKey alloc] initWithAuthority:authority resource:resource clientId:clientId];
+    key.applicationIdentifier = appIdentifier;
     return key;
 }
 
@@ -156,7 +176,7 @@
 
 - (ADTokenCacheKey *)mrrtKey
 {
-    return [[self class] keyWithAuthority:_authority resource:nil clientId:_clientId error:nil];
+    return [[self class] keyWithAuthority:_authority resource:nil clientId:_clientId appIdentifier:nil error:nil];
 }
 
 @end

--- a/ADAL/src/public/ADTokenCacheItem.h
+++ b/ADAL/src/public/ADTokenCacheItem.h
@@ -42,6 +42,8 @@
     NSString* _refreshToken;
     NSData* _sessionKey;
     NSDate* _expiresOn;
+    NSString* _enrollmentId;
+    NSString* _applicationIdentifier;
     ADUserInformation* _userInformation;
     
     // Any extra properties that have been added to ADTokenCacheItem since 2.2,

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -594,6 +594,7 @@
 
 - (BOOL)isCapableForMAMCA
 {
+#if TARGET_OS_IPHONE
     NSString *authority = _requestParams.cloudAuthority ? _requestParams.cloudAuthority : _requestParams.authority;
     __auto_type adfsAuthority = [[MSIDADFSAuthority alloc] initWithURL:[NSURL URLWithString:authority] context:nil error:nil];
     
@@ -605,6 +606,9 @@
     }
     
     return NO;
+#else
+    return NO;
+#endif
 }
 
 - (NSString *)enrollmentIDForHomeAccountID:(NSString *)homeAccountId

--- a/ADAL/src/request/ADAcquireTokenSilentHandler.m
+++ b/ADAL/src/request/ADAcquireTokenSilentHandler.m
@@ -370,6 +370,7 @@
     BOOL enrollmentIdMatch = YES;
     
     // If token is scoped down to a particular enrollmentId and app is capable for True MAM CA, verify that enrollmentIds match
+    // EnrollmentID matching is done on the request layer to ensure that expired access tokens get removed even if valid enrollmentId is not presented
     if ([self isCapableForMAMCA] && ![NSString msidIsStringNilOrBlank:item.enrollmentId])
     {
         enrollmentIdMatch = configuration.enrollmentId && [configuration.enrollmentId isEqualToString:item.enrollmentId];

--- a/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
+++ b/ADAL/src/request/ADAuthenticationRequest+AcquireToken.m
@@ -286,6 +286,7 @@
                                                                             fromRefreshToken:nil
                                                                                        cache:self.tokenCache
                                                                                       params:_requestParams
+                                                                               configuration:_requestParams.msidConfig
                                                                                 verifyUserId:YES];
             completionBlock(result);
         }];
@@ -495,6 +496,7 @@
                                                                                       fromRefreshToken:nil
                                                                                                  cache:self.tokenCache
                                                                                                 params:_requestParams
+                                                                                         configuration:_requestParams.msidConfig
                                                                                           verifyUserId:!_silent];
                       
                       [result setCloudAuthority:_cloudAuthority];

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -249,6 +249,7 @@ NSString *kAdalSDKObjc = @"adal-objc";
                     MSIDLegacyTokenCacheAccessor *cache = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor] factory:factory];
 
                     BOOL saveResult = [cache saveTokensWithBrokerResponse:intuneTokenResponse
+                                                            appIdentifier:[ADRequestParameters applicationIdentifierWithAuthority:intuneTokenResponse.authority]
                                                          saveSSOStateOnly:intuneTokenResponse.isAccessTokenInvalid
                                                                   context:nil
                                                                     error:&tokenResponseError];
@@ -311,6 +312,7 @@ NSString *kAdalSDKObjc = @"adal-objc";
         MSIDLegacyTokenCacheAccessor *cache = [[MSIDLegacyTokenCacheAccessor alloc] initWithDataSource:dataSource otherCacheAccessors:@[otherAccessor] factory:factory];
 
         BOOL saveResult = [cache saveTokensWithBrokerResponse:brokerResponse
+                                                appIdentifier:[ADRequestParameters applicationIdentifierWithAuthority:brokerResponse.authority]
                                              saveSSOStateOnly:brokerResponse.isAccessTokenInvalid
                                                       context:nil
                                                         error:&msidError];

--- a/ADAL/tests/app/resources/ios/Info.plist
+++ b/ADAL/tests/app/resources/ios/Info.plist
@@ -4,6 +4,8 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>ADALOutlook</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
@@ -28,6 +30,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>x-msauth-adaltestapp-210</string>
+				<string>x-msauth-outlook-prod</string>
 			</array>
 		</dict>
 	</array>

--- a/ADAL/tests/app/resources/ios/Info.plist
+++ b/ADAL/tests/app/resources/ios/Info.plist
@@ -4,8 +4,6 @@
 <dict>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
-	<key>CFBundleDisplayName</key>
-	<string>ADALOutlook</string>
 	<key>CFBundleExecutable</key>
 	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleIdentifier</key>
@@ -30,7 +28,6 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>x-msauth-adaltestapp-210</string>
-				<string>x-msauth-outlook-prod</string>
 			</array>
 		</dict>
 	</array>

--- a/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
+++ b/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
@@ -455,6 +455,8 @@
     self.claimsPickerController = [ADTestAppClaimsPickerController alertControllerWithTitle:@"" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     self.claimsPickerController.claimsTextField = _claimsField;
     self.claimsPickerController.claims = @{@"MFA" : @"%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%225ce770ea-8690-4747-aa73-c5b3cd509cd4%22%5D%7D%7D%7D", @"MAM CA" : @"%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%22d77e91f0-fc60-45e4-97b8-14a1337faa28%22%5D%7D%7D%7D", @"DeviceID" : @"%7B%22access_token%22%3A%7B%22deviceid%22%3A%7B%22essential%22%3Atrue%7D%7D%7D"};
+    
+    [[NSUserDefaults standardUserDefaults] setObject:@"{}" forKey:@"intune_mam_resource_V1"];
 }
 
 - (void)keyboardWillShow:(NSNotification *)aNotification

--- a/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
+++ b/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
@@ -455,8 +455,6 @@
     self.claimsPickerController = [ADTestAppClaimsPickerController alertControllerWithTitle:@"" message:nil preferredStyle:UIAlertControllerStyleActionSheet];
     self.claimsPickerController.claimsTextField = _claimsField;
     self.claimsPickerController.claims = @{@"MFA" : @"%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%225ce770ea-8690-4747-aa73-c5b3cd509cd4%22%5D%7D%7D%7D", @"MAM CA" : @"%7B%22access_token%22%3A%7B%22polids%22%3A%7B%22essential%22%3Atrue%2C%22values%22%3A%5B%22d77e91f0-fc60-45e4-97b8-14a1337faa28%22%5D%7D%7D%7D", @"DeviceID" : @"%7B%22access_token%22%3A%7B%22deviceid%22%3A%7B%22essential%22%3Atrue%7D%7D%7D"};
-    
-    [[NSUserDefaults standardUserDefaults] setObject:@"{}" forKey:@"intune_mam_resource_V1"];
 }
 
 - (void)keyboardWillShow:(NSNotification *)aNotification

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -612,6 +612,8 @@ const int sAsyncContextTimeout = 10;
     [self waitForExpectations:@[expectation] timeout:1];
 }
 
+#if TARGET_OS_IPHONE
+
 - (void)testAcquireTokenSilent_whenAccessTokenCached_andEnrollmentIdRequired_andCorrectEnrollmentIdPassed_shouldReturnToken
 {
     [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:[ADEnrollmentGateway getTestEnrollmentIDJSON]];
@@ -763,6 +765,7 @@ const int sAsyncContextTimeout = 10;
     XCTAssertNil(error);
     XCTAssertEqual(allItems.count, 0);
 }
+#endif
 
 - (void)testSilentExpiredItemCached
 {

--- a/ADAL/tests/integration/ADAcquireTokenTests.m
+++ b/ADAL/tests/integration/ADAcquireTokenTests.m
@@ -45,6 +45,7 @@
 #import "ADTokenCacheKey.h"
 #import "MSIDBaseToken.h"
 #import "MSIDAADV1Oauth2Factory.h"
+#import "ADEnrollmentGateway+TestUtil.h"
 
 #if TARGET_OS_IPHONE
 #import "MSIDKeychainTokenCache+MSIDTestsUtil.h"
@@ -55,6 +56,7 @@
 #endif
 #import "ADWebAuthDelegate.h"
 #import "ADUserInformation.h"
+#import "ADEnrollmentGateway+UnitTests.h"
 
 const int sAsyncContextTimeout = 10;
 
@@ -113,6 +115,8 @@ const int sAsyncContextTimeout = 10;
     [super tearDown];
     
     [ADTelemetry sharedInstance].piiEnabled = NO;
+    [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:nil];
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:nil];
 }
 
 - (ADAuthenticationContext *)getTestAuthenticationContext
@@ -606,6 +610,158 @@ const int sAsyncContextTimeout = 10;
      }];
 
     [self waitForExpectations:@[expectation] timeout:1];
+}
+
+- (void)testAcquireTokenSilent_whenAccessTokenCached_andEnrollmentIdRequired_andCorrectEnrollmentIdPassed_shouldReturnToken
+{
+    [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:[ADEnrollmentGateway getTestEnrollmentIDJSON]];
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:[ADEnrollmentGateway getTestResourceJSON]];
+    
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    // Add a token item to return in the cache
+    ADTokenCacheItem* item = [self adCreateCacheItem];
+    item.enrollmentId = @"adf79e3f-mike-454d-9f0f-2299e76dbfd5";
+    item.applicationIdentifier = @"com.microsoft.unittesthost";
+    
+    [self.cacheDataSource addOrUpdateItem:item correlationId:nil error:&error];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         XCTAssertNotNil(result.tokenCacheItem);
+         XCTAssertEqualObjects(result.tokenCacheItem, item);
+         XCTAssertEqualObjects(result.authority, TEST_AUTHORITY);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+}
+
+- (void)testAcquireTokenSilent_whenAccessTokenCached_andEnrollmentIdRequired_andNoEnrollmentIdPassed_shouldReturnNil
+{
+    [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:[ADEnrollmentGateway getTestEnrollmentIDJSON]];
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:[ADEnrollmentGateway getTestResourceJSON]];
+    
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    // Add a token item to return in the cache
+    ADTokenCacheItem* item = [self adCreateCacheItem];
+    item.enrollmentId = @"wrong-enrollmentId";
+    item.applicationIdentifier = @"com.microsoft.unittesthost";
+    item.refreshToken = nil;
+    
+    [self.cacheDataSource addOrUpdateItem:item correlationId:nil error:&error];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_USER_INPUT_NEEDED);
+         XCTAssertNil(result.authority);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+}
+
+- (void)testAcquireTokenSilent_whenExpiredAccessTokenCached_andEnrollmentIdRequired_andCorrectEnrollmentIdPassed_shouldReturnNil
+{
+    [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:[ADEnrollmentGateway getTestEnrollmentIDJSON]];
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:[ADEnrollmentGateway getTestResourceJSON]];
+    
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    // Add a token item to return in the cache
+    ADTokenCacheItem* item = [self adCreateCacheItem];
+    item.enrollmentId = @"adf79e3f-mike-454d-9f0f-2299e76dbfd5";
+    item.expiresOn = [NSDate date];
+    item.applicationIdentifier = @"com.microsoft.unittesthost";
+    item.refreshToken = nil;
+    
+    [self.cacheDataSource addOrUpdateItem:item correlationId:nil error:&error];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_USER_INPUT_NEEDED);
+         XCTAssertNil(result.authority);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // Also verify the expired item has been removed from the cache
+    NSArray* allItems = [self.cacheDataSource allItems:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allItems.count, 0);
+}
+
+- (void)testAcquireTokenSilent_whenExpiredAccessTokenCached_andNoEnrollmentIdProvided_shouldRemoveExpiredToken
+
+{
+    [ADEnrollmentGateway setEnrollmentIdsWithJsonBlob:[ADEnrollmentGateway getTestEnrollmentIDJSON]];
+    [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:[ADEnrollmentGateway getTestResourceJSON]];
+    
+    ADAuthenticationError* error = nil;
+    ADAuthenticationContext* context = [self getTestAuthenticationContext];
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquireTokenSilentWithResource"];
+    
+    // Add a token item to return in the cache
+    ADTokenCacheItem* item = [self adCreateCacheItem];
+    item.enrollmentId = @"wrongenroll";
+    item.expiresOn = [NSDate date];
+    item.applicationIdentifier = @"com.microsoft.unittesthost";
+    item.refreshToken = nil;
+    
+    [self.cacheDataSource addOrUpdateItem:item correlationId:nil error:&error];
+    
+    [context acquireTokenSilentWithResource:TEST_RESOURCE
+                                   clientId:TEST_CLIENT_ID
+                                redirectUri:TEST_REDIRECT_URL
+                                     userId:TEST_USER_ID
+                            completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_FAILED);
+         XCTAssertNotNil(result.error);
+         XCTAssertEqual(result.error.code, AD_ERROR_SERVER_USER_INPUT_NEEDED);
+         XCTAssertNil(result.authority);
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1];
+    
+    // Also verify the expired item has been removed from the cache
+    NSArray* allItems = [self.cacheDataSource allItems:&error];
+    XCTAssertNil(error);
+    XCTAssertEqual(allItems.count, 0);
 }
 
 - (void)testSilentExpiredItemCached
@@ -3401,6 +3557,8 @@ const int sAsyncContextTimeout = 10;
 }
 #endif
 
+#pragma mark - Enrollment ID
+
 - (void)testSilentForceRefresh_whenValidATAndMRRTInCache_shouldSkipCurrentATAndGetNewAT
 {
     ADAuthenticationError *error = nil;
@@ -3586,6 +3744,7 @@ const int sAsyncContextTimeout = 10;
                       }];
 
     [self waitForExpectations:@[expectation1, expectation2] timeout:1.0];
+    
 }
 
 @end

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -46,6 +46,7 @@
 #import "MSIDAADV1Oauth2Factory.h"
 #import "ADEnrollmentGateway.h"
 #import "ADEnrollmentGateway+TestUtil.h"
+#import "ADTokenCacheKey.h"
 
 @interface ADEnrollmentGateway ()
 
@@ -754,7 +755,9 @@
 
     ADLegacyKeychainTokenCache *tokenCache = ADLegacyKeychainTokenCache.defaultKeychainCache;
 
-    XCTAssertEqualObjects([tokenCache getAT:authority], @"i-am-a-access-token");
+    ADTokenCacheKey *accessTokenCacheKey = [ADTokenCacheKey keyWithAuthority:authority resource:TEST_RESOURCE clientId:TEST_CLIENT_ID appIdentifier:@"com.microsoft.unittesthost" error:nil];
+    ADTokenCacheItem *accessTokenCacheItem = [tokenCache getItemWithKey:accessTokenCacheKey userId:TEST_USER_ID correlationId:nil error:nil];
+    XCTAssertEqualObjects(accessTokenCacheItem.accessToken, @"i-am-a-access-token");
     XCTAssertEqualObjects([tokenCache getMRRT:authority], @"i-am-a-refresh-token");
     XCTAssertEqualObjects([tokenCache getFRT:authority], @"i-am-a-refresh-token");
     [ADEnrollmentGateway setIntuneMAMResourceWithJsonBlob:@""];

--- a/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.m
+++ b/ADAL/tests/integration/legacytest/ADLegacyKeychainTokenCache.m
@@ -406,6 +406,7 @@ static ADLegacyKeychainTokenCache* s_defaultCache = nil;
 {
     RETURN_NO_ON_NIL_ARGUMENT(item);
     ADTokenCacheKey* key = [item extractKey:error];
+
     if (!key)
     {
         return NO;
@@ -498,8 +499,15 @@ static ADLegacyKeychainTokenCache* s_defaultCache = nil;
     //The key contains all of the ADAL cache key elements plus the version of the
     //library. The latter is required to ensure that SecItemAdd won't break on collisions
     //with items left over from the previous versions of the library.
+    
+    NSString *servicePrefix = s_libraryString;
+    if (![NSString msidIsStringNilOrBlank:itemKey.applicationIdentifier])
+    {
+        servicePrefix = [servicePrefix stringByAppendingFormat:@"-%@", [itemKey.applicationIdentifier msidBase64UrlEncode]];
+    }
+    
     return [NSString stringWithFormat:@"%@%@%@%@%@%@%@",
-            s_libraryString, s_delimiter,
+            servicePrefix, s_delimiter,
             [itemKey.authority msidBase64UrlEncode], s_delimiter,
             [self.class getAttributeName:itemKey.resource], s_delimiter,
             [itemKey.clientId msidBase64UrlEncode]

--- a/ADAL/tests/unit/ios/ADEnrollmentGateway+UnitTests.h
+++ b/ADAL/tests/unit/ios/ADEnrollmentGateway+UnitTests.h
@@ -22,40 +22,11 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "ADTokenCacheItem.h"
+#import "ADEnrollmentGateway.h"
 
-@class ADAuthenticationError;
-@class ADAuthenticationResult;
+@interface ADEnrollmentGateway ()
 
-@interface ADTokenCacheItem ()
-
-@property (readonly) NSDictionary * additionalServer;
-
-// Intune Enrollment ID. Application trying to retrieve access token from cache will need to present a valid intune enrollment ID to complete cache lookup.
-@property (nonatomic) NSString *enrollmentId;
-
-// Unique app identifier used for cases when access token storage needs to be partitioned per application
-@property (nonatomic) NSString *applicationIdentifier;
-
-@end
-
-@interface ADTokenCacheItem ()
-
-@property NSString *storageAuthority;
-
-@end
-
-@interface ADTokenCacheItem (Internal)
-
-/*!
- This indicates whether the request was executed on a ring serving SPE traffic.
- An empty string indicates this occurred on an outer ring,
- and the string "I" indicated the request occurred on the inner ring.
- */
-@property (readonly) NSString *speInfo;
-
-- (void)logMessage:(NSString *)message
-             level:(MSIDLogLevel)level
-     correlationId:(NSUUID*)correlationId;
++ (void)setEnrollmentIdsWithJsonBlob:(NSString *)enrollmentIds;
++ (void)setIntuneMAMResourceWithJsonBlob:(NSString *)resources;
 
 @end

--- a/ADAL/tests/unit/ios/ADEnrollmentGatewayTests.m
+++ b/ADAL/tests/unit/ios/ADEnrollmentGatewayTests.m
@@ -25,13 +25,7 @@
 #import "XCTestCase+TestHelperMethods.h"
 #import "ADEnrollmentGateway.h"
 #import "ADEnrollmentGateway+TestUtil.h"
-
-@interface ADEnrollmentGateway ()
-
-+ (void)setEnrollmentIdsWithJsonBlob:(NSString *)enrollmentIds;
-+ (void)setIntuneMAMResourceWithJsonBlob:(NSString *)resources;
-
-@end
+#import "ADEnrollmentGateway+UnitTests.h"
 
 @interface ADEnrollmentGatewayTests : ADTestCase
 @end


### PR DESCRIPTION
This is an update to the previous enrollment ID cache implementation.
This one applies it only for ADAL pieces, MSAL and broker updates will come separately.

Enrollment ID is an Intune MAM SDK artifact that's used to differentiate app installation and record the fact that MAM policies have been properly enforced. ADAL and MSAL are passing Intune Enrollment ID to all token requests. If True MAM policies have been applied, ESTS won't return an access token without app providing a valid enrollment ID in the request.
Enrollment ID enforcement works properly unless broker is involved. When broker is involved, access tokens are cached in a shared location, where any authorized app can access them. However, current cache schema doesn't ensure that apps have a valid enrollment ID and that Intune MAM policies are applied.
Additionally, access tokens are cached by clientID, which means that apps sharing the same client ID will be able to read each other's access tokens on iOS through keychain sharing or broker.
Previous design recommended caching each Access token with its own enrollment ID. Additionally, it suggested using enrollment ID as part of the cache key for the access token. This design has been adopted in iOS v2 broker.
However, additional analysis of the previous design has revealed a few issues:
If application's enrollment ID changes, the access token cached by previous enrollment ID will be left in cache without deletion.
There're many entries created in cache for an essentially same access token which introduces additional performance issues when there're many tokens.
This PR is a slight improvement over previous design:

Cache access tokens per physical application bundle ID and verify enrollment ID validity before returning the token.

It addresses the problem of enrollment ID mutability and presence of stale tokens, because it uses immutable application identifier (e.g. bundle Identifier) for token caching.

Common core PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/486