### PR TITLE
Fix a bug when setting parentcontroller and webview

### DIFF
--- a/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
+++ b/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
@@ -651,6 +651,7 @@
                                                                         validateAuthority:validateAuthority
                                                                                     error:&error];
     context.clientCapabilities = capabilities;
+    context.parentController = self;
 
     if (!context)
     {


### PR DESCRIPTION
Fixing an issue where setting both parent controller and webview for ADAL 4.0.x results in unexpected behavior (we display an empty navigation controller, and user is blocked).