### PR TITLE
Cherry-pick #1578: Remote PkeyAuthToken support for iOS simulator

### DIFF
--- a/ADAL/ADAL.xcodeproj/project.pbxproj
+++ b/ADAL/ADAL.xcodeproj/project.pbxproj
@@ -58,6 +58,9 @@
 		236BF403205B49EF006E3897 /* ADWipeTokensTelemetryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B200BC4320180A57000A81FD /* ADWipeTokensTelemetryTests.m */; };
 		236BF407205B4E1A006E3897 /* ADAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */; };
 		236BF40B205B4E1C006E3897 /* ADAcquireTokenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = B20DC60C1F0D99A300957806 /* ADAcquireTokenTests.m */; };
+		236D398F26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 236D398D26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		236D399026F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h in Headers */ = {isa = PBXBuildFile; fileRef = 236D398D26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		236D399326F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.m in Sources */ = {isa = PBXBuildFile; fileRef = 236D398E26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.m */; };
 		23766BB32013D91E00449D47 /* NSDictionary+ADALiOSUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 23766BB22013D91E00449D47 /* NSDictionary+ADALiOSUITests.m */; };
 		23B7919D20118B9F008D4BD2 /* ADAutoPassedInWebViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B7919820118B9E008D4BD2 /* ADAutoPassedInWebViewController.m */; };
 		23B791A220119030008D4BD2 /* ADAutoRequestViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 23B791A120119030008D4BD2 /* ADAutoRequestViewController.m */; };
@@ -920,6 +923,8 @@
 		236BF3C820521382006E3897 /* ADALUserInformation+Internal.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ADALUserInformation+Internal.m"; sourceTree = "<group>"; };
 		236BF3DF2059C1C4006E3897 /* ADALAuthenticationContext+TestUtil.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALAuthenticationContext+TestUtil.h"; sourceTree = "<group>"; };
 		236BF3E02059C1C4006E3897 /* ADALAuthenticationContext+TestUtil.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ADALAuthenticationContext+TestUtil.m"; sourceTree = "<group>"; };
+		236D398D26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ADALAuthenticationContext+RemoteDeviceIdentity.h"; sourceTree = "<group>"; };
+		236D398E26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "ADALAuthenticationContext+RemoteDeviceIdentity.m"; sourceTree = "<group>"; };
 		23766BB12013D91E00449D47 /* NSDictionary+ADALiOSUITests.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "NSDictionary+ADALiOSUITests.h"; sourceTree = "<group>"; };
 		23766BB22013D91E00449D47 /* NSDictionary+ADALiOSUITests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "NSDictionary+ADALiOSUITests.m"; sourceTree = "<group>"; };
 		237A6D4B202D0B490084E15F /* adal__uitest__ios.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = adal__uitest__ios.xcconfig; sourceTree = "<group>"; };
@@ -1616,6 +1621,7 @@
 			children = (
 				9453C3A41C583AA8006B9E79 /* public */,
 				60C351B91DA0D588006C8435 /* ADAL.m */,
+				236D398E26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.m */,
 				D67D3D401F38542700660F32 /* ADAL.pch */,
 				9453C3A31C583A9C006B9E79 /* ADAL_Internal.h */,
 				D61AFAAB1FD8A06D00DABBE5 /* ADALConstants.h */,
@@ -1860,6 +1866,7 @@
 				9453C3C01C583AE6006B9E79 /* ADALUserIdentifier.h */,
 				9453C3C11C583AE6006B9E79 /* ADALUserInformation.h */,
 				9453C3C21C583AE6006B9E79 /* ADALWebAuthController.h */,
+				236D398D26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h */,
 				9453C3C31C583AE6006B9E79 /* ios */,
 				9453C3C51C583AE6006B9E79 /* mac */,
 			);
@@ -2370,6 +2377,7 @@
 				9453C3DB1C583E8B006B9E79 /* ADALErrorCodes.h in Headers */,
 				9453C3D61C583E8B006B9E79 /* ADALAuthenticationContext.h in Headers */,
 				9453C3DF1C583E8B006B9E79 /* ADALUserInformation.h in Headers */,
+				236D398F26F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h in Headers */,
 				9453C3DC1C583E8B006B9E79 /* ADALLogger.h in Headers */,
 				9453C3DA1C583E8B006B9E79 /* ADALAuthenticationSettings.h in Headers */,
 				9453C3D81C583E8B006B9E79 /* ADALAuthenticationParameters.h in Headers */,
@@ -2426,6 +2434,7 @@
 				D60B653B1F355C5700A89487 /* ADALAuthorityValidationRequest.h in Headers */,
 				B24D25E92059F67D00025B8B /* ADALResponseCacheHandler.h in Headers */,
 				94DD18D41C5AC8DE00F80C62 /* ADALAuthenticationSettings.h in Headers */,
+				236D399026F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.h in Headers */,
 				94DD18CF1C5AC8DE00F80C62 /* ADAL.h in Headers */,
 				94DD18DA1C5AC8DE00F80C62 /* ADALWebAuthController.h in Headers */,
 				94DD18D91C5AC8DE00F80C62 /* ADALUserInformation.h in Headers */,
@@ -3415,6 +3424,7 @@
 				D6CF4ED51FC37A1B00CD70C5 /* ADAL.m in Sources */,
 				60D2F4021D531F16008725D9 /* ADALRequestParameters.m in Sources */,
 				A521AB7920EED96A0005735B /* ADALEnrollmentGateway.m in Sources */,
+				236D399326F429D00080BB29 /* ADALAuthenticationContext+RemoteDeviceIdentity.m in Sources */,
 				D61AFAAF1FD8A06D00DABBE5 /* ADALConstants.m in Sources */,
 				9453C4101C586456006B9E79 /* ADALAuthenticationResult.m in Sources */,
 				9453C4091C586456006B9E79 /* ADALAuthenticationContext+Internal.m in Sources */,
@@ -3688,6 +3698,7 @@
 				D664F1A71D302B9C0017B799 /* ADALAuthenticationRequest+AcquireAssertion.m in Sources */,
 				D69A721B1D4FF68300E91DB3 /* ADALAggregatedDispatcher.m in Sources */,
 				B299FF1A1F22BE32004A2CB9 /* NSString+ADALURLExtensions.m in Sources */,
+				21350FCE27BB43A500347037 /* ADALAuthenticationContext+RemoteDeviceIdentity.m in Sources */,
 				D664F1AA1D302B9C0017B799 /* ADALAuthenticationParameters+Internal.m in Sources */,
 				B2A17EA422FFCA300051637E /* ADALBrokerApplicationTokenHelper.m in Sources */,
 				D664F1AB1D302B9C0017B799 /* ADALBrokerNotificationManager.m in Sources */,

--- a/ADAL/src/ADALAuthenticationContext+RemoteDeviceIdentity.m
+++ b/ADAL/src/ADALAuthenticationContext+RemoteDeviceIdentity.m
@@ -1,0 +1,69 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#if MS_REMOTE_PKEYAUTH_CALLBACK && TARGET_OS_SIMULATOR
+
+#import "ADALAuthenticationContext+RemoteDeviceIdentity.h"
+#import "MSIDPKeyAuthHandler.h"
+
+static ADALRemotePkeyAuthResponseCallback s_ADALRemotePkeyAuthResponseCallback = nil;
+static BOOL s_isInMemoryTokenCacheEnabled = NO;
+
+@implementation ADALAuthenticationContext (RemoteDeviceIdentity)
+
++ (void)setRemotePkeyAuthCallback:(ADALRemotePkeyAuthResponseCallback)callback
+{
+    @synchronized (self)
+    {
+        s_ADALRemotePkeyAuthResponseCallback = [callback copy];
+        
+        [MSIDPKeyAuthHandler setRemotePkeyAuthCallback:^NSString * (NSString *challengeUrl) {
+            
+            @synchronized (self) //Guard against thread-unsafe callback
+            {
+                if (s_ADALRemotePkeyAuthResponseCallback)
+                {
+                    return s_ADALRemotePkeyAuthResponseCallback(challengeUrl);
+                }
+                else
+                {
+                    return nil;
+                }
+            }
+        }];
+        
+    }
+}
+
++ (void)setIsInMemoryTokenCacheEnabled:(BOOL)enabled
+{
+    s_isInMemoryTokenCacheEnabled = enabled;
+}
+
++ (BOOL)isInMemoryTokenCacheEnabled
+{
+    return s_isInMemoryTokenCacheEnabled;
+}
+@end
+
+#endif

--- a/ADAL/src/ADALAuthenticationContext.m
+++ b/ADAL/src/ADALAuthenticationContext.m
@@ -46,6 +46,10 @@
 #import "MSIDDefaultTokenCacheAccessor.h"
 #import "MSIDAADV1Oauth2Factory.h"
 
+#if MS_REMOTE_PKEYAUTH_CALLBACK && TARGET_OS_SIMULATOR
+#import "ADALAuthenticationContext+RemoteDeviceIdentity.h"
+#endif
+
 // This variable is purposefully a global so that way we can more easily pull it out of the
 // symbols in a binary to detect what version of ADAL is being used without needing to
 // run the application.
@@ -89,11 +93,28 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     API_ENTRY;
     
     self.sharedGroup = sharedGroup;
+    id<MSIDTokenCacheDataSource> tokenCacheDataSource;
+#if MS_REMOTE_PKEYAUTH_CALLBACK && TARGET_OS_SIMULATOR
+    if ([ADALAuthenticationContext isInMemoryTokenCacheEnabled])
+    {
+        tokenCacheDataSource = [MSIDMacTokenCache defaultCache];
+    }
+    else
+    {
+        MSIDKeychainTokenCache *keychainTokenCache = [[MSIDKeychainTokenCache alloc] initWithGroup:sharedGroup];
+        tokenCacheDataSource = keychainTokenCache;
+        // In case if sharedGroup is nil, keychainTokenCache.keychainGroup will return default group.
+        // Note: it is in the following format: <team id>.<sharedGroup>
+        [self setSharedGroup:[keychainTokenCache keychainGroup]];
+    }
+#else
     MSIDKeychainTokenCache *keychainTokenCache = [[MSIDKeychainTokenCache alloc] initWithGroup:sharedGroup];
+    tokenCacheDataSource = keychainTokenCache;
     // In case if sharedGroup is nil, keychainTokenCache.keychainGroup will return default group.
     // Note: it is in the following format: <team id>.<sharedGroup>
-    self.sharedGroup = keychainTokenCache.keychainGroup;
-    MSIDLegacyTokenCacheAccessor *tokenCache = [self createIosCache:keychainTokenCache];
+    [self setSharedGroup:[keychainTokenCache keychainGroup]];
+#endif
+    MSIDLegacyTokenCacheAccessor *tokenCache = [self createIosCache:tokenCacheDataSource];
     
     return [self initWithAuthority:authority
                  validateAuthority:bValidate
@@ -127,8 +148,21 @@ NSString* ADAL_VERSION_VAR = @ADAL_VERSION_STRING;
     MSIDLegacyTokenCacheAccessor *tokenCache = nil;
 
 #if TARGET_OS_IPHONE
+#if MS_REMOTE_PKEYAUTH_CALLBACK && TARGET_OS_SIMULATOR
+    if ([ADALAuthenticationContext isInMemoryTokenCacheEnabled])
+    {
+        tokenCache = [self createIosCache:[MSIDMacTokenCache defaultCache]];
+    }
+    else
+    {
+        tokenCache = [self createIosCache:[MSIDKeychainTokenCache defaultKeychainCache]];
+        self.sharedGroup = MSIDKeychainTokenCache.defaultKeychainGroup;
+    }
+#else
     tokenCache = [self createIosCache:[MSIDKeychainTokenCache defaultKeychainCache]];
-    self.sharedGroup = MSIDKeychainTokenCache.defaultKeychainGroup;
+    [self setSharedGroup:[MSIDKeychainTokenCache defaultKeychainGroup]];
+#endif
+    
 #else
     self.legacyMacCache = [ADALTokenCache defaultCache];
     tokenCache = [self createMacCache:self.legacyMacCache.macTokenCache];

--- a/ADAL/src/public/ADALAuthenticationContext+RemoteDeviceIdentity.h
+++ b/ADAL/src/public/ADALAuthenticationContext+RemoteDeviceIdentity.h
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft Corporation.
+// All rights reserved.
+//
+// This code is licensed under the MIT License.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files(the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and / or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions :
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+#import <ADAL/ADAL.h>
+
+#if MS_REMOTE_PKEYAUTH_CALLBACK && TARGET_OS_SIMULATOR
+
+/// This block for the ADAL gets device identity (device has to be enrolled and compliant)
+/// @param challengeUrl device CA challenge recieved from AAD
+typedef NSString * _Nullable (^ADALRemotePkeyAuthResponseCallback)(NSString * _Nonnull challengeUrl);
+
+@interface ADALAuthenticationContext (RemoteDeviceIdentity)
+/// Enables In memory token cache
+@property (class, nonatomic) BOOL isInMemoryTokenCacheEnabled;
+
+/// Sets a block for the ADAL, which will be called once device CA request from AAD recieved to get device identity (device has to be enrolled and compliant)
+/// @param callback The block autjentication challenge is sent.
++(void)setRemotePkeyAuthCallback:(nullable ADALRemotePkeyAuthResponseCallback)callback;
+
+@end
+#endif


### PR DESCRIPTION
Reapply the changes from #1578:
Remote PkeyAuthToken support for iOS simulator

These changes are missing from the 6.0 releases.