### PR TITLE
[ADAL 4.x] Fixed validation for custom AAD authorities

### DIFF
--- a/ADAL.podspec
+++ b/ADAL.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.name         = "ADAL"
   s.module_name  = "ADAL"
-  s.version      = "4.0.7"
+  s.version      = "4.0.8"
   s.summary      = "The ADAL SDK for iOS gives you the ability to add Azure Identity authentication to your application"
 
   s.description  = <<-DESC

--- a/ADAL/resources/ios/Framework/Info.plist
+++ b/ADAL/resources/ios/Framework/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.7</string>
+	<string>4.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/ADAL/src/ADAL_Internal.h
+++ b/ADAL/src/ADAL_Internal.h
@@ -28,7 +28,7 @@
 
 #define ADAL_VER_HIGH       4
 #define ADAL_VER_LOW        0
-#define ADAL_VER_PATCH      7
+#define ADAL_VER_PATCH      8
 
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -185,7 +185,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     {
         // Validate AAD authority
         [self validateAADAuthority:authorityURL
-                 validateAuthority:validateAuthority
+           shouldValidateAuthority:validateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -204,7 +204,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 // If the authority is known, the server will set the "tenant_discovery_endpoint" parameter in the response.
 // The method should be executed on a thread that is guarranteed to exist upon completion, e.g. the UI thread.
 - (void)validateAADAuthority:(NSURL *)authority
-           validateAuthority:(BOOL)validateAuthority
+     shouldValidateAuthority:(BOOL)shouldValidateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -227,7 +227,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
         __block dispatch_semaphore_t dsem = dispatch_semaphore_create(0);
         
         [self requestAADValidation:authority
-                 validateAuthority:validateAuthority
+           shouldValidateAuthority:shouldValidateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -258,7 +258,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 }
 
 - (void)requestAADValidation:(NSURL *)authorityUrl
-           validateAuthority:(BOOL)validateAuthority
+     shouldValidateAuthority:(BOOL)shouldValidateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -282,7 +282,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     
     NSString *trustedHost = ADTrustedAuthorityWorldWide;
     
-    if ([ADAuthorityUtils isKnownHost:authority.url] || !validateAuthority)
+    if ([ADAuthorityUtils isKnownHost:authority.url] || !shouldValidateAuthority)
     {
         trustedHost = authority.environment;
     }

--- a/ADAL/src/validation/ADAuthorityValidation.m
+++ b/ADAL/src/validation/ADAuthorityValidation.m
@@ -185,6 +185,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     {
         // Validate AAD authority
         [self validateAADAuthority:authorityURL
+                 validateAuthority:validateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -203,6 +204,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 // If the authority is known, the server will set the "tenant_discovery_endpoint" parameter in the response.
 // The method should be executed on a thread that is guarranteed to exist upon completion, e.g. the UI thread.
 - (void)validateAADAuthority:(NSURL *)authority
+           validateAuthority:(BOOL)validateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -225,6 +227,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
         __block dispatch_semaphore_t dsem = dispatch_semaphore_create(0);
         
         [self requestAADValidation:authority
+                 validateAuthority:validateAuthority
                      requestParams:requestParams
                    completionBlock:^(BOOL validated, ADAuthenticationError *error)
          {
@@ -255,6 +258,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
 }
 
 - (void)requestAADValidation:(NSURL *)authorityUrl
+           validateAuthority:(BOOL)validateAuthority
                requestParams:(ADRequestParameters *)requestParams
              completionBlock:(ADAuthorityValidationCallback)completionBlock
 {
@@ -278,7 +282,7 @@ static NSString* const s_kWebFingerError               = @"WebFinger request was
     
     NSString *trustedHost = ADTrustedAuthorityWorldWide;
     
-    if ([ADAuthorityUtils isKnownHost:authority.url])
+    if ([ADAuthorityUtils isKnownHost:authority.url] || !validateAuthority)
     {
         trustedHost = authority.environment;
     }

--- a/ADAL/tests/ADTestAuthorityValidationResponse.h
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.h
@@ -30,11 +30,12 @@
 + (ADTestURLResponse*)validAuthority:(NSString *)authority;
 + (ADTestURLResponse *)validAuthority:(NSString *)authority
                          withMetadata:(NSArray *)metadata;
+
 + (ADTestURLResponse *)validAuthority:(NSString *)authority
                           trustedHost:(NSString *)trustedHost
                          withMetadata:(NSArray *)metadata;
 
-+ (ADTestURLResponse*)invalidAuthority:(NSString *)authority;
++ (ADTestURLResponse *)invalidAuthority:(NSString *)authority validationEnabled:(BOOL)validationEnabled;
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority
                            trustedHost:(NSString *)trustedHost;
 

--- a/ADAL/tests/ADTestAuthorityValidationResponse.m
+++ b/ADAL/tests/ADTestAuthorityValidationResponse.m
@@ -63,9 +63,10 @@
     return response;
 }
 
-+ (ADTestURLResponse *)invalidAuthority:(NSString *)authority
++ (ADTestURLResponse *)invalidAuthority:(NSString *)authority validationEnabled:(BOOL)validationEnabled
 {
-    return [self invalidAuthority:authority trustedHost:DEFAULT_TRUSTED_HOST];
+    NSString *trustedHost = validationEnabled ? DEFAULT_TRUSTED_HOST : [NSURL URLWithString:authority].host;
+    return [self invalidAuthority:authority trustedHost:trustedHost];
 }
 
 + (ADTestURLResponse*)invalidAuthority:(NSString *)authority

--- a/ADAL/tests/app/resources/ios/Info.plist
+++ b/ADAL/tests/app/resources/ios/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.7</string>
+	<string>4.0.8</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleURLTypes</key>

--- a/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
+++ b/ADAL/tests/integration/AADAuthorityValidationIntegrationTests.m
@@ -162,7 +162,7 @@
     requestParams.authority = authority;
     requestParams.correlationId = [NSUUID UUID];
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:YES]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
     [authorityValidation checkAuthority:requestParams
@@ -194,7 +194,7 @@
     requestParams.authority = authority;
     requestParams.correlationId = [NSUUID UUID];
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:NO]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"Validate invalid authority."];
     [authorityValidation checkAuthority:requestParams
@@ -228,7 +228,7 @@
     XCTAssertNotNil(context);
     XCTAssertNil(error);
 
-    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority]];
+    [ADTestURLSession addResponse:[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:YES]];
 
     XCTestExpectation* expectation = [self expectationWithDescription:@"acquireTokenWithResource: with invalid authority."];
     [context acquireTokenWithResource:TEST_RESOURCE
@@ -284,7 +284,7 @@
                   newAccessToken:updatedAT
                       newIDToken:[self adDefaultIDToken]
                 additionalFields:@{ @"foci" : @"1" }];
-    [ADTestURLSession addResponses:@[[ADTestAuthorityValidationResponse invalidAuthority:authority],
+    [ADTestURLSession addResponses:@[[ADTestAuthorityValidationResponse invalidAuthority:authority validationEnabled:NO],
                                      tokenResponse]];
 
     __block XCTestExpectation *expectation = [self expectationWithDescription:@"acquire token"];
@@ -510,7 +510,7 @@
     NSArray *metadata = @[ @{ @"preferred_network" : @"login.contoso.net",
                               @"preferred_cache" : @"login.contoso.com",
                               @"aliases" : @[ @"login.contoso.net", @"login.contoso.com"] } ];
-    ADTestURLResponse *validationResponse = [ADTestAuthorityValidationResponse validAuthority:authority withMetadata:metadata];
+    ADTestURLResponse *validationResponse = [ADTestAuthorityValidationResponse validAuthority:authority trustedHost:@"login.contoso.com" withMetadata:metadata];
     ADTestURLResponse *tokenResponse = [self adResponseRefreshToken:TEST_REFRESH_TOKEN
                                                           authority:preferredAuthority
                                                            resource:TEST_RESOURCE


### PR DESCRIPTION
## Proposed changes

There's currently a problem when developer declares a custom AAD authority, because it would still go to login.microsoftonline.com to download the aliases instead of using actual authority host. If login.microsoftonline.com is unavailable, this would cause failures for validation.
Since developer explicitly declared authority as known and trusted, it is fine to go to actual authority for validation.

## Type of change

- [ ] Feature work
- [x] Bug fix
- [ ] Documentation
- [ ] Engineering change
- [ ] Test
- [ ] Logging/Telemetry

## Risk

- [ ] High – Errors could cause MAJOR regression of many scenarios. (Example: new large features or high level infrastructure changes)
- [x] Medium – Errors could cause regression of 1 or more scenarios. (Example: somewhat complex bug fixes, small new features)
- [ ] Small – No issues are expected. (Example: Very small bug fixes, string changes, or configuration settings changes)
