### PR TITLE
Send refresh token to web view to fix multiple password prompts when interaction is required

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -513,6 +513,33 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     [request acquireToken:@"137" completionBlock:completionBlock];
 }
 
+- (void)acquireTokenInteractiveWithResource:(NSString *)resource
+                        clientId:(NSString *)clientId
+                     redirectUri:(NSURL *)redirectUri
+                  promptBehavior:(ADPromptBehavior)promptBehavior
+                  userIdentifier:(ADUserIdentifier *)userId
+            extraQueryParameters:(NSString *)queryParams
+                          claims:(NSString *)claims
+                 completionBlock:(ADAuthenticationCallback)completionBlock
+{
+    API_ENTRY;
+    REQUEST_WITH_REDIRECT_URL(redirectUri, clientId, resource);
+
+    [request setPromptBehavior:promptBehavior];
+    [request setUserIdentifier:userId];
+    [request setExtraQueryParameters:queryParams];
+    [request setSkipCache:YES];
+
+    ADAuthenticationError *claimsError;
+    if (![request setClaims:claims error:&claimsError])
+    {
+        completionBlock([ADAuthenticationResult resultFromError:claimsError correlationId:_correlationId]);
+        return;
+    }
+
+    [request acquireToken:@"138" completionBlock:completionBlock];
+}
+
 #pragma mark - Private
 
 #if TARGET_OS_IPHONE

--- a/ADAL/src/cache/ADResponseCacheHandler.m
+++ b/ADAL/src/cache/ADResponseCacheHandler.m
@@ -88,7 +88,8 @@
                                   cache:(MSIDLegacyTokenCacheAccessor *)cache
                                  params:(ADRequestParameters *)requestParams
 {
-    if (response.oauthErrorCode == MSIDErrorServerInvalidGrant && refreshToken)
+    NSString *subError = [[msidError userInfo] objectForKey:MSIDOAuthSubErrorKey];
+    if (response.oauthErrorCode == MSIDErrorServerInvalidGrant && refreshToken && (subError == nil || [subError caseInsensitiveCompare:@"consent_required"] != NSOrderedSame))
     {
         NSError *removeError = nil;
 

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -283,6 +283,9 @@ typedef enum
 /*! Enable to return access token with extended lifetime during server outage. */
 @property BOOL extendedLifetimeEnabled;
 
+/*! Enables sending refresh token to the webview when consenting to new scopes without re-entering password.
+ This also causes the auth provider to ignore SSO cookies in the webview and instead use the cached refresh token. */
+@property BOOL useRefreshTokenForWebview;
 /*!
     List of additional ESTS features that client handles.
  */
@@ -519,6 +522,26 @@ typedef enum
                          redirectUri:(nonnull NSURL *)redirectUri
                               userId:(nonnull NSString *)userId
                      completionBlock:(nonnull ADAuthenticationCallback)completionBlock;
+
+/*! Follows the OAuth2 protocol (RFC 6749). The function accepts claims challenge returned from middle tier service, which will be sent to authorization endpoint. ADAL will ignore cache and will not attempt
+ to silently acquire token or return access token from cache. It will get the token through webview.
+ @param resource The resource for whom token is needed.
+ @param clientId The client identifier
+ @param redirectUri The redirect URI according to OAuth2 protocol
+ @param promptBehavior Controls if any credentials UI will be shown.
+ @param userId An ADUserIdentifier object describing the user being authenticated
+ @param queryParams The extra query parameters will be appended to the HTTP request to the authorization endpoint. This parameter can be nil. It should be URL-encoded.
+ @param claims The claims parameter that needs to be sent to authorization endpoint. It should be URL-encoded.
+ @param completionBlock the block to execute upon completion. You can use embedded block, e.g. "^(ADAuthenticationResult res){ <your logic here> }"
+ */
+- (void)acquireTokenInteractiveWithResource:(nonnull NSString *)resource
+                        clientId:(nonnull NSString *)clientId
+                     redirectUri:(nonnull NSURL *)redirectUri
+                  promptBehavior:(ADPromptBehavior)promptBehavior
+                  userIdentifier:(nullable ADUserIdentifier *)userId
+            extraQueryParameters:(nullable NSString *)queryParams
+                          claims:(nullable NSString *)claims
+                 completionBlock:(nonnull ADAuthenticationCallback)completionBlock;
 
 @end
 

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -131,7 +131,7 @@
     MSID_LOG_VERBOSE_PII(_requestParams, @"Requesting authorization code for resource: %@", _requestParams.resource);
 
     NSString *refreshToken = nil;
-    if (_promptBehavior != AD_FORCE_PROMPT && _promptBehavior != AD_PROMPT_ALWAYS && [_context useRefreshTokenForWebview])
+    if (_promptBehavior == AD_PROMPT_AUTO && [_context useRefreshTokenForWebview])
     {
         refreshToken = [self getRefreshTokenForRequest];
     }

--- a/ADAL/src/ui/ADWebAuthController+Internal.h
+++ b/ADAL/src/ui/ADWebAuthController+Internal.h
@@ -35,6 +35,7 @@
 // the authentication process.
 + (void)startWithRequest:(ADRequestParameters *)requestParams
           promptBehavior:(ADPromptBehavior)promptBehavior
+            refreshToken:(NSString*)refreshToken
                  context:(ADAuthenticationContext *)context
               completion:(MSIDWebviewAuthCompletionHandler)completionHandler;
 

--- a/ADAL/src/ui/ADWebAuthController.m
+++ b/ADAL/src/ui/ADWebAuthController.m
@@ -54,6 +54,10 @@ NSString* ADWebAuthDidReceieveResponseFromBroker = @"ADWebAuthDidReceiveResponse
 
 NSString* ADWebAuthWillSwitchToBrokerApp = @"ADWebAuthWillSwitchToBrokerApp";
 
+NSString* ADWebAuthIgnoreSSOHeader = @"x-ms-sso-Ignore-SSO";
+
+NSString* ADWebAuthRefreshTokenHeader = @"x-ms-sso-RefreshToken";
+
 // Private interface declaration
 @interface ADWebAuthController ()
 @end
@@ -94,6 +98,7 @@ static ADAuthenticationResult *s_result = nil;
 
 + (void)startWithRequest:(ADRequestParameters *)requestParams
           promptBehavior:(ADPromptBehavior)promptBehavior
+            refreshToken:(NSString*)refreshToken
                  context:(ADAuthenticationContext *)context
               completion:(MSIDWebviewAuthCompletionHandler)completionHandler
 {
@@ -138,6 +143,15 @@ static ADAuthenticationResult *s_result = nil;
     webviewConfig.parentController = context.parentController;
     webviewConfig.presentationType = ADAuthenticationSettings.sharedInstance.webviewPresentationStyle;
 #endif
+
+    if ([context useRefreshTokenForWebview])
+    {
+        [[webviewConfig customHeaders] setObject:@"1" forKey:ADWebAuthIgnoreSSOHeader];
+        if (![NSString msidIsStringNilOrBlank:refreshToken])
+        {
+            [[webviewConfig customHeaders] setObject:refreshToken forKey:ADWebAuthRefreshTokenHeader];
+        }
+    }
 
     [MSIDWebviewAuthorization startEmbeddedWebviewAuthWithConfiguration:webviewConfig
                                                           oauth2Factory:context.oauthFactory

--- a/ADAL/tests/util/ADTestWebAuthController.m
+++ b/ADAL/tests/util/ADTestWebAuthController.m
@@ -30,6 +30,7 @@
 
 + (void)startWithRequest:(ADRequestParameters *)requestParams
           promptBehavior:(ADPromptBehavior)promptBehavior
+            refreshToken:(NSString*)refreshToken
                  context:(ADAuthenticationContext *)context
               completion:(MSIDWebviewAuthCompletionHandler)completionHandler
 {


### PR DESCRIPTION
In the case consent or MFA is required to access a new resource ADAL SDK prompts user to re-enter the password even though the user has already entered a password and attained a valid refresh token previously. This change will enable sending the refresh token to WKWebView so that it can be used to directly show the prompt required. The client application will need to explicitly enable -[ADAuthenticationContext useRefreshTokenForWebview] to use this new feature, which has the side effect of disabling cookie auth that WKWebView may have persisted. It will use the refresh token instead. Only session cookies were used in previous implementation, so when the application closes cookies are lost. x-ms-sso-Ignore-SSO needs to have been used when acquiring the refresh token to bypass future password prompts.

**Testing**

- Tested setting useRefreshTokenForWebview to YES in the test app, then acquiring a token for OneDrive using interactive flow, I could then restart the test app and acquire a token for OneDrive using the interactive flow.

- Tested both family refresh token and refresh token without a family id work. 

- AD_PROMPT_ALWAYS and AD_FORCE_PROMPT append &prompt=login to the querystring which forces user to enter password again. We do not send the refresh token in this case for performance.

- Tested MFA scenario with claims and consent scenario by passing AD_PROMPT_AUTO after initially acquiring refresh token to https://api.office.com/discovery.

- Tested iOS/Mac using the test app.

- Tested useRefreshTokenForWebview set to NO reverts to the previous behavior without sending refresh token.
