### PR TITLE
Save app token for ADAL 2.7.14

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -321,6 +321,7 @@
 		B267CA1B1EE0E9FF00C0B5A8 /* ADNegotiateHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */; };
 		B267CA1D1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */; };
 		B27552442082EECF00AA7A38 /* libIdentityAutomation iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B27552182082BEB900AA7A38 /* libIdentityAutomation iOS.a */; };
+		B2775F7622FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */; };
 		B2822A2F2055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
 		B2822A302055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
 		B2822A342055DBF900390B6E /* ADLegacyKeychainTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */; };
@@ -345,6 +346,7 @@
 		B2A02CE820F5AEEB0048792D /* ADALAADLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B791CE2012B7A9008D4BD2 /* ADALAADLoginTests.m */; };
 		B2A02CE920F5AEF20048792D /* ADALADFSv4InteractiveLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AACE0420DF2CFF00AC88E2 /* ADALADFSv4InteractiveLoginTests.m */; };
 		B2A02CEA20F5AEF50048792D /* ADALADFSv3InteractiveLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B791D42012C0D6008D4BD2 /* ADALADFSv3InteractiveLoginTests.m */; };
+		B2A17E8C22FE872A0051637E /* ADBrokerApplicationTokenHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */; };
 		B2A409D620D36524004AA9B7 /* ADALiOSMSALCoexistenceCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2A409D520D36524004AA9B7 /* ADALiOSMSALCoexistenceCacheTests.m */; };
 		B2A409E220D36545004AA9B7 /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D626FFC81FBD1B1300EE4487 /* libIdentityCore.a */; };
 		B2A409E320D3654B004AA9B7 /* libIdentityAutomation iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B27552182082BEB900AA7A38 /* libIdentityAutomation iOS.a */; };
@@ -1163,6 +1165,8 @@
 		B26207E022C872DA00F867D9 /* ADEnrollmentGateway+UnitTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "ADEnrollmentGateway+UnitTests.h"; sourceTree = "<group>"; };
 		B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADNegotiateHandler.h; sourceTree = "<group>"; };
 		B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADNegotiateHandler.m; sourceTree = "<group>"; };
+		B2775F7422FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ADBrokerApplicationTokenHelper.h; sourceTree = "<group>"; };
+		B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ADBrokerApplicationTokenHelper.m; sourceTree = "<group>"; };
 		B2822A2C2055D67200390B6E /* ADLegacyMacTokenCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ADLegacyMacTokenCache.h; sourceTree = "<group>"; };
 		B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADLegacyMacTokenCache.m; sourceTree = "<group>"; };
 		B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ADLegacyKeychainTokenCache.m; sourceTree = "<group>"; };
@@ -1924,6 +1928,8 @@
 				9453C37A1C5801CB006B9E79 /* ADBrokerKeyHelper.m */,
 				9453C37B1C5801CB006B9E79 /* ADBrokerNotificationManager.h */,
 				9453C37C1C5801CB006B9E79 /* ADBrokerNotificationManager.m */,
+				B2775F7422FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.h */,
+				B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */,
 			);
 			path = ios;
 			sourceTree = "<group>";
@@ -3466,6 +3472,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2775F7622FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m in Sources */,
 				9699EB972155A80C0049451D /* ADAL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3519,6 +3526,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B2A17E8C22FE872A0051637E /* ADBrokerApplicationTokenHelper.m in Sources */,
 				D6CF4EC81FC376F500CD70C5 /* ADAL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -321,7 +321,6 @@
 		B267CA1B1EE0E9FF00C0B5A8 /* ADNegotiateHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = B267CA191EE0E9FF00C0B5A8 /* ADNegotiateHandler.h */; };
 		B267CA1D1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = B267CA1A1EE0E9FF00C0B5A8 /* ADNegotiateHandler.m */; };
 		B27552442082EECF00AA7A38 /* libIdentityAutomation iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B27552182082BEB900AA7A38 /* libIdentityAutomation iOS.a */; };
-		B2775F7622FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */; };
 		B2822A2F2055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
 		B2822A302055D67200390B6E /* ADLegacyMacTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A2D2055D67200390B6E /* ADLegacyMacTokenCache.m */; };
 		B2822A342055DBF900390B6E /* ADLegacyKeychainTokenCache.m in Sources */ = {isa = PBXBuildFile; fileRef = B2822A312055DBF800390B6E /* ADLegacyKeychainTokenCache.m */; };
@@ -346,7 +345,7 @@
 		B2A02CE820F5AEEB0048792D /* ADALAADLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B791CE2012B7A9008D4BD2 /* ADALAADLoginTests.m */; };
 		B2A02CE920F5AEF20048792D /* ADALADFSv4InteractiveLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2AACE0420DF2CFF00AC88E2 /* ADALADFSv4InteractiveLoginTests.m */; };
 		B2A02CEA20F5AEF50048792D /* ADALADFSv3InteractiveLoginTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B791D42012C0D6008D4BD2 /* ADALADFSv3InteractiveLoginTests.m */; };
-		B2A17E8C22FE872A0051637E /* ADBrokerApplicationTokenHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */; };
+		B2A17EA422FFCA300051637E /* ADBrokerApplicationTokenHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = B2775F7522FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m */; };
 		B2A409D620D36524004AA9B7 /* ADALiOSMSALCoexistenceCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B2A409D520D36524004AA9B7 /* ADALiOSMSALCoexistenceCacheTests.m */; };
 		B2A409E220D36545004AA9B7 /* libIdentityCore.a in Frameworks */ = {isa = PBXBuildFile; fileRef = D626FFC81FBD1B1300EE4487 /* libIdentityCore.a */; };
 		B2A409E320D3654B004AA9B7 /* libIdentityAutomation iOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B27552182082BEB900AA7A38 /* libIdentityAutomation iOS.a */; };
@@ -3472,7 +3471,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2775F7622FE7FC200D7DEB9 /* ADBrokerApplicationTokenHelper.m in Sources */,
 				9699EB972155A80C0049451D /* ADAL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3526,7 +3524,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2A17E8C22FE872A0051637E /* ADBrokerApplicationTokenHelper.m in Sources */,
 				D6CF4EC81FC376F500CD70C5 /* ADAL.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3883,6 +3880,7 @@
 				D664F1A91D302B9C0017B799 /* ADPkeyAuthHelper.m in Sources */,
 				B299FF1A1F22BE32004A2CB9 /* NSString+ADURLExtensions.m in Sources */,
 				D664F1AA1D302B9C0017B799 /* ADAuthenticationParameters+Internal.m in Sources */,
+				B2A17EA422FFCA300051637E /* ADBrokerApplicationTokenHelper.m in Sources */,
 				D664F1AB1D302B9C0017B799 /* ADBrokerNotificationManager.m in Sources */,
 				D664F1AC1D302B9C0017B799 /* ADAuthenticationResult.m in Sources */,
 				E0A4E9701EA8080E008472FF /* ADWorkPlaceJoinConstants.m in Sources */,

--- a/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.h
+++ b/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface ADBrokerApplicationTokenHelper : NSObject
+
+- (instancetype)initWithAccessGroup:(NSString *)accessGroup;
+
+- (BOOL)saveApplicationBrokerToken:(NSString *)token
+                          clientId:(NSString *)clientId;
+
+- (NSString *)getApplicationBrokerTokenForClientId:(NSString *)clientId;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.h
+++ b/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.h
@@ -27,12 +27,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ADBrokerApplicationTokenHelper : NSObject
 
-- (instancetype)initWithAccessGroup:(NSString *)accessGroup;
+- (nullable instancetype)initWithAccessGroup:(NSString *)accessGroup;
 
 - (BOOL)saveApplicationBrokerToken:(NSString *)token
                           clientId:(NSString *)clientId;
 
-- (NSString *)getApplicationBrokerTokenForClientId:(NSString *)clientId;
+- (nullable NSString *)getApplicationBrokerTokenForClientId:(NSString *)clientId;
 
 @end
 

--- a/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.m
@@ -69,7 +69,7 @@
     
     OSStatus err = SecItemUpdate((CFDictionaryRef)keyQuery, (CFDictionaryRef)updateAttributes);
     
-    MSID_LOG_INFO(nil, @"Updating application token");
+    MSID_LOG_INFO(nil, @"Updating application token for clientId %@", clientId);
     
     if (err == errSecItemNotFound)
     {
@@ -84,7 +84,7 @@
     
     if (err != errSecSuccess)
     {
-        MSID_LOG_ERROR(nil, @"Failed to write application token. Application will not have SSO in broker, error %ld", (long)err);
+        MSID_LOG_ERROR(nil, @"Failed to write application token. Application will not have SSO in broker for the next request, write error %ld", (long)err);
         return NO;
     }
     

--- a/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerApplicationTokenHelper.m
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import "ADBrokerApplicationTokenHelper.h"
+#import "MSIDKeychainUtil.h"
+
+@interface ADBrokerApplicationTokenHelper()
+
+@property (nonatomic) NSString *keychainAccessGroup;
+
+@end
+
+@implementation ADBrokerApplicationTokenHelper
+
+- (instancetype)initWithAccessGroup:(NSString *)accessGroup
+{
+    if (!(self = [super init]))
+    {
+        return nil;
+    }
+    
+    if (!accessGroup)
+    {
+        accessGroup = [[NSBundle mainBundle] bundleIdentifier];
+    }
+    
+    if (!MSIDKeychainUtil.teamId)
+    {
+        return nil;
+    }
+    
+    // Add team prefix to keychain group if it is missed.
+    if (![accessGroup hasPrefix:MSIDKeychainUtil.teamId])
+    {
+        accessGroup = [MSIDKeychainUtil accessGroup:accessGroup];
+    }
+    
+    _keychainAccessGroup = accessGroup;
+    
+    return self;
+}
+
+- (BOOL)saveApplicationBrokerToken:(NSString *)token
+                          clientId:(NSString *)clientId
+{
+    NSDictionary *keyQuery = [self applicationTokenQueryWithClientId:clientId];
+    
+    NSDictionary *updateAttributes = @{(id)kSecValueData : [token dataUsingEncoding:NSUTF8StringEncoding]};
+    
+    OSStatus err = SecItemUpdate((CFDictionaryRef)keyQuery, (CFDictionaryRef)updateAttributes);
+    
+    MSID_LOG_INFO(nil, @"Updating application token");
+    
+    if (err == errSecItemNotFound)
+    {
+        MSID_LOG_INFO(nil, @"Application token not found. Saving new one in cache");
+        
+        NSMutableDictionary *mutableKeyQuery = [keyQuery mutableCopy];
+        mutableKeyQuery[(id)kSecAttrAccessible] = (id)kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly;
+        mutableKeyQuery[(id)kSecAttrAccessGroup] = self.keychainAccessGroup;
+        
+        err = SecItemAdd((CFDictionaryRef)mutableKeyQuery, NULL);
+    }
+    
+    if (err != errSecSuccess)
+    {
+        MSID_LOG_ERROR(nil, @"Failed to write application token. Application will not have SSO in broker, error %ld", (long)err);
+        return NO;
+    }
+    
+    return NO;
+}
+
+- (NSString *)getApplicationBrokerTokenForClientId:(NSString *)clientId
+{
+    OSStatus err = noErr;
+    NSDictionary *keyQuery = [self applicationTokenQueryWithClientId:clientId];
+    
+    // Get the key bits.
+    CFDataRef key = nil;
+    err = SecItemCopyMatching((__bridge CFDictionaryRef)keyQuery, (CFTypeRef *)&key);
+    if (err == errSecSuccess)
+    {
+        MSID_LOG_INFO(nil, @"Found a valid application token");
+        NSData *result = (__bridge NSData*)key;
+        CFRelease(key);
+        return [[NSString alloc] initWithData:result encoding:NSUTF8StringEncoding];
+    }
+    
+    MSID_LOG_INFO(nil, @"Didn't find any valid application tokens");
+    
+    return nil;
+}
+
+- (NSDictionary *)applicationTokenQueryWithClientId:(NSString *)clientId
+{
+    return @{
+             (id)kSecClass : (id)kSecClassKey,
+             (id)kSecAttrApplicationTag : [self applicationTokenTagWithClientId:clientId],
+             (id)kSecReturnData : @(YES),
+             (id)kSecAttrAccessGroup : self.keychainAccessGroup
+             };
+}
+
+- (NSData *)applicationTokenTagWithClientId:(NSString *)clientId
+{
+    return [[NSString stringWithFormat:@"msauth-application-token-%@", clientId] dataUsingEncoding:NSUTF8StringEncoding];
+}
+
+@end

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -211,7 +211,6 @@ NSString *kAdalSDKObjc = @"adal-objc";
         
         if (!appTokenSaveResult)
         {
-            // TODO: add error? Reason for failure?
             MSID_LOG_ERROR(nil, @"Failed to save application token");
         }
     }

--- a/ADAL/src/request/ADAuthenticationRequest+Broker.m
+++ b/ADAL/src/request/ADAuthenticationRequest+Broker.m
@@ -357,6 +357,7 @@ NSString *kAdalSDKObjc = @"adal-objc";
 #endif
 }
 
+#if TARGET_OS_IPHONE
 + (void)saveApplicationToken:(NSString *)applicationToken
                keychainGroup:(NSString *)keychainGroup
                     clientId:(NSString *)clientId
@@ -372,6 +373,7 @@ NSString *kAdalSDKObjc = @"adal-objc";
         }
     }
 }
+#endif
 
 - (BOOL)canUseBroker
 {

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -48,6 +48,7 @@
 #import "ADEnrollmentGateway+TestUtil.h"
 #import "ADTokenCacheKey.h"
 #import "ADTokenCacheItem+Internal.h"
+#import "ADBrokerApplicationTokenHelper.h"
 
 @interface ADEnrollmentGateway ()
 
@@ -1031,6 +1032,125 @@
     [context setCredentialsType:AD_CREDENTIALS_AUTO];
     
     return context;
+}
+
+- (void)testBroker_whenReceivedApplicationToken_shouldSendApplicationTokenInNextRequest
+{
+    NSString *authority = @"https://login.windows.net/common";
+    NSString *brokerKey = @"BU-bLN3zTfHmyhJ325A8dJJ1tzrnKMHEfsTlStdMo0U";
+    NSString *redirectUri = @"x-msauth-unittest://com.microsoft.unittesthost";
+    [ADBrokerKeyHelper setSymmetricKey:brokerKey];
+    
+    NSDictionary *expectedRequestParams = @{
+                                            @"authority" : authority,
+                                            @"resource" : TEST_RESOURCE,
+                                            @"username_type" : @"RequiredDisplayableId",
+                                            @"max_protocol_ver" : @"2",
+                                            @"broker_key" : brokerKey,
+                                            @"client_version" : ADAL_VERSION_NSSTRING,
+                                            @"force" : @"NO",
+                                            @"redirect_uri" : redirectUri,
+                                            @"username" : @"",
+                                            @"client_id" : TEST_CLIENT_ID,
+                                            @"correlation_id" : TEST_CORRELATION_ID,
+                                            @"skip_cache" : @"NO",
+                                            @"extra_qp" : @"",
+                                            @"claims" : @"",
+                                            @"intune_enrollment_ids" : @"",
+                                            @"intune_mam_resource" : @"",
+                                            @"client_capabilities": @"",
+                                            @"client_app_name": @"UnitTestHost",
+                                            @"client_app_version": @"1.0",
+                                            @"application_token": @""
+                                            };
+    
+    NSDictionary *responseParams =  @{
+                                      @"authority" : authority,
+                                      @"resource" : TEST_RESOURCE,
+                                      @"client_id" : TEST_CLIENT_ID,
+                                      @"id_token" : [[self adCreateUserInformation:TEST_USER_ID] rawIdToken],
+                                      @"access_token" : @"i-am-a-access-token",
+                                      @"refresh_token" : @"i-am-a-refresh-token",
+                                      @"foci" : @"1",
+                                      @"expires_in" : @"3600",
+                                      @"application_token": @"myapplication-token"
+                                      };
+    
+    [ADApplicationTestUtil onOpenURL:^BOOL(NSURL *url, NSDictionary<NSString *,id> *options) {
+        (void)options;
+        
+        NSDictionary *expectedParams = expectedRequestParams;
+        
+        NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
+        NSURL *expectedURL = [NSURL URLWithString:expectedUrlString];
+        XCTAssertTrue([expectedURL matchesURL:url]);
+        
+        [ADAuthenticationContext handleBrokerResponse:[ADBrokerIntegrationTests createV2BrokerResponse:responseParams redirectUri:redirectUri]];
+        return YES;
+    }];
+    
+    NSArray *metadata = @[ @{ @"preferred_network" : @"login.microsoftonline.com",
+                              @"preferred_cache" : @"login.windows.net",
+                              @"aliases" : @[ @"login.windows.net", @"login.microsoftonline.com"] } ];
+    ADTestURLResponse *validationResponse =
+    [ADTestAuthorityValidationResponse validAuthority:authority
+                                          trustedHost:@"login.windows.net"
+                                         withMetadata:metadata];
+    [ADTestURLSession addResponses:@[validationResponse]];
+    
+    ADAuthenticationContext *context = [self getBrokerTestContext:authority];
+    
+    XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token callback"];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:[NSURL URLWithString:redirectUri]
+                       promptBehavior:AD_PROMPT_ALWAYS
+                               userId:nil
+                 extraQueryParameters:nil
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         
+         XCTAssertEqualObjects(result.tokenCacheItem.accessToken, @"i-am-a-access-token");
+         XCTAssertEqualObjects(result.tokenCacheItem.refreshToken, @"i-am-a-refresh-token");
+         
+         [expectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[expectation] timeout:1.0];
+    
+    // Now send second request
+    
+    [ADApplicationTestUtil onOpenURL:^BOOL(NSURL *url, NSDictionary<NSString *,id> *options) {
+        (void)options;
+        
+        NSMutableDictionary *expectedParams = [expectedRequestParams mutableCopy];
+        expectedParams[@"application_token"] = @"myapplication-token";
+        
+        NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
+        NSURL *expectedURL = [NSURL URLWithString:expectedUrlString];
+        XCTAssertTrue([expectedURL matchesURL:url]);
+        
+        [ADAuthenticationContext handleBrokerResponse:[ADBrokerIntegrationTests createV2BrokerResponse:responseParams redirectUri:redirectUri]];
+        return YES;
+    }];
+    
+    XCTestExpectation *secondRequestExpectation = [self expectationWithDescription:@"acquire token second callback"];
+    [context acquireTokenWithResource:TEST_RESOURCE
+                             clientId:TEST_CLIENT_ID
+                          redirectUri:[NSURL URLWithString:redirectUri]
+                       promptBehavior:AD_PROMPT_ALWAYS
+                               userId:nil
+                 extraQueryParameters:nil
+                      completionBlock:^(ADAuthenticationResult *result)
+     {
+         XCTAssertNotNil(result);
+         XCTAssertEqual(result.status, AD_SUCCEEDED);
+         [secondRequestExpectation fulfill];
+     }];
+    
+    [self waitForExpectations:@[secondRequestExpectation] timeout:1.0];
 }
 
 - (void)testBroker_whenClientCapabilitiesPresent_shouldSucceed

--- a/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
+++ b/ADAL/tests/integration/ios/ADBrokerIntegrationTests.m
@@ -106,7 +106,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
         
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -202,7 +203,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
         
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -302,7 +304,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -381,7 +384,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -474,7 +478,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
         
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -585,7 +590,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
         
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -703,7 +709,8 @@
           @"intune_mam_resource" : intuneResource,
           @"client_capabilities" : @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -796,7 +803,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities": @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -899,7 +907,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities": @"",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];
@@ -1054,7 +1063,8 @@
           @"intune_mam_resource" : @"",
           @"client_capabilities": @"llt",
           @"client_app_name": @"UnitTestHost",
-          @"client_app_version": @"1.0"
+          @"client_app_version": @"1.0",
+          @"application_token": @""
           };
 
         NSString *expectedUrlString = [NSString stringWithFormat:@"msauth://broker?%@", [expectedParams msidWWWFormURLEncode]];


### PR DESCRIPTION
This is intentionally an ADAL only change.
Common core will have common future solution for both ADAL and MSAL.
However, ADAL 2.7.x is not ready to switch to latest common core yet, so putting the fix in place in ADAL for now. 