### PR TITLE
Remove ADTokenCache.h dependency from iOS library since that header only exists on macOS

### DIFF
--- a/ADAL/src/ADAuthenticationContext.m
+++ b/ADAL/src/ADAuthenticationContext.m
@@ -22,11 +22,13 @@
 // THE SOFTWARE.
 
 #import "ADAuthenticationSettings.h"
-#import "ADTokenCache+Internal.h"
 #import "ADRequestParameters.h"
 #if TARGET_OS_IPHONE
 #import "ADKeychainTokenCache+Internal.h"
 #import "MSIDKeychainTokenCache.h"
+#else
+#import "ADTokenCache.h"
+#import "ADTokenCache+Internal.h"
 #endif 
 
 #import "ADAuthenticationContext+Internal.h"
@@ -42,7 +44,6 @@
 #import "MSIDMacTokenCache.h"
 #import "MSIDLegacyTokenCacheAccessor.h"
 #import "MSIDDefaultTokenCacheAccessor.h"
-#import "ADTokenCache.h"
 #import "MSIDAADV1Oauth2Factory.h"
 
 // This variable is purposefully a global so that way we can more easily pull it out of the
@@ -53,8 +54,10 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
 @interface ADAuthenticationContext()
 
 @property (nonatomic) MSIDLegacyTokenCacheAccessor *tokenCache;
+#if !TARGET_OS_IPHONE
 // It is used only for delegate proxy purposes between legacy mac delegate and msdi mac delegate.
 @property (nonatomic) ADTokenCache *legacyMacCache;
+#endif
 // iOS keychain group.
 @property (nonatomic) NSString *sharedGroup;
 

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -29,10 +29,10 @@
 @class ADUserInformation;
 @class ADUserIdentifier;
 @class UIViewController;
-@class ADTokenCache;
 @class WKWebView;
 
 #if !TARGET_OS_IPHONE
+@class ADTokenCache;
 @protocol ADTokenCacheDelegate;
 #endif
 

--- a/ADAL/src/public/ADAuthenticationSettings.h
+++ b/ADAL/src/public/ADAuthenticationSettings.h
@@ -23,7 +23,9 @@
 
 #import <Foundation/Foundation.h>
 
+#if !TARGET_OS_IPHONE
 @protocol ADTokenCacheDelegate;
+#endif
 
 /*! The class stores global settings for the ADAL library. It is a singleton class
  and the alloc, init and new should not be called directly. The "sharedInstance" selector


### PR DESCRIPTION
See here for more details: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/issues/689