### PR TITLE
new release with  WPJChallenge & PKeyAuth updates on the iOS side

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ Version 4.0.9 (06.16.2020)
 ------
 * Stop sending x-client-last-* headers.
 * Improve logging.
-* Disabled WPJChallenge on iOS and also added "PKeyAuth/1.0" keyword to the User Agent string in the HTTP Header on iOS as an alternate way to enable PKeyAuth Challenge on iOS.
+* Disabled WPJChallenge on iOS and also added "PKeyAuth/1.0" keyword to the User Agent string in the HTTP Header on iOS as an alternate way to enable PKeyAuth Challenge on iOS (functionality verified with a test account with device proof CA policy)
 
 Version 4.0.8 (05.16.2020)
 ------


### PR DESCRIPTION
The purpose of this PR is to disable WPJ Challenge on iOS and also to add "PKeyAuth/1.0" keyword to the User Agent field in the HTTP header to enable PKeyAuth challenge during the embedded webview initialization/configuration stage.

There is a known issue where Apple has a bug in iOS about WKWebview handling NSURLAuthenticationMethodClientCertificate.
It swallows the challenge response rather than sending it to server. Therefore, WPJ Challenge needs to be disabled on iOS at the moment.

Also, passing in the x-ms-PkeyAuth field in the HTTP header doesn't work for the scenario where the user is first directed to Microsoft sign-in page and then redirected to another adfs sign in page.
ex:

User opens ADAL test app and then attempts to acquire token using OneDrive or Office profile.
user is redirected to Office356 login page (login.microsoft.com)
3)user types in the user id - test@unisys.com
4)user is then redirected to (adfs.unisys.com)
Embedded webview is initialized during step 1, and "x-ms-PkeyAuth" field is added to the HTTP request header.
However, when the user makes it to step 4, "x-ms-PkeyAuth" field is lost by then.

This issue can be addressed by appending "PKeyAuth/1.0" keyword to the User Agent string in the HTTP header during the embedded webview initialization/configuration stage. This complies with the PKeyAuth spec and also has been shown to retain the keyword in the User-Agent string field from step 1 through step 4. I have also verified that having the keyword in the User Agent string triggers PKeyAuth challenge using a test account that has device proof CA policy.

https://portal.microsofticm.com/imp/v3/incidents/details/200672947/home

Related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/832