### PR TITLE
Enable dogfood authenticator support by default

### DIFF
--- a/ADAL/src/ADALConstants.h
+++ b/ADAL/src/ADALConstants.h
@@ -50,4 +50,4 @@ extern NSString* const ADAL_BROKER_SCHEME;
 extern NSString* const ADAL_BROKER_NONCE_SCHEME;
 extern NSString* const ADAL_BROKER_APP_REDIRECT_URI;
 extern NSString* const ADAL_BROKER_APP_BUNDLE_ID;
-
+extern NSString* const ADAL_BROKER_APP_BUNDLE_ID_DOGFOOD;

--- a/ADAL/src/ADALConstants.m
+++ b/ADAL/src/ADALConstants.m
@@ -52,4 +52,5 @@ NSString* const ADAL_BROKER_SCHEME = @"msauth";
 NSString* const ADAL_BROKER_NONCE_SCHEME = @"msauthv3";
 NSString* const ADAL_BROKER_APP_REDIRECT_URI = @"urn:ietf:wg:oauth:2.0:oob";
 NSString* const ADAL_BROKER_APP_BUNDLE_ID = @"com.microsoft.azureauthenticator";
+NSString* const ADAL_BROKER_APP_BUNDLE_ID_DOGFOOD = @"com.microsoft.azureauthenticator-df";
 

--- a/ADAL/src/ADAuthenticationContext+Internal.m
+++ b/ADAL/src/ADAuthenticationContext+Internal.m
@@ -215,11 +215,8 @@ NSString* const ADRedirectUriInvalidError = @"Your AuthenticationContext is conf
 + (BOOL)isResponseFromBroker:(NSString *)sourceApplication
                     response:(NSURL *)response
 {
-    BOOL isBroker = [sourceApplication isEqualToString:ADAL_BROKER_APP_BUNDLE_ID];
-    
-#ifdef DOGFOOD_BROKER
-    isBroker = isBroker || [sourceApplication isEqualToString:ADAL_BROKER_APP_BUNDLE_ID_DOGFOOD];
-#endif
+    BOOL isBroker = [sourceApplication isEqualToString:ADAL_BROKER_APP_BUNDLE_ID]
+                    || [sourceApplication isEqualToString:ADAL_BROKER_APP_BUNDLE_ID_DOGFOOD];
     
     return response && isBroker;
 }


### PR DESCRIPTION
This change enables dogfood broker support without app having to do custom configuration. This will ensure that all Microsoft apps have support for it by default.