### PR TITLE
Remove ADAL SHA-1 dependency

### DIFF
--- a/ADAL/src/broker/ios/ADBrokerKeyHelper.m
+++ b/ADAL/src/broker/ios/ADBrokerKeyHelper.m
@@ -329,7 +329,7 @@ static const uint8_t symmetricKeyIdentifier[]   = kSymmetricKeyTag;
     }
 
     //now compute the hash on the unencrypted data
-    NSString *actualHash = [MSIDPkeyAuthHelper computeThumbprint:decrypted isSha2:YES];
+    NSString *actualHash = [MSIDPkeyAuthHelper computeThumbprint:decrypted];
     if(![hash isEqualToString:actualHash])
     {
         AUTH_ERROR(AD_ERROR_TOKENBROKER_RESPONSE_HASH_MISMATCH, @"Decrypted response does not match the hash", correlationId);

--- a/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
+++ b/ADAL/src/request/ADAuthenticationRequest+WebRequest.m
@@ -114,7 +114,7 @@
             }
         }
 
-        MSID_LOG_VERBOSE(_requestParams, @"Retrieve refresh token from cache for web view: %@, error code: %ld", _PII_NULLIFY(refreshTokenItem), refreshTokenError.code);
+        MSID_LOG_VERBOSE(_requestParams, @"Retrieve refresh token from cache for web view: %@, error code: %ld", _PII_NULLIFY(refreshTokenItem), (long)refreshTokenError.code);
         return [refreshTokenItem refreshToken];
     }
 


### PR DESCRIPTION
Use of SHA-1 is not permitted in production code anymore by SDL (it hasn't been for years and getting exception has become increasingly difficult). Hash collisions are computationally feasible for these algorithms, which effectively "breaks" them.

There were two scenarios where our libraries took dependency on SHA-1 protocols:

1. PKeyAuth response when server provides CertificateThumbrint. This is only supported by ADFS and not supported by AAD. It is not feasible to update older versions of ADFS to get rid of SHA-1 dependency. However, it is confirmed by ADFS that thumbprint is only meant to be used as a hint. Since it is SHA-1 thumbprint and it is not meant to be used as a reliable thumbprint by any production code, this code is now removed and certificate is sent to ADFS for final validation.

2. Client credential request for automation token requests. This is not production code and sha-1 can be used there.