### PR TITLE
[ADAL 2.x] Fixed authority aliases for custom authorities

### DIFF
--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -185,6 +185,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     {
         // Validate AAD authority
         [self validateAADAuthority:authorityURL
+                 validateAuthority:validateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -203,6 +204,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 // If the authority is known, the server will set the "tenant_discovery_endpoint" parameter in the response.
 // The method should be executed on a thread that is guarranteed to exist upon completion, e.g. the UI thread.
 - (void)validateAADAuthority:(NSURL *)authority
+           validateAuthority:(BOOL)validateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -224,6 +226,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
         __block dispatch_semaphore_t dsem = dispatch_semaphore_create(0);
         
         [self requestAADValidation:authority
+                 validateAuthority:validateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -254,6 +257,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 }
 
 - (void)requestAADValidation:(NSURL *)authorityUrl
+           validateAuthority:(BOOL)validateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -277,7 +281,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     
     NSString *trustedHost = ADTrustedAuthorityWorldWide;
     
-    if ([ADAuthorityUtils isKnownHost:authority.url])
+    if ([ADAuthorityUtils isKnownHost:authority.url] || !validateAuthority)
     {
         trustedHost = authority.environment;
     }

--- a/ADAL/tests/ADTestAuthorityValidationResponse.h
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.h
@@ -34,7 +34,7 @@
                           trustedHost:(NSString *)trustedHost
                          withMetadata:(NSArray *)metadata;
 
-+ (ADTestURLResponse*)invalidAuthority:(NSString *)authority;
++ (ADTestURLResponse *)invalidAuthority:(NSString *)authority validationEnabled:(BOOL)validationEnabled;
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority
                            trustedHost:(NSString *)trustedHost;
 

--- a/ADAL/tests/ADTestAuthorityValidationResponse.m
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.m
@@ -63,9 +63,10 @@
     return response;
 }
 
-+ (ADTestURLResponse *)invalidAuthority:(NSString *)authority
++ (ADTestURLResponse *)invalidAuthority:(NSString *)authority validationEnabled:(BOOL)validationEnabled
 {
-    return [self invalidAuthority:authority trustedHost:DEFAULT_TRUSTED_HOST];
+    NSString *trustedHost = validationEnabled ? DEFAULT_TRUSTED_HOST : [NSURL URLWithString:authority].host;
+    return [self invalidAuthority:authority trustedHost:trustedHost];
 }
 
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority

--- a/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
@@ -162,7 +162,7 @@
     requestParams.authority = authority;
     requestParams.correlationId = [NSUUID UUID];
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:YES]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
     [authorityValidation checkAuthority:requestParams
@@ -194,7 +194,7 @@
     requestParams.authority = authority;
     requestParams.correlationId = [NSUUID UUID];
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:NO]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
     [authorityValidation checkAuthority:requestParams
@@ -228,7 +228,7 @@
     XCTAssertNotNil(context);
     XCTAssertNil(error);
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:YES]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"acquireTokenWithResource: with invalid authority."];
     [context acquireTokenWithResource:TEST_RESOURCE
@@ -284,7 +284,7 @@
                   newAccessToken:updatedAT
                       newIDToken:[self adDefaultIDToken]
                 additionalFields:@{ @"foci" : @"1" }];
-    [ADTestURLSession addResponses:@[[ADTestAuthorityValidationResponse invalidAuthority:authority],
+    [ADTestURLSession addResponses:@[[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:NO],
                                      tokenResponse]];
 
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token"];
@@ -510,7 +510,7 @@
     NSArray *metadata = @[ @{ @"preferred_network" : @"login.contoso.net",
                               @"preferred_cache" : @"login.contoso.com",
                               @"aliases" : @[ @"login.contoso.net", @"login.contoso.com"] } ];
-    ADTestURLResponse *validationResponse = [ADTestAuthorityValidationResponse validAuthority:authority withMetadata:metadata];
+    ADTestURLResponse *validationResponse = [ADTestAuthorityValidationResponse validAuthority:authority trustedHost:@"login.contoso.com" withMetadata:metadata];
     ADTestURLResponse *tokenResponse = [self adResponseRefreshToken:TEST_REFRESH_TOKEN
                                                           authority:preferredAuthority
                                                            resource:TEST_RESOURCE


### PR DESCRIPTION
## Proposed changes

There's currently a problem when developer declares a custom AAD authority, because it would still go to login.microsoftonline.com to download the aliases instead of using actual authority host. If login.microsoftonline.com is unavailable, this would cause failures for validation.
Since developer explicitly declared authority as known and trusted, it is fine to go to actual authority for validation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
