### PR TITLE
added public APIs to change WKWebViewConfig

### DIFF
--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -26,6 +26,7 @@
 #import "ADAuthenticationSettings.h"
 #import "ADWebRequest.h"
 #import "ADWebResponse.h"
+#import "MSIDWebviewUIController.h"
 
 @implementation ADAuthenticationParameters
 

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -150,5 +150,14 @@
     return parameters;
 }
 
+#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
+
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
+{
+    return [MSIDWebviewUIController defaultWKWebviewConfiguration];
+}
+
+#endif
+
 
 @end

--- a/ADAL/src/ADAuthenticationParameters.m
+++ b/ADAL/src/ADAuthenticationParameters.m
@@ -150,14 +150,9 @@
     return parameters;
 }
 
-#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
-
 + (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
     return [MSIDWebviewUIController defaultWKWebviewConfiguration];
 }
-
-#endif
-
 
 @end

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -23,6 +23,8 @@
 
 #import "ADTokenCacheDataSource.h"
 #import "MSIDRequestContext.h"
+#import "MSIDWorkPlaceJoinConstants.h"
+#import <WebKit/WebKit.h>
 
 @class MSIDConfiguration;
 @class MSIDAccountIdentifier;
@@ -55,5 +57,12 @@
 
 - (NSString *)enrollmentIDForHomeAccountID:(NSString *)homeAccountId
                               legacyUserID:(NSString *)legacyUserID;
+
+#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
+
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
+
+#endif
+
 
 @end

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -23,7 +23,6 @@
 
 #import "ADTokenCacheDataSource.h"
 #import "MSIDRequestContext.h"
-#import "MSIDWebviewUIController.h"
 
 @class MSIDConfiguration;
 @class MSIDAccountIdentifier;
@@ -56,12 +55,5 @@
 
 - (NSString *)enrollmentIDForHomeAccountID:(NSString *)homeAccountId
                               legacyUserID:(NSString *)legacyUserID;
-
-#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
-
-+ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
-
-#endif
-
 
 @end

--- a/ADAL/src/ADRequestParameters.h
+++ b/ADAL/src/ADRequestParameters.h
@@ -23,8 +23,7 @@
 
 #import "ADTokenCacheDataSource.h"
 #import "MSIDRequestContext.h"
-#import "MSIDWorkPlaceJoinConstants.h"
-#import <WebKit/WebKit.h>
+#import "MSIDWebviewUIController.h"
 
 @class MSIDConfiguration;
 @class MSIDAccountIdentifier;
@@ -60,7 +59,7 @@
 
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
 
-+ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent;
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration;
 
 #endif
 

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -204,4 +204,19 @@
     return enrollId;
 }
 
+#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
+
++ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
+{
+    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
+    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
+    
+    if (@available(iOS 13.0, *))
+    {
+        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
+    }
+    return webConfig;
+}
+
+#endif
 @end

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -204,12 +204,4 @@
     return enrollId;
 }
 
-#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
-
-+ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
-{
-    return [MSIDWebviewUIController defaultWKWebviewConfiguration];
-}
-
-#endif
 @end

--- a/ADAL/src/ADRequestParameters.m
+++ b/ADAL/src/ADRequestParameters.m
@@ -206,16 +206,9 @@
 
 #if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
 
-+ (WKWebViewConfiguration *)createWebViewConfigWithPKeyAuthUserAgent
++ (WKWebViewConfiguration *)defaultWKWebviewConfiguration
 {
-    WKWebViewConfiguration *webConfig = [WKWebViewConfiguration new];
-    webConfig.applicationNameForUserAgent = kMSIDPKeyAuthKeyWordForUserAgent;
-    
-    if (@available(iOS 13.0, *))
-    {
-        webConfig.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile;
-    }
-    return webConfig;
+    return [MSIDWebviewUIController defaultWKWebviewConfiguration];
 }
 
 #endif

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -280,12 +280,12 @@ typedef enum
     when needed, leveraging the parentController property.
  
  Note that on iOS and iPadOS devices it is recommended to configure WKWebView to use mobile content mode to guarantee consistent experience across all mobile apps.
+ Likewise, on MacOS, it is recommended to configure WKWebView to use destkop content mode.
  
+ New ADAL release has a new API "defaultWKWebviewConfiguration" that will return a default configuration object with recommended settings enabled for both iOS and MacOS.
  When creating your WKWebView, please configure it in the following way:
  
- WKWebViewConfiguration *config = [WKWebViewConfiguration new];
- config.defaultWebpagePreferences.preferredContentMode = WKContentModeMobile; // This sets up WKWebView to display UI as mobile
-     
+ WKWebViewConfiguration *config = [ADAuthenticationParameters defaultWKWebviewConfiguration];     
  WKWebView *webView = [[WKWebView alloc] initWithFrame:your_frame configuration:config];
  */
 @property (weak, nullable) WKWebView* webView;

--- a/ADAL/src/public/ADAuthenticationContext.h
+++ b/ADAL/src/public/ADAuthenticationContext.h
@@ -280,9 +280,9 @@ typedef enum
     when needed, leveraging the parentController property.
  
  Note that on iOS and iPadOS devices it is recommended to configure WKWebView to use mobile content mode to guarantee consistent experience across all mobile apps.
- Likewise, on MacOS, it is recommended to configure WKWebView to use destkop content mode.
+ Likewise, on MacOS, it is recommended to configure WKWebView to use desktop content mode.
  
- New ADAL release has a new API "defaultWKWebviewConfiguration" that will return a default configuration object with recommended settings enabled for both iOS and MacOS.
+ [ADAuthenticationParameters defaultWKWebviewConfiguration] can be used to return a default configuration object with recommended settings enabled for both iOS and MacOS.
  When creating your WKWebView, please configure it in the following way:
  
  WKWebViewConfiguration *config = [ADAuthenticationParameters defaultWKWebviewConfiguration];     

--- a/ADAL/src/public/ADAuthenticationParameters.h
+++ b/ADAL/src/public/ADAuthenticationParameters.h
@@ -22,7 +22,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
-#import "MSIDWebviewUIController.h"
+#import <WebKit/WebKit.h>
 
 @class ADAuthenticationError;
 

--- a/ADAL/src/public/ADAuthenticationParameters.h
+++ b/ADAL/src/public/ADAuthenticationParameters.h
@@ -22,6 +22,7 @@
 // THE SOFTWARE.
 
 #import <Foundation/Foundation.h>
+#import "MSIDWebviewUIController.h"
 
 @class ADAuthenticationError;
 
@@ -85,5 +86,16 @@ typedef void (^ADParametersCompletion)(ADAuthenticationParameters * _Nullable pa
  */
 + (void)parametersFromResourceUrl:(nonnull NSURL *)resourceUrl
                   completionBlock:(nonnull ADParametersCompletion)completionBlock;
+
+
+/*!
+    Generates default WKWebviewConfiguration with "PkeyAuth/1.0" keyword appended to the UserAgent String.
+    The user can initialize an embedded webview with the default configuration returned from this API to enable PKeyAuth challenge.
+ */
+#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
+
++ (nonnull WKWebViewConfiguration *)defaultWKWebviewConfiguration;
+
+#endif
 
 @end

--- a/ADAL/src/public/ADAuthenticationParameters.h
+++ b/ADAL/src/public/ADAuthenticationParameters.h
@@ -89,13 +89,9 @@ typedef void (^ADParametersCompletion)(ADAuthenticationParameters * _Nullable pa
 
 
 /*!
-    Generates default WKWebviewConfiguration with "PkeyAuth/1.0" keyword appended to the UserAgent String.
-    The user can initialize an embedded webview with the default configuration returned from this API to enable PKeyAuth challenge.
+    Generates default WKWebviewConfiguration with recommended settings for the developers. 
  */
-#if TARGET_OS_IPHONE && !MSID_EXCLUDE_WEBKIT
 
 + (nonnull WKWebViewConfiguration *)defaultWKWebviewConfiguration;
-
-#endif
 
 @end

--- a/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
+++ b/ADAL/tests/app/src/ios/ADTestAppAcquireTokenViewController.m
@@ -31,6 +31,7 @@
 #import "ADUserIdentifier.h"
 #import "ADWebAuthController.h"
 #import "ADEnrollmentGateway.h"
+#import "ADAuthenticationParameters.h"
 
 #ifdef AD_MAM_SDK_TESTING
 #import <IntuneMAM/IntuneMAM.h>
@@ -351,7 +352,8 @@
     
     UIView* contentView = blurView.contentView;
     
-    _webView = [[WKWebView alloc] init];
+    WKWebViewConfiguration *defaultConfig = [ADAuthenticationParameters defaultWKWebviewConfiguration];
+    _webView = [[WKWebView alloc] initWithFrame:contentView.frame configuration:defaultConfig];
     _webView.translatesAutoresizingMaskIntoConstraints = NO;
     [contentView addSubview:_webView];
     

--- a/ADAL/tests/app/src/mac/ADTestAppAcquireTokenWindowController.m
+++ b/ADAL/tests/app/src/mac/ADTestAppAcquireTokenWindowController.m
@@ -29,6 +29,7 @@
 #import "ADAuthenticationSettings.h"
 #import "ADWebAuthController.h"
 #import "ADTestAppCache.h"
+#import "ADAuthenticationParameters.h"
 
 @interface ADTestAppAcquireTokenWindowController ()
 
@@ -110,8 +111,10 @@
     [self populateCurrentProfile];
     
     
-    _webview = [[WKWebView alloc] initWithFrame:_contentWebView.bounds];
+    WKWebViewConfiguration *defaultConfig = [ADAuthenticationParameters defaultWKWebviewConfiguration];
+    _webview = [[WKWebView alloc] initWithFrame:_contentWebView.bounds configuration:defaultConfig];
     _webview.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+    
     [_contentWebView addSubview:_webview];
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ Hotfix 4.0.9 (09.03.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)
-* Added public APIs in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfiguration with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.20.2020)
+* Added a public API in ADRequestParameters class for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.21.2020)
 
 Version 4.0.9 (06.16.2020)
 ------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ Hotfix 4.0.9 (09.03.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)
-* Added a public API in ADRequestParameters class for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.21.2020)
+* Added a public API in ADAuthenticationParameters class for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.21.2020)
 
 Version 4.0.9 (06.16.2020)
 ------

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,6 +2,7 @@ Hotfix 4.0.9 (09.03.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)
+* Added public APIs in MSIDWebviewUIController for iOS & MacOS to generate a custom WKWebViewConfiguration with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.20.2020)
 
 Version 4.0.9 (06.16.2020)
 ------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Hotfix 4.0.9 (09.03.2020)
+Hotfix 4.0.9 (09.23.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@ Hotfix 4.0.9 (09.03.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)
-* Added a public API in ADAuthenticationParameters class for iOS to generate a custom WKWebViewConfig with "PKeyAuth/1.0" Keyword appended to the UserAgent String. (09.21.2020)
+* Added a public API in ADAuthenticationParameters class for iOS & MacOS to generate a custom WKWebViewConfig with default recommended settings for the developers to use. On iOS, "PKeyAuth/1.0" keyword is also appended to the UserAgent string as part of the default settings in order to enable PKeyAuth challenge. (09.23.2020)
 
 Version 4.0.9 (06.16.2020)
 ------

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-Hotfix 4.0.9 (09.23.2020)
+Hotfix 4.0.9 (09.24.2020)
 ------
 * Disabled WPJChallenge on iOS as there's a known issue with WKWebview handling NSURLAuthenticationMethodClientCertificate; It swallows the challenge response rather than sending it to server. (09.03.2020)
 * Append 'PkeyAuth/1.0' keyword to the User Agent String to reliably advertise PkeyAuth capability to ADFS (09.03.2020)


### PR DESCRIPTION
Added public APIs on iOS & MacOS to generate custom WKWebViewConfiguration with PKeyAuth UserAgent Keyword.

Related PR: https://github.com/AzureAD/microsoft-authentication-library-common-for-objc/pull/848