### PR TITLE
Fixed parent controller logic

### DIFF
--- a/ADAL/src/ui/ios/ADAuthenticationViewController.m
+++ b/ADAL/src/ui/ios/ADAuthenticationViewController.m
@@ -39,6 +39,8 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
     id _foregroundObserver;
 }
 
+@property (nonatomic) BOOL presentInParentController;
+
 @end
 
 @implementation ADAuthenticationViewController
@@ -62,6 +64,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
     // hijack the delegate on the webview.
     if (_webView)
     {
+        self.presentInParentController = NO;
         _webView.delegate = self;
         return YES;
     }
@@ -107,6 +110,8 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
                                                                                   target:self
                                                                                   action:@selector(onCancel:)];
     self.navigationItem.leftBarButtonItem = cancelButton;
+    
+    self.presentInParentController = YES;
 
     return YES;
 }
@@ -137,7 +142,7 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 
     //if webview is created by us, dismiss and then complete and return;
     //otherwise just complete and return.
-    if (_parentController)
+    if (_parentController && self.presentInParentController)
     {
         if (_parentController.parentViewController && _parentController.presentedViewController)
         {
@@ -161,6 +166,8 @@ NSString *const AD_FAILED_NO_CONTROLLER = @"The Application does not have a curr
 - (void)startRequest:(NSURLRequest *)request
 {
     [self loadRequest:request];
+    
+    if (!self.presentInParentController) return;
 
     UINavigationController *navController = [[UINavigationController alloc] initWithRootViewController:self];
 

--- a/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
+++ b/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
@@ -644,6 +644,7 @@
                                                                         validateAuthority:validateAuthority
                                                                                     error:&error];
     context.clientCapabilities = capabilities;
+    context.parentController = self;
 
     if (!context)
     {


### PR DESCRIPTION
Fixing an issue where setting both parent controller and webview for ADAL 2.7.x results in unexpected behavior (we display an empty navigation controller, and user is blocked). 